### PR TITLE
Fix warnings by upgrading netcoreapp3.0 -> netcoreapp3.1

### DIFF
--- a/ModernWpf.Controls/ModernWpf.Controls.csproj
+++ b/ModernWpf.Controls/ModernWpf.Controls.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net462;netcoreapp3.0;net5.0-windows10.0.18362.0</TargetFrameworks>
+    <TargetFrameworks>net45;net462;netcoreapp3.1;net5.0-windows10.0.18362.0</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <NeutralLanguage>en-US</NeutralLanguage>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);GetDocumentationFile</TargetsForTfmSpecificBuildOutput>

--- a/ModernWpf.MahApps/ModernWpf.MahApps.csproj
+++ b/ModernWpf.MahApps/ModernWpf.MahApps.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net46;net462;net47;netcoreapp3.0;netcoreapp3.1;net5.0-windows10.0.18362.0</TargetFrameworks>
+    <TargetFrameworks>net452;net46;net462;net47;netcoreapp3.1;net5.0-windows10.0.18362.0</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <NeutralLanguage>en-US</NeutralLanguage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/ModernWpf/ModernWpf.csproj
+++ b/ModernWpf/ModernWpf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net462;netcoreapp3.0;net5.0-windows10.0.18362.0</TargetFrameworks>
+    <TargetFrameworks>net45;net462;netcoreapp3.1;net5.0-windows10.0.18362.0</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <NeutralLanguage>en-US</NeutralLanguage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
[.NET Core 3.0 stopped being supported by Microsoft on 2020-03-03](https://dotnet.microsoft.com/platform/support/policy/dotnet-core). Building ModernWPF with a recent toolchain results in warnings like the following:

> NETSDK1138: The target framework 'netcoreapp3.0' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy.

I think it would be good to upgrade to .NET Core 3.1 as the minimum .NET Core version. 3.1 is a LTS release and will be supported until 2022-12-03.

P.S. ModernWPF is awesome, thank you! I am hoping to contribute more fixes to the project in the future.