### PR TITLE
Fix DataGridColumnHeader not using HeaderTemplate

### DIFF
--- a/ModernWpf/Styles/DataGrid.xaml
+++ b/ModernWpf/Styles/DataGrid.xaml
@@ -212,6 +212,7 @@
 
                             <ContentPresenter
                                 Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
                                 RecognizesAccessKey="True"


### PR DESCRIPTION
Hi,
thanks for this awesome library!
I've come to notice, that the DataGrid style overrides the use of my column's HeaderTemplate.

## Example
```xaml
<DataGrid>
    <DataGrid.Columns>
        <DataGridTemplateColumn Header="Header!">
            <DataGridTemplateColumn.HeaderTemplate>
                <DataTemplate>
                    <TextBlock Text="Template!" />
                </DataTemplate>
            </DataGridTemplateColumn.HeaderTemplate>
        </DataGridTemplateColumn>
    </DataGrid.Columns>
</DataGrid>
```
### Actual Output
![image](https://user-images.githubusercontent.com/3752127/111908406-6ff54700-8a59-11eb-936f-aac32f25c402.png)
### Expected Output
![image](https://user-images.githubusercontent.com/3752127/111908441-9a470480-8a59-11eb-8452-3c41d62e9a57.png)

## Proposed Solution
It came down to the ContentTemplate of the DataGridColumnHeader's ContentPresenter not being passed down.
Change required: Use provided HeaderTemplate for DataGridColumnHeader's ContentPresenter

Hope this helps :)
cheers