### PR TITLE
Timepicker bug fix

### DIFF
--- a/ModernWpf.MahApps/TimePicker/DateTimeComponentSelector.cs
+++ b/ModernWpf.MahApps/TimePicker/DateTimeComponentSelector.cs
@@ -185,6 +185,7 @@ namespace ModernWpf.MahApps.Controls
 
         protected override void OnSelectionChanged(SelectionChangedEventArgs e)
         {
+            ReleaseMouseCapture();
             e.Handled = true;
             _deferredSelectionChangedEventArgs = e;
 


### PR DESCRIPTION
Currently if you have a timepicker and click and drag to outside the time picker, it will cause it to enter an infinite loop and the application will hang. This is a fix for that.