### PR TITLE
Avoid default TextBox background in ComboBoxTextBoxStyle

### DIFF
--- a/ModernWpf/Styles/ComboBox.xaml
+++ b/ModernWpf/Styles/ComboBox.xaml
@@ -133,7 +133,6 @@
                     <Grid SnapsToDevicePixels="True">
                         <Border
                             x:Name="BorderElement"
-                            Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding primitives:ControlHelper.CornerRadius}" />


### PR DESCRIPTION
Fixes #230. Let me know if this is the right way to fix it.