### PR TITLE
Tilt Effect as suggested in #17

### DIFF
--- a/ModernWpf/Controls/Primitives/Planerator.cs
+++ b/ModernWpf/Controls/Primitives/Planerator.cs
@@ -13,7 +13,7 @@ namespace ModernWpf.Controls.Primitives
     /// </summary>
 
     [ContentProperty("Child")]
-    public class Planerator : FrameworkElement
+    internal class Planerator : FrameworkElement
     {
         #region Public API
 

--- a/ModernWpf/Controls/Primitives/Planerator.cs
+++ b/ModernWpf/Controls/Primitives/Planerator.cs
@@ -1,0 +1,322 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Markup;
+using System.Windows.Media;
+using System.Windows.Media.Media3D;
+
+namespace ModernWpf.Controls.Primitives
+{
+    /// <summary>
+    /// Based on Greg Schechter's Planeator
+    /// http://blogs.msdn.com/b/greg_schechter/archive/2007/10/26/enter-the-planerator-dead-simple-3d-in-wpf-with-a-stupid-name.aspx
+    /// </summary>
+
+    [ContentProperty("Child")]
+    public class Planerator : FrameworkElement
+    {
+        #region Public API
+
+        #region Dependency Properties
+
+        public static readonly DependencyProperty RotationXProperty =
+            DependencyProperty.Register("RotationX", typeof(double), typeof(Planerator), new UIPropertyMetadata(0.0, (d, args) => ((Planerator)d).UpdateRotation()));
+        public static readonly DependencyProperty RotationYProperty =
+            DependencyProperty.Register("RotationY", typeof(double), typeof(Planerator), new UIPropertyMetadata(0.0, (d, args) => ((Planerator)d).UpdateRotation()));
+        public static readonly DependencyProperty RotationZProperty =
+            DependencyProperty.Register("RotationZ", typeof(double), typeof(Planerator), new UIPropertyMetadata(0.0, (d, args) => ((Planerator)d).UpdateRotation()));
+        public static readonly DependencyProperty FieldOfViewProperty =
+            DependencyProperty.Register("FieldOfView", typeof(double), typeof(Planerator), new UIPropertyMetadata(45.0, (d, args) => ((Planerator)d).Update3D(),
+                (d, val) => Math.Min(Math.Max((double)val, 0.5), 179.9))); // clamp to a meaningful range
+
+        public static readonly DependencyProperty OriginXProperty =
+            DependencyProperty.Register("OriginX", typeof(double), typeof(Planerator), new UIPropertyMetadata(0.5, (d, args) => ((Planerator)d).Update3D()));
+        public static readonly DependencyProperty OriginYProperty =
+            DependencyProperty.Register("OriginY", typeof(double), typeof(Planerator), new UIPropertyMetadata(0.5, (d, args) => ((Planerator)d).Update3D()));
+
+        public static readonly DependencyProperty DepthProperty =
+           DependencyProperty.Register("Depth", typeof(double), typeof(Planerator), new UIPropertyMetadata(0.0, (d, args) => ((Planerator)d).UpdateDepth()));
+
+
+        public double RotationX
+        {
+            get { return (double)GetValue(RotationXProperty); }
+            set { SetValue(RotationXProperty, value); }
+        }
+        public double RotationY
+        {
+            get { return (double)GetValue(RotationYProperty); }
+            set { SetValue(RotationYProperty, value); }
+        }
+        public double RotationZ
+        {
+            get { return (double)GetValue(RotationZProperty); }
+            set { SetValue(RotationZProperty, value); }
+        }
+        public double FieldOfView
+        {
+            get { return (double)GetValue(FieldOfViewProperty); }
+            set { SetValue(FieldOfViewProperty, value); }
+        }
+
+        public double OriginX
+        {
+            get { return (double)GetValue(OriginXProperty); }
+            set { SetValue(OriginXProperty, value); }
+        }
+        public double OriginY
+        {
+            get { return (double)GetValue(OriginYProperty); }
+            set { SetValue(OriginYProperty, value); }
+        }
+
+        public double Depth
+        {
+            get { return (double)GetValue(DepthProperty); }
+            set { SetValue(DepthProperty, value); }
+        }
+
+        #endregion
+
+        public FrameworkElement Child
+        {
+            get
+            {
+                return _originalChild;
+            }
+            set
+            {
+                if (_originalChild != value)
+                {
+                    this.RemoveVisualChild(_visualChild);
+                    this.RemoveLogicalChild(_logicalChild);
+
+                    // Wrap child with special decorator that catches layout invalidations. 
+                    _originalChild = value;
+                    _logicalChild = new LayoutInvalidationCatcher() { Child = _originalChild };
+                    _visualChild = CreateVisualChild();
+
+                    this.AddVisualChild(_visualChild);
+
+                    // Need to use a logical child here to make sure databinding operations get down to it,
+                    // since otherwise the child appears only as the Visual to a Viewport2DVisual3D, which 
+                    // doesn't have databinding operations pass into it from above.
+                    this.AddLogicalChild(_logicalChild);
+                    this.InvalidateMeasure();
+                }
+            }
+        }
+
+        public void ClearChild()
+        {
+            var l = _logicalChild as LayoutInvalidationCatcher;
+            l.Child = null;
+            this.RemoveLogicalChild(_logicalChild);
+            this.RemoveVisualChild(_visualChild);
+        }
+
+        #endregion
+
+        #region Layout Stuff
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            Size result;
+            if (_logicalChild != null)
+            {
+                // Measure based on the size of the logical child, since we want to align with it.
+                _logicalChild.Measure(availableSize);
+                result = _logicalChild.DesiredSize;
+                _visualChild.Measure(result);
+            }
+            else
+            {
+                result = new Size(0, 0);
+            }
+            return result;
+        }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            if (_logicalChild != null)
+            {
+                _logicalChild.Arrange(new Rect(finalSize));
+                _visualChild.Arrange(new Rect(finalSize));
+                Update3D();
+            }
+            return base.ArrangeOverride(finalSize);
+        }
+
+        protected override Visual GetVisualChild(int index)
+        {
+            return _visualChild;
+
+        }
+
+        protected override int VisualChildrenCount
+        {
+            get
+            {
+                return _visualChild == null ? 0 : 1;
+            }
+        }
+
+        #endregion
+
+        #region 3D Stuff
+
+        private FrameworkElement CreateVisualChild()
+        {
+            MeshGeometry3D simpleQuad = new MeshGeometry3D()
+            {
+                Positions = new Point3DCollection(_mesh),
+                TextureCoordinates = new PointCollection(_texCoords),
+                TriangleIndices = new Int32Collection(_indices)
+            };
+
+            // Front material is interactive, back material is not.
+            Material frontMaterial = new DiffuseMaterial(Brushes.White);
+            frontMaterial.SetValue(Viewport2DVisual3D.IsVisualHostMaterialProperty, true);
+
+            VisualBrush vb = new VisualBrush(_logicalChild);
+            SetCachingForObject(vb);  // big perf wins by caching!!
+            Material backMaterial = new DiffuseMaterial(vb);
+
+            _rotationTransform.Rotation = _quaternionRotation;
+            var xfGroup = new Transform3DGroup() { Children = { _translateTransform, _scaleTransform, _rotationTransform } };
+
+            GeometryModel3D backModel = new GeometryModel3D() { Geometry = simpleQuad, Transform = xfGroup, BackMaterial = backMaterial };
+            Model3DGroup m3dGroup = new Model3DGroup()
+            {
+                Children = { new DirectionalLight(Colors.White, new Vector3D(0, 0, -1)),
+                                 new DirectionalLight(Colors.White, new Vector3D(0.1, -0.1, 1)),
+                                 backModel }
+            };
+
+            // Non-interactive Visual3D consisting of the backside, and two lights.
+            ModelVisual3D mv3d = new ModelVisual3D() { Content = m3dGroup };
+
+            // Interactive frontside Visual3D
+            Viewport2DVisual3D frontModel = new Viewport2DVisual3D() { Geometry = simpleQuad, Visual = _logicalChild, Material = frontMaterial, Transform = xfGroup };
+
+            // Cache the brush in the VP2V3 by setting caching on it.  Big perf wins.
+            SetCachingForObject(frontModel);
+
+            // Scene consists of both the above Visual3D's.
+            _viewport3d = new Viewport3D() { ClipToBounds = false, Children = { mv3d, frontModel } };
+
+            UpdateRotation();
+
+            return _viewport3d;
+        }
+
+        private void SetCachingForObject(DependencyObject d)
+        {
+            RenderOptions.SetCachingHint(d, CachingHint.Cache);
+            RenderOptions.SetCacheInvalidationThresholdMinimum(d, 0.5);
+            RenderOptions.SetCacheInvalidationThresholdMaximum(d, 2.0);
+        }
+
+        private void UpdateDepth()
+        {
+            _translateTransform.OffsetZ = -Depth;
+            _rotationTransform.CenterZ = -Depth;
+            _scaleTransform.CenterZ = -Depth;
+        }
+
+        private void UpdateRotation()
+        {
+            Quaternion qx = new Quaternion(_xAxis, RotationX);
+            Quaternion qy = new Quaternion(_yAxis, RotationY);
+            Quaternion qz = new Quaternion(_zAxis, RotationZ);
+
+            _quaternionRotation.Quaternion = qx * qy * qz;
+        }
+
+        private void Update3D()
+        {
+            if (_logicalChild == null) { return; }
+            // Use GetDescendantBounds for sizing and centering since DesiredSize includes layout whitespace, whereas GetDescendantBounds 
+            // is tighter
+            Rect logicalBounds = VisualTreeHelper.GetDescendantBounds(_logicalChild);
+            double w = logicalBounds.Width;
+            double h = logicalBounds.Height;
+
+            // Create a camera that looks down -Z, with up as Y, and positioned right halfway in X and Y on the element, 
+            // and back along Z the right distance based on the field-of-view is the same projected size as the 2D content
+            // that it's looking at.  See http://blogs.msdn.com/greg_schechter/archive/2007/04/03/camera-construction-in-parallaxui.aspx
+            // for derivation of this camera.
+            double fovInRadians = FieldOfView * (Math.PI / 180);
+            double zValue = w / Math.Tan(fovInRadians / 2) / 2;
+            _viewport3d.Camera = new PerspectiveCamera(new Point3D(w / 2, h / 2, zValue),
+                                                       -_zAxis,
+                                                       _yAxis,
+                                                       FieldOfView);
+
+            _scaleTransform.ScaleX = w;
+            _scaleTransform.ScaleY = h;
+            _rotationTransform.CenterX = w * OriginX;
+            _rotationTransform.CenterY = h * OriginY;
+        }
+
+        #endregion
+
+        #region Private Classes
+
+        /// <summary>
+        /// Wrap this around a class that we want to catch the measure and arrange 
+        /// processes occuring on, and propagate to the parent Planerator, if any.
+        /// Do this because layout invalidations don't flow up out of a 
+        /// Viewport2DVisual3D object.
+        /// </summary>
+        public class LayoutInvalidationCatcher : Decorator
+        {
+            public Planerator PlaParent { get { return this.Parent as Planerator; } }
+
+            protected override Size MeasureOverride(Size constraint)
+            {
+                Planerator pl = PlaParent;
+                if (pl != null)
+                {
+                    pl.InvalidateMeasure();
+                }
+                return base.MeasureOverride(constraint);
+            }
+
+            protected override Size ArrangeOverride(Size arrangeSize)
+            {
+                Planerator pl = PlaParent;
+                if (pl != null)
+                {
+                    pl.InvalidateArrange();
+                }
+                return base.ArrangeOverride(arrangeSize);
+            }
+        }
+
+        #endregion
+
+        #region Private data
+
+        // Instance data
+        private FrameworkElement _logicalChild;
+        private FrameworkElement _visualChild;
+        private FrameworkElement _originalChild;
+
+        private QuaternionRotation3D _quaternionRotation = new QuaternionRotation3D();
+        private RotateTransform3D _rotationTransform = new RotateTransform3D();
+        private Viewport3D _viewport3d;
+        private ScaleTransform3D _scaleTransform = new ScaleTransform3D();
+        private TranslateTransform3D _translateTransform = new TranslateTransform3D();
+
+        // Static data
+        static private readonly Point3D[] _mesh = new Point3D[] { new Point3D(0, 0, 0), new Point3D(0, 1, 0), new Point3D(1, 1, 0), new Point3D(1, 0, 0) };
+        static private readonly Point[] _texCoords = new Point[] { new Point(0, 1), new Point(0, 0), new Point(1, 0), new Point(1, 1) };
+        static private readonly int[] _indices = new int[] { 0, 2, 1, 0, 3, 2 };
+        static private readonly Vector3D _xAxis = new Vector3D(1, 0, 0);
+        static private readonly Vector3D _yAxis = new Vector3D(0, 1, 0);
+        static private readonly Vector3D _zAxis = new Vector3D(0, 0, 1);
+
+        #endregion
+    }
+}

