### PR TITLE
fixes Error NETSDK1130

### DIFF
--- a/ModernWpf.Controls/ModernWpfUI.nuspec
+++ b/ModernWpf.Controls/ModernWpfUI.nuspec
@@ -41,5 +41,10 @@
     <file src="bin\$configuration$\**\ModernWpf*.dll" target="lib" />
     <file src="bin\$configuration$\**\ModernWpf*.xml" target="lib" />
     <file src="readme.txt" target="" />
+    <file src="..\ModernWpfUI.props" target="build"/>
+    <file src="..\ModernWpfUI.props" target="buildTransitive"/>
+    <file src="..\ModernWpfUI.targets" target="build"/>
+    <file src="..\ModernWpfUI.targets" target="buildTransitive"/>
+
   </files>
 </package>

--- a/ModernWpfUI.props
+++ b/ModernWpfUI.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <UseWPF Condition="'$(UseWPF)'==''">true</UseWPF>
+    <LangVersion Condition="'$(LangVersion)'==''">latest</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/ModernWpfUI.targets
+++ b/ModernWpfUI.targets
@@ -1,0 +1,12 @@
+<Project>
+  <Target Name="ValidateWinUIProject" BeforeTargets="PrepareForBuild" Condition="$(TargetFramework.StartsWith('net5.0-windows'))">
+    <PropertyGroup>
+      <UseWinRT Condition="'$(UseWinRT)'==''">true</UseWinRT>
+      <CsWinRTEnabled Condition="'$(CsWinRTEnabled)'==''">true</CsWinRTEnabled>
+      <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)'==''">sdk</CsWinRTWindowsMetadata>
+    </PropertyGroup>
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.2.1"  PrivateAssets="All"/>
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
Avoid Error NETSDK1130 Referencing a Windows Metadata component directly when targeting .NETCoreApp,Version=v5.0 is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.

fixed #187 
fixed #208
fixed #271
fixed #283