--- a/ModernWpf/Controls/Primitives/PlaneratorHelper.cs
+++ b/ModernWpf/Controls/Primitives/PlaneratorHelper.cs
@@ -1,0 +1,256 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace ModernWpf.Controls.Primitives
+{
+    public static class PlaneratorHelper
+    {
+
+        #region Dependency Properties
+        #region RotationX
+        public static double GetRotationX(FrameworkElement frameworkElement)
+        {
+            return (double)frameworkElement.GetValue(RotationXProperty);
+        }
+
+        public static void SetRotationX(FrameworkElement frameworkElement, double value)
+        {
+            frameworkElement.SetValue(RotationXProperty, value);
+        }
+
+        public static readonly DependencyProperty RotationXProperty =
+            DependencyProperty.RegisterAttached(
+                "RotationX",
+                typeof(double),
+                typeof(PlaneratorHelper), new PropertyMetadata(0.0));
+        #endregion
+        #region RotationY
+        public static double GetRotationY(FrameworkElement frameworkElement)
+        {
+            return (double)frameworkElement.GetValue(RotationYProperty);
+        }
+
+        public static void SetRotationY(FrameworkElement frameworkElement, double value)
+        {
+            frameworkElement.SetValue(RotationYProperty, value);
+        }
+
+        public static readonly DependencyProperty RotationYProperty =
+            DependencyProperty.RegisterAttached(
+                "RotationY",
+                typeof(double),
+                typeof(PlaneratorHelper), new PropertyMetadata(0.0));
+        #endregion
+        #region RotationZ
+        public static double GetRotationZ(FrameworkElement frameworkElement)
+        {
+            return (double)frameworkElement.GetValue(RotationZProperty);
+        }
+
+        public static void SetRotationZ(FrameworkElement frameworkElement, double value)
+        {
+            frameworkElement.SetValue(RotationZProperty, value);
+        }
+
+        public static readonly DependencyProperty RotationZProperty =
+            DependencyProperty.RegisterAttached(
+                "RotationZ",
+                typeof(double),
+                typeof(PlaneratorHelper), new PropertyMetadata(0.0));
+        #endregion
+        #region FieldOfView
+        public static double GetFieldOfView(FrameworkElement frameworkElement)
+        {
+            return (double)frameworkElement.GetValue(FieldOfViewProperty);
+        }
+
+        public static void SetFieldOfView(FrameworkElement frameworkElement, double value)
+        {
+            frameworkElement.SetValue(FieldOfViewProperty, value);
+        }
+
+        public static readonly DependencyProperty FieldOfViewProperty =
+            DependencyProperty.RegisterAttached(
+                "FieldOfView",
+                typeof(double),
+                typeof(PlaneratorHelper), new PropertyMetadata(45.0));
+        #endregion
+        #region OriginX
+        public static double GetOriginX(FrameworkElement frameworkElement)
+        {
+            return (double)frameworkElement.GetValue(OriginXProperty);
+        }
+
+        public static void SetOriginX(FrameworkElement frameworkElement, double value)
+        {
+            frameworkElement.SetValue(OriginXProperty, value);
+        }
+
+        public static readonly DependencyProperty OriginXProperty =
+            DependencyProperty.RegisterAttached(
+                "OriginX",
+                typeof(double),
+                typeof(PlaneratorHelper), new PropertyMetadata(0.5));
+        #endregion
+        #region OriginY
+        public static double GetOriginY(FrameworkElement frameworkElement)
+        {
+            return (double)frameworkElement.GetValue(OriginYProperty);
+        }
+
+        public static void SetOriginY(FrameworkElement frameworkElement, double value)
+        {
+            frameworkElement.SetValue(OriginYProperty, value);
+        }
+
+        public static readonly DependencyProperty OriginYProperty =
+            DependencyProperty.RegisterAttached(
+                "OriginY",
+                typeof(double),
+                typeof(PlaneratorHelper), new PropertyMetadata(0.5));
+        #endregion
+        #region Depth
+        public static double GetDepth(FrameworkElement frameworkElement)
+        {
+            return (double)frameworkElement.GetValue(DepthProperty);
+        }
+
+        public static void SetDepth(FrameworkElement frameworkElement, double value)
+        {
+            frameworkElement.SetValue(DepthProperty, value);
+        }
+
+        public static readonly DependencyProperty DepthProperty =
+            DependencyProperty.RegisterAttached(
+                "Depth",
+                typeof(double),
+                typeof(PlaneratorHelper), new PropertyMetadata(0.0));
+        #endregion
+        #region PlaceIn3D
+        public static bool GetPlaceIn3D(FrameworkElement frameworkElement)
+        {
+            return (bool)frameworkElement.GetValue(PlaceIn3DProperty);
+        }
+
+        public static void SetPlaceIn3D(FrameworkElement frameworkElement, bool value)
+        {
+            frameworkElement.SetValue(PlaceIn3DProperty, value);
+        }
+
+        public static readonly DependencyProperty PlaceIn3DProperty =
+            DependencyProperty.RegisterAttached(
+                "PlaceIn3D",
+                typeof(bool),
+                typeof(PlaneratorHelper), new PropertyMetadata(false, OnPlaceIn3dPropertyChanged));
+        #endregion
+        #region RotatorParent
+        public static Planerator GetRotatorParent(FrameworkElement frameworkElement)
+        {
+            return frameworkElement.GetValue(RotatorParentProperty) as Planerator;
+        }
+
+        public static void SetRotatorParent(FrameworkElement frameworkElement, Planerator value)
+        {
+            frameworkElement.SetValue(RotatorParentProperty, value);
+        }
+
+        public static readonly DependencyProperty RotatorParentProperty =
+            DependencyProperty.RegisterAttached("RotatorParent", typeof(Planerator), typeof(PlaneratorHelper), new PropertyMetadata(null));
+        #endregion
+        #endregion
+
+        private static void OnPlaceIn3dPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var fe = d as FrameworkElement;
+
+            bool newValue = (bool)e.NewValue;
+            bool oldValue = (bool)e.OldValue;
+
+            if (fe == null) { return; }
+
+            if (oldValue && !newValue)
+            {
+                GetItOut(fe);
+            }
+            if (!oldValue && newValue)
+            {
+                PlaceItIn3D(fe);
+            }
+        }
+
+        private static void GetItOut(FrameworkElement fe)
+        {
+            Planerator RotatorParent = GetRotatorParent(fe);
+            if (RotatorParent == null) { return; }
+            Panel OriginalPanel = RotatorParent.Parent as Panel;
+            Thickness OriginalMargin = RotatorParent.Margin;
+            Size OriginalSize = new Size(RotatorParent.Width, RotatorParent.Height);
+            BindingOperations.ClearBinding(RotatorParent, Planerator.RotationXProperty);
+            BindingOperations.ClearBinding(RotatorParent, Planerator.RotationYProperty);
+            BindingOperations.ClearBinding(RotatorParent, Planerator.RotationZProperty);
+            BindingOperations.ClearBinding(RotatorParent, Planerator.FieldOfViewProperty);
+            BindingOperations.ClearBinding(RotatorParent, Planerator.OriginXProperty);
+            BindingOperations.ClearBinding(RotatorParent, Planerator.OriginYProperty);
+            BindingOperations.ClearBinding(RotatorParent, Planerator.DepthProperty);
+
+            RotatorParent.ClearChild();
+            OriginalPanel.Children.Remove(RotatorParent);
+            RotatorParent = null;
+
+            fe.ClearValue(RotatorParentProperty);
+
+            //fe.Width = OriginalSize.Width;
+            //fe.Height = OriginalSize.Height;
+            fe.Margin = OriginalMargin;
+
+            OriginalPanel.Children.Add(fe);
+        }
+
+        private static void PlaceItIn3D(FrameworkElement fe)
+        {
+
+            Panel OriginalPanel = fe.Parent as Panel;
+            Thickness OriginalMargin = fe.Margin;
+            Size OriginalSize = new Size(fe.Width, fe.Height);
+            double left = Canvas.GetLeft(fe);
+            double right = Canvas.GetRight(fe);
+            double top = Canvas.GetTop(fe);
+            double bottom = Canvas.GetBottom(fe);
+            int z = Canvas.GetZIndex(fe);
+            VerticalAlignment va = fe.VerticalAlignment;
+            HorizontalAlignment ha = fe.HorizontalAlignment;
+
+            Planerator RotatorParent = new Planerator();
+            RotatorParent.Width = OriginalSize.Width;
+            RotatorParent.Height = OriginalSize.Height;
+            RotatorParent.Margin = OriginalMargin;
+            RotatorParent.VerticalAlignment = va;
+            RotatorParent.HorizontalAlignment = ha;
+            RotatorParent.SetValue(Canvas.LeftProperty, left);
+            RotatorParent.SetValue(Canvas.RightProperty, right);
+            RotatorParent.SetValue(Canvas.TopProperty, top);
+            RotatorParent.SetValue(Canvas.BottomProperty, bottom);
+            RotatorParent.SetValue(Canvas.ZIndexProperty, z);
+
+            //fe.Width = double.NaN;
+            //fe.Height = double.NaN;
+
+            BindingOperations.SetBinding(RotatorParent, Planerator.RotationXProperty, new Binding() { Source = fe, Path = new PropertyPath(RotationXProperty) });
+            BindingOperations.SetBinding(RotatorParent, Planerator.RotationYProperty, new Binding() { Source = fe, Path = new PropertyPath(RotationYProperty) });
+            BindingOperations.SetBinding(RotatorParent, Planerator.RotationZProperty, new Binding() { Source = fe, Path = new PropertyPath(RotationZProperty) });
+            BindingOperations.SetBinding(RotatorParent, Planerator.FieldOfViewProperty, new Binding() { Source = fe, Path = new PropertyPath(FieldOfViewProperty) });
+            BindingOperations.SetBinding(RotatorParent, Planerator.OriginXProperty, new Binding() { Source = fe, Path = new PropertyPath(OriginXProperty) });
+            BindingOperations.SetBinding(RotatorParent, Planerator.OriginYProperty, new Binding() { Source = fe, Path = new PropertyPath(OriginYProperty) });
+            BindingOperations.SetBinding(RotatorParent, Planerator.DepthProperty, new Binding() { Source = fe, Path = new PropertyPath(DepthProperty) });
+
+            OriginalPanel.Children.Remove(fe);
+            fe.Margin = new Thickness();
+
+            OriginalPanel.Children.Add(RotatorParent);
+            SetRotatorParent(fe, RotatorParent);
+            RotatorParent.Child = fe;
+        }
+    }
+}

--- a/ModernWpf/Controls/Primitives/PlaneratorHelper.cs
+++ b/ModernWpf/Controls/Primitives/PlaneratorHelper.cs
@@ -5,7 +5,7 @@ using System.Windows.Data;
 
 namespace ModernWpf.Controls.Primitives
 {
-    public static class PlaneratorHelper
+    internal static class PlaneratorHelper
     {
 
         #region Dependency Properties

--- a/ModernWpf/Controls/Primitives/PointerUpDownHelper.cs
+++ b/ModernWpf/Controls/Primitives/PointerUpDownHelper.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media.Animation;
+
+namespace ModernWpf.Controls.Primitives
+{
+    public static class PointerUpDownHelper
+    {
+
+        #region IsPressed
+        public static bool GetIsPressed(FrameworkElement frameworkElement)
+        {
+            return (bool)frameworkElement.GetValue(IsPressedProperty);
+        }
+
+        public static void SetIsPressed(FrameworkElement frameworkElement, bool value)
+        {
+            frameworkElement.SetValue(IsPressedProperty, value);
+        }
+
+        public static readonly DependencyProperty IsPressedProperty =
+            DependencyProperty.RegisterAttached(
+                "IsPressed",
+                typeof(bool),
+                typeof(PointerUpDownHelper), new PropertyMetadata(false, OnIsPressedPropertyChanged));
+        #endregion
+
+        private static Duration DefaultDuration = TimeSpan.FromMilliseconds(167.0);
+
+        private static double TiltFactor = 3.0;
+
+        private static double Depth = 5.0;
+
+        private static void OnIsPressedPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var fe = d as FrameworkElement;
+
+            bool newValue = (bool)e.NewValue;
+            bool oldValue = (bool)e.OldValue;
+
+            if (fe == null) { return; }
+
+            if (oldValue && !newValue)
+            {
+                var RP = PlaneratorHelper.GetRotatorParent(fe);
+                if (RP == null) { return; }
+                double yrot = 0;
+                double xrot = 0;
+                PrepareForCompletion(fe, DefaultDuration.TimeSpan);
+                SetAnim(RP, Planerator.RotationYProperty, yrot);
+                SetAnim(RP, Planerator.RotationXProperty, xrot);
+                SetAnim(RP, Planerator.DepthProperty, 0);
+            }
+
+            if (!oldValue && newValue)
+            {
+                fe.BeginAnimation(PlaneratorHelper.PlaceIn3DProperty, null);
+                PlaneratorHelper.SetPlaceIn3D(fe, true);
+                var RP = PlaneratorHelper.GetRotatorParent(fe);
+                if (RP == null) { return; }
+                Point current = Mouse.GetPosition(RP);
+                bool IsPressed = Mouse.LeftButton == MouseButtonState.Pressed;
+                bool IsEnter = current.X > 0 && current.X < fe.ActualWidth && current.Y > 0 && current.Y < fe.ActualHeight;
+                if (IsEnter && IsPressed)
+                {
+                    double yrot = -1 * TiltFactor + current.X * 2 * TiltFactor / fe.ActualWidth;
+                    double xrot = -1 * TiltFactor + current.Y * 2 * TiltFactor / fe.ActualHeight;
+                    SetAnim(RP, Planerator.RotationYProperty, yrot);
+                    SetAnim(RP, Planerator.RotationXProperty, xrot);
+                }
+                SetAnim(RP, Planerator.DepthProperty, Depth);
+            }
+        }
+
+        private static void PrepareForCompletion(FrameworkElement fe, TimeSpan timeSpan)
+        {
+            var bauk = new BooleanAnimationUsingKeyFrames() { BeginTime = timeSpan, Duration = TimeSpan.FromMilliseconds(10) };
+            bauk.KeyFrames.Add(new DiscreteBooleanKeyFrame(false, KeyTime.FromTimeSpan(TimeSpan.Zero)));
+            fe.BeginAnimation(PlaneratorHelper.PlaceIn3DProperty, bauk);
+        }
+
+        private static void SetAnim(Planerator pl, DependencyProperty dp, double value)
+        {
+            DoubleAnimation da = new DoubleAnimation(value, DefaultDuration);
+            da.EasingFunction = new CircleEase() { EasingMode = EasingMode.EaseOut };
+            pl.BeginAnimation(dp, da);
+        }
+    }
+}

--- a/ModernWpf/Controls/Primitives/TiltEffect.cs
+++ b/ModernWpf/Controls/Primitives/TiltEffect.cs
@@ -5,28 +5,46 @@ using System.Windows.Media.Animation;
 
 namespace ModernWpf.Controls.Primitives
 {
-    public static class PointerUpDownHelper
+    public static class TiltEffect
     {
 
         #region IsPressed
-        public static bool GetIsPressed(FrameworkElement frameworkElement)
+        internal static bool GetIsPressed(FrameworkElement frameworkElement)
         {
             return (bool)frameworkElement.GetValue(IsPressedProperty);
         }
 
-        public static void SetIsPressed(FrameworkElement frameworkElement, bool value)
+        internal static void SetIsPressed(FrameworkElement frameworkElement, bool value)
         {
             frameworkElement.SetValue(IsPressedProperty, value);
         }
 
-        public static readonly DependencyProperty IsPressedProperty =
+        internal static readonly DependencyProperty IsPressedProperty =
             DependencyProperty.RegisterAttached(
                 "IsPressed",
                 typeof(bool),
-                typeof(PointerUpDownHelper), new PropertyMetadata(false, OnIsPressedPropertyChanged));
+                typeof(TiltEffect), new PropertyMetadata(false, OnIsPressedPropertyChanged));
         #endregion
 
-        private static Duration DefaultDuration = TimeSpan.FromMilliseconds(167.0);
+        #region IsEnabled
+        public static bool GetIsEnabled(FrameworkElement frameworkElement)
+        {
+            return (bool)frameworkElement.GetValue(IsEnabledProperty);
+        }
+
+        public static void SetIsEnabled(FrameworkElement frameworkElement, bool value)
+        {
+            frameworkElement.SetValue(IsEnabledProperty, value);
+        }
+
+        public static readonly DependencyProperty IsEnabledProperty =
+            DependencyProperty.RegisterAttached(
+                "IsEnabled",
+                typeof(bool),
+                typeof(TiltEffect), new PropertyMetadata(false));
+        #endregion
+
+        private static Duration DefaultDuration = TimeSpan.FromMilliseconds(300.0);
 
         private static double TiltFactor = 3.0;
 
@@ -55,21 +73,26 @@ namespace ModernWpf.Controls.Primitives
 
             if (!oldValue && newValue)
             {
-                fe.BeginAnimation(PlaneratorHelper.PlaceIn3DProperty, null);
-                PlaneratorHelper.SetPlaceIn3D(fe, true);
-                var RP = PlaneratorHelper.GetRotatorParent(fe);
-                if (RP == null) { return; }
-                Point current = Mouse.GetPosition(RP);
-                bool IsPressed = Mouse.LeftButton == MouseButtonState.Pressed;
-                bool IsEnter = current.X > 0 && current.X < fe.ActualWidth && current.Y > 0 && current.Y < fe.ActualHeight;
-                if (IsEnter && IsPressed)
+                bool IsEnabled = GetIsEnabled(fe);
+
+                if (IsEnabled)
                 {
-                    double yrot = -1 * TiltFactor + current.X * 2 * TiltFactor / fe.ActualWidth;
-                    double xrot = -1 * TiltFactor + current.Y * 2 * TiltFactor / fe.ActualHeight;
-                    SetAnim(RP, Planerator.RotationYProperty, yrot);
-                    SetAnim(RP, Planerator.RotationXProperty, xrot);
+                    fe.BeginAnimation(PlaneratorHelper.PlaceIn3DProperty, null);
+                    PlaneratorHelper.SetPlaceIn3D(fe, true);
+                    var RP = PlaneratorHelper.GetRotatorParent(fe);
+                    if (RP == null) { return; }
+                    Point current = Mouse.GetPosition(RP);
+                    bool IsPressed = Mouse.LeftButton == MouseButtonState.Pressed;
+                    bool IsEnter = current.X > 0 && current.X < fe.ActualWidth && current.Y > 0 && current.Y < fe.ActualHeight;
+                    if (IsEnter && IsPressed)
+                    {
+                        double yrot = -1 * TiltFactor + current.X * 2 * TiltFactor / fe.ActualWidth;
+                        double xrot = -1 * TiltFactor + current.Y * 2 * TiltFactor / fe.ActualHeight;
+                        SetAnim(RP, Planerator.RotationYProperty, yrot);
+                        SetAnim(RP, Planerator.RotationXProperty, xrot);
+                    }
+                    SetAnim(RP, Planerator.DepthProperty, Depth);
                 }
-                SetAnim(RP, Planerator.DepthProperty, Depth);
             }
         }
 

--- a/ModernWpf/Media/Animation/PointerDownThemeAnimation.cs
+++ b/ModernWpf/Media/Animation/PointerDownThemeAnimation.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Media.Animation;
+using ModernWpf.Controls.Primitives;
+
+namespace ModernWpf.Media.Animation
+{
+    /// <summary>
+    /// Represents the preconfigured pointer down animation that applies to controls when
+    /// they are pressed.
+    /// </summary>
+    public sealed class PointerDownThemeAnimation : BooleanAnimationUsingKeyFrames
+    {
+
+        static PointerDownThemeAnimation()
+        {
+            Storyboard.TargetPropertyProperty.OverrideMetadata(typeof(PointerDownThemeAnimation), new FrameworkPropertyMetadata(new PropertyPath(PointerUpDownHelper.IsPressedProperty)));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the PointerDownThemeAnimation class.
+        /// </summary>
+        public PointerDownThemeAnimation()
+        {
+            var one = new DiscreteBooleanKeyFrame(true, KeyTime.FromTimeSpan(TimeSpan.Zero));
+            this.KeyFrames.Add(one);
+        }
+
+        /// <summary>
+        /// Identifies the TargetName dependency property.
+        /// </summary>
+        public static readonly DependencyProperty TargetNameProperty = Storyboard.TargetNameProperty.AddOwner(typeof(PointerDownThemeAnimation));
+
+        /// <summary>
+        /// Gets or sets the reference name of the control element being targeted.
+        /// </summary>
+        /// <returns>
+        /// The reference name. This is typically the **x:Name** of the relevant element
+        /// as declared in XAML.
+        /// </returns>
+        public string TargetName
+        {
+            get => (string)GetValue(TargetNameProperty);
+            set => SetValue(TargetNameProperty, value);
+        }
+
+        protected override Freezable CreateInstanceCore()
+        {
+            return new PointerDownThemeAnimation();
+        }
+    }
+}

--- a/ModernWpf/Media/Animation/PointerDownThemeAnimation.cs
+++ b/ModernWpf/Media/Animation/PointerDownThemeAnimation.cs
@@ -6,8 +6,7 @@ using ModernWpf.Controls.Primitives;
 namespace ModernWpf.Media.Animation
 {
     /// <summary>
-    /// Represents the preconfigured pointer down animation that applies to controls when
-    /// they are pressed.
+    /// Represents a preconfigured animation that runs when a pointer down is detected on an item or element.
     /// </summary>
     public sealed class PointerDownThemeAnimation : BooleanAnimationUsingKeyFrames
     {

--- a/ModernWpf/Media/Animation/PointerDownThemeAnimation.cs
+++ b/ModernWpf/Media/Animation/PointerDownThemeAnimation.cs
@@ -13,7 +13,7 @@ namespace ModernWpf.Media.Animation
 
         static PointerDownThemeAnimation()
         {
-            Storyboard.TargetPropertyProperty.OverrideMetadata(typeof(PointerDownThemeAnimation), new FrameworkPropertyMetadata(new PropertyPath(PointerUpDownHelper.IsPressedProperty)));
+            Storyboard.TargetPropertyProperty.OverrideMetadata(typeof(PointerDownThemeAnimation), new FrameworkPropertyMetadata(new PropertyPath(TiltEffect.IsPressedProperty)));
         }
 
         /// <summary>

--- a/ModernWpf/Media/Animation/PointerUpThemeAnimation.cs
+++ b/ModernWpf/Media/Animation/PointerUpThemeAnimation.cs
@@ -13,7 +13,7 @@ namespace ModernWpf.Media.Animation
 
         static PointerUpThemeAnimation()
         {
-            Storyboard.TargetPropertyProperty.OverrideMetadata(typeof(PointerUpThemeAnimation), new FrameworkPropertyMetadata(new PropertyPath(PointerUpDownHelper.IsPressedProperty)));
+            Storyboard.TargetPropertyProperty.OverrideMetadata(typeof(PointerUpThemeAnimation), new FrameworkPropertyMetadata(new PropertyPath(TiltEffect.IsPressedProperty)));
         }
 
         /// <summary>

--- a/ModernWpf/Media/Animation/PointerUpThemeAnimation.cs
+++ b/ModernWpf/Media/Animation/PointerUpThemeAnimation.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Media.Animation;
+using ModernWpf.Controls.Primitives;
+
+namespace ModernWpf.Media.Animation
+{
+    /// <summary>
+    /// Represents the preconfigured pointer up animation that applies to controls when
+    /// they are pressed.
+    /// </summary>
+    public sealed class PointerUpThemeAnimation : BooleanAnimationUsingKeyFrames
+    {
+
+        static PointerUpThemeAnimation()
+        {
+            Storyboard.TargetPropertyProperty.OverrideMetadata(typeof(PointerUpThemeAnimation), new FrameworkPropertyMetadata(new PropertyPath(PointerUpDownHelper.IsPressedProperty)));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the PointerUpThemeAnimation class.
+        /// </summary>
+        public PointerUpThemeAnimation()
+        {
+            var one = new DiscreteBooleanKeyFrame(false, KeyTime.FromTimeSpan(TimeSpan.Zero));
+            this.KeyFrames.Add(one);
+        }
+
+        /// <summary>
+        /// Identifies the TargetName dependency property.
+        /// </summary>
+        public static readonly DependencyProperty TargetNameProperty = Storyboard.TargetNameProperty.AddOwner(typeof(PointerUpThemeAnimation));
+
+        /// <summary>
+        /// Gets or sets the reference name of the control element being targeted.
+        /// </summary>
+        /// <returns>
+        /// The reference name. This is typically the **x:Name** of the relevant element
+        /// as declared in XAML.
+        /// </returns>
+        public string TargetName
+        {
+            get => (string)GetValue(TargetNameProperty);
+            set => SetValue(TargetNameProperty, value);
+        }
+
+        protected override Freezable CreateInstanceCore()
+        {
+            return new PointerUpThemeAnimation();
+        }
+    }
+}

--- a/ModernWpf/Media/Animation/PointerUpThemeAnimation.cs
+++ b/ModernWpf/Media/Animation/PointerUpThemeAnimation.cs
@@ -6,8 +6,7 @@ using ModernWpf.Controls.Primitives;
 namespace ModernWpf.Media.Animation
 {
     /// <summary>
-    /// Represents the preconfigured pointer up animation that applies to controls when
-    /// they are pressed.
+    /// Represents a preconfigured animation that runs after a pointer down is detected on an item or element and the tap action is released.
     /// </summary>
     public sealed class PointerUpThemeAnimation : BooleanAnimationUsingKeyFrames
     {

--- a/ModernWpf/Styles/Button.xaml
+++ b/ModernWpf/Styles/Button.xaml
@@ -2,7 +2,8 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:primitives="clr-namespace:ModernWpf.Controls.Primitives">
+    xmlns:primitives="clr-namespace:ModernWpf.Controls.Primitives"
+    xmlns:animation="clr-namespace:ModernWpf.Media.Animation">
 
     <Thickness x:Key="ButtonPadding">8,5,8,6</Thickness>
 
@@ -27,26 +28,49 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
-                    <Border
+                    <Grid>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal">
+                                    <Storyboard>
+                                        <animation:PointerUpThemeAnimation TargetName="Background"/>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="MouseOver">
+                                    <Storyboard>
+                                        <animation:PointerUpThemeAnimation TargetName="Background"/>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Pressed">
+                                    <Storyboard>
+                                        <animation:PointerDownThemeAnimation TargetName="Background"/>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Disabled">
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Border
                         x:Name="Background"
                         Background="{TemplateBinding Background}"
                         CornerRadius="{TemplateBinding primitives:ControlHelper.CornerRadius}"
                         SnapsToDevicePixels="True">
-                        <Border
+                            <Border
                             x:Name="Border"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             Padding="{TemplateBinding Padding}"
                             CornerRadius="{TemplateBinding primitives:ControlHelper.CornerRadius}">
-                            <ContentPresenter
+                                <ContentPresenter
                                 x:Name="ContentPresenter"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Focusable="False"
                                 RecognizesAccessKey="True"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Border>
                         </Border>
-                    </Border>
+                    </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Background" Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />

--- a/ModernWpf/Styles/Button.xaml
+++ b/ModernWpf/Styles/Button.xaml
@@ -24,6 +24,7 @@
         <Setter Property="primitives:ControlHelper.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" />
         <Setter Property="primitives:FocusVisualHelper.FocusVisualMargin" Value="-3" />
+        <Setter Property="primitives:TiltEffect.IsEnabled" Value="True"/>
         <Setter Property="Stylus.IsPressAndHoldEnabled" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
@@ -53,7 +54,7 @@
                         <Border
                         x:Name="Background"
                         Background="{TemplateBinding Background}"
-                        CornerRadius="{TemplateBinding primitives:ControlHelper.CornerRadius}"
+                        CornerRadius="{TemplateBinding primitives:ControlHelper.CornerRadius}" primitives:TiltEffect.IsEnabled="{TemplateBinding primitives:TiltEffect.IsEnabled}"
                         SnapsToDevicePixels="True">
                             <Border
                             x:Name="Border"


### PR DESCRIPTION
This PR is for adding the **Pointer Up and Down Theme Animations**

1.  Preview (ModernWpf)
- Normal
 ![image](https://user-images.githubusercontent.com/54765038/75870256-c385fa00-5e30-11ea-84f8-a4238ee7bdd4.png)
- Pressed
 ![image](https://user-images.githubusercontent.com/54765038/75865259-4acf6f80-5e29-11ea-8fe1-110fd5fe7bd6.png)
2. Preview (UWP)
- Pressed
![image](https://user-images.githubusercontent.com/54765038/75870657-4c049a80-5e31-11ea-9f62-4971ed983be9.png)

> Note : for using this effect, the element to be affected must be placed with in a **Panel** (such as Grid, Canvas, etc.) not other controls. The effect is subtle

These animations can be implemented in Visual States as follows 

```xaml
    <VisualStateManager.VisualStateGroups>
        <VisualStateGroup x:Name="CommonStates">
            <VisualState x:Name="Normal">
                <Storyboard>
                    <animation:PointerUpThemeAnimation TargetName="ElementToBeAffected"/>
                </Storyboard>
            </VisualState>
            <VisualState x:Name="MouseOver">
                <Storyboard>
                    <animation:PointerUpThemeAnimation TargetName="ElementToBeAffected"/>
                </Storyboard>
            </VisualState>
            <VisualState x:Name="Pressed">
                <Storyboard>
                    <animation:PointerDownThemeAnimation TargetName="ElementToBeAffected"/>
                </Storyboard>
            </VisualState>
            <VisualState x:Name="Disabled">
            </VisualState>
        </VisualStateGroup>
    </VisualStateManager.VisualStateGroups>
```
where xmlns:animation = "ModernWpf.Media.Animation"

The contents may be blurred since they are placed in a ViewPort3D but not as blur as in UWP

Thanks to @ORRNY66 for suggesting this 😁.

![7d3dd84-1](https://user-images.githubusercontent.com/54765038/75866699-73f0ff80-5e2b-11ea-9b76-05ed00b08c3b.jpg)
