### PR TITLE
Avoid retaining hidden PasswordBox plaintext copies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,119 @@
+# Repository agent guide
+
+This file applies to the entire repository unless a more specific `AGENTS.md`
+exists below the directory being changed.
+
+## Product direction
+
+- Work against the active ModernWpf 1.x line. Treat 0.9.x as a legacy,
+  security-only input rather than a compatibility baseline.
+- Preserve the supported package targets:
+  - `net462`
+  - `net8.0-windows7.0`
+  - `net10.0-windows7.0`
+- Do not reintroduce retired `net45`, `netcoreapp3.0`, or
+  `net5.0-windows` assets.
+- `ModernWpfUI.MahApps` is not part of the 1.x product.
+- For WinUI-derived controls, current WinUI is the behavioral and API-shape
+  authority unless WPF needs a documented adaptation. For stock WPF controls,
+  official WPF Fluent is the styling and behavior authority.
+- Read the related source-audit document under `docs/` before doing control
+  parity or template synchronization work.
+
+## Compatibility contract
+
+- `1.0.0-preview.1` is the forward-compatibility baseline. Do not remove or
+  change shipped public CLR APIs or explicitly shipped public resource keys.
+- Public API inventories live in:
+  - `ModernWpf/PublicAPI.Shipped.txt`
+  - `ModernWpf/PublicAPI.Unshipped.txt`
+  - `ModernWpf.Controls/PublicAPI.Shipped.txt`
+  - `ModernWpf.Controls/PublicAPI.Unshipped.txt`
+- Public resource-key inventories live in the corresponding
+  `PublicResourceKeys.Shipped.txt` and `PublicResourceKeys.Unshipped.txt`
+  files.
+- Prefer internal implementation types. Do not expose template helpers,
+  converters, automation details, or WinRT projection types as package API.
+- Do not add members to an already shipped public interface. Add a new
+  capability interface or an extensible base-class member instead.
+- When adding a deliberate public resource key, run:
+
+  ```powershell
+  .\tools\api-contracts\Update-PublicResourceKeyContract.ps1
+  ```
+
+- Consult `docs/public-api-contract-1x.md` for the complete boundary and
+  `docs/migrating-from-0.9.md` for intentional legacy breaks.
+
+## Implementation rules
+
+- Keep changes narrowly scoped and preserve behavior across every supported
+  target framework.
+- Follow `.editorconfig`: four-space indentation, underscore-prefixed private
+  fields, block-scoped namespaces, and CRLF for C#.
+- Preserve Light, Dark, High Contrast, and compact-resource behavior when
+  changing styles or templates.
+- Treat user secrets as sensitive. Do not copy passwords, tokens, or other
+  secrets into string-backed controls, dependency properties, logs, test
+  output, or long-lived managed objects unless the user explicitly requests
+  visible plaintext.
+- Never log secret test values. Security regressions need a focused automated
+  test that verifies the sensitive copy is not created or retained.
+- Do not edit build outputs under `bin/`, `obj/`, `artifacts/`,
+  `TestResults/`, or `.artifacts/`.
+
+## Test placement
+
+- `test/ModernWpf.WinUI.Tests`: control APIs, behavior, templates, layout,
+  input, and focused WPF-hosted regressions.
+- `test/ModernWpf.Theme.Tests`: theme dictionaries, resource contracts, and
+  cross-theme validation.
+- `test/ModernWpf.Gallery.Tests`: Gallery catalog, page, snippet, and runtime
+  coverage.
+- `test/ModernWpf.Tools.Tests`: repository and release tooling.
+- `test/ModernWpfTestApp`: retained .NET Framework compatibility suite.
+- Use the existing `WpfTestHost` and `TestWindowHost` infrastructure for
+  dispatcher-bound WPF tests.
+- Every skipped test must include a specific reason. Do not expand the legacy
+  skip list without updating `docs/legacy-test-retirements.md`.
+
+## Validation
+
+- Run restore, build, and tests serially. Parallel solution builds and test
+  builds can lock shared WPF `obj` files.
+- Start with the smallest relevant test filter, then run the complete affected
+  test project.
+- For product-code changes, build the solution in Release:
+
+  ```powershell
+  dotnet restore ModernWpf.sln
+  dotnet build ModernWpf.sln --configuration Release --no-restore
+  ```
+
+- A typical focused WinUI test run is:
+
+  ```powershell
+  dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj `
+    --configuration Release `
+    --framework net8.0-windows7.0 `
+    --no-build `
+    --no-restore `
+    --filter "FullyQualifiedName~RelevantTestName"
+  ```
+
+- Before release or after broad cross-cutting changes, run the complete
+  serialized gate in `docs/release-readiness-1x.md`. The complete WinUI suite
+  must pass three consecutive times from the final clean tip.
+- Restore treats moderate-or-higher NuGet audit findings as errors.
+- If package shape or public surface changes, also run the package verification
+  and smoke scripts documented in `docs/release-readiness-1x.md`.
+
+## Issue and pull-request work
+
+- Read the full issue or pull-request context before changing code.
+- Validate reports against the current 1.x implementation; age alone is not a
+  reason to close an issue.
+- A bug fix should include a regression test that fails for the reported
+  behavior and passes with the fix.
+- Report the exact commands run, test counts, skipped tests, and any validation
+  not performed.

--- a/ModernWpf/Controls/Primitives/PasswordBoxHelper.cs
+++ b/ModernWpf/Controls/Primitives/PasswordBoxHelper.cs
@@ -16,6 +16,9 @@ namespace ModernWpf.Controls.Primitives
         private readonly PasswordBox _passwordBox;
 
         private bool _hideRevealButton;
+        private bool _isUpdatingPasswordBox;
+        private bool _isUpdatingTextBox;
+        private TextBox _textBox;
 
         static PasswordBoxHelper()
         {
@@ -71,7 +74,11 @@ namespace ModernWpf.Controls.Primitives
         private static void OnPasswordRevealModeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var helper = GetHelperInstance((PasswordBox)d);
-            helper?.UpdateVisualState(true);
+            if (helper != null)
+            {
+                helper.UpdateTextBox();
+                helper.UpdateVisualState(true);
+            }
         }
 
         #endregion
@@ -167,8 +174,6 @@ namespace ModernWpf.Controls.Primitives
 
         #endregion
 
-        private TextBox TextBox { get; set; }
-
         private PasswordRevealMode PasswordRevealMode => GetPasswordRevealMode(_passwordBox);
 
         private static void OnDisabledCommandCanExecute(object sender, CanExecuteRoutedEventArgs e)
@@ -200,13 +205,7 @@ namespace ModernWpf.Controls.Primitives
             _passwordBox.LostFocus -= OnLostFocus;
             _passwordBox.Loaded -= OnLoaded;
 
-            if (TextBox != null)
-            {
-                TextBox.CommandBindings.Remove(TextBoxCutBinding);
-                TextBox.CommandBindings.Remove(TextBoxCopyBinding);
-                TextBox.TextChanged -= OnTextBoxTextChanged;
-                TextBox = null;
-            }
+            DetachTextBox();
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
@@ -217,17 +216,19 @@ namespace ModernWpf.Controls.Primitives
 
         private void OnApplyTemplate()
         {
+            DetachTextBox();
             _passwordBox.ApplyTemplate();
 
-            TextBox = _passwordBox.GetTemplateChild<TextBox>(nameof(TextBox));
+            _textBox = _passwordBox.GetTemplateChild<TextBox>("TextBox");
 
-            if (TextBox != null)
+            if (_textBox != null)
             {
-                TextBox.IsUndoEnabled = false;
-                SpellCheck.SetIsEnabled(TextBox, false);
-                TextBox.CommandBindings.Add(TextBoxCutBinding);
-                TextBox.CommandBindings.Add(TextBoxCopyBinding);
-                TextBox.TextChanged += OnTextBoxTextChanged;
+                _textBox.IsUndoEnabled = false;
+                SpellCheck.SetIsEnabled(_textBox, false);
+                _textBox.CommandBindings.Add(TextBoxCutBinding);
+                _textBox.CommandBindings.Add(TextBoxCopyBinding);
+                _textBox.TextChanged += OnTextBoxTextChanged;
+                _textBox.IsVisibleChanged += OnTextBoxIsVisibleChanged;
                 UpdateTextBox();
             }
 
@@ -236,16 +237,16 @@ namespace ModernWpf.Controls.Primitives
 
         private void OnGotFocus(object sender, RoutedEventArgs e)
         {
-            if (PasswordRevealMode == PasswordRevealMode.Visible && TextBox != null)
+            if (PasswordRevealMode == PasswordRevealMode.Visible && _textBox != null)
             {
                 if (e.OriginalSource == _passwordBox)
                 {
-                    TextBox.Focus();
+                    _textBox.Focus();
                     e.Handled = true;
                 }
             }
 
-            if (!string.IsNullOrEmpty(_passwordBox.Password))
+            if (HasPassword())
             {
                 _hideRevealButton = true;
             }
@@ -260,7 +261,7 @@ namespace ModernWpf.Controls.Primitives
 
         private void OnPasswordChanged(object sender, RoutedEventArgs e)
         {
-            bool hasPassword = !string.IsNullOrEmpty(_passwordBox.Password);
+            bool hasPassword = HasPassword();
 
             if (!hasPassword)
             {
@@ -274,17 +275,74 @@ namespace ModernWpf.Controls.Primitives
 
         private void OnTextBoxTextChanged(object sender, TextChangedEventArgs e)
         {
-            if (PasswordRevealMode == PasswordRevealMode.Visible)
+            if (!_isUpdatingTextBox &&
+                PasswordRevealMode == PasswordRevealMode.Visible &&
+                _textBox.IsVisible)
             {
-                _passwordBox.Password = ((TextBox)sender).Text;
+                _isUpdatingPasswordBox = true;
+                try
+                {
+                    _passwordBox.Password = ((TextBox)sender).Text;
+                }
+                finally
+                {
+                    _isUpdatingPasswordBox = false;
+                }
             }
+        }
+
+        private void OnTextBoxIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            UpdateTextBox();
+        }
+
+        private void DetachTextBox()
+        {
+            if (_textBox == null)
+            {
+                return;
+            }
+
+            _textBox.CommandBindings.Remove(TextBoxCutBinding);
+            _textBox.CommandBindings.Remove(TextBoxCopyBinding);
+            _textBox.TextChanged -= OnTextBoxTextChanged;
+            _textBox.IsVisibleChanged -= OnTextBoxIsVisibleChanged;
+            _textBox.Text = string.Empty;
+            _textBox = null;
+        }
+
+        private bool HasPassword()
+        {
+            using var password = _passwordBox.SecurePassword;
+            return password.Length > 0;
         }
 
         private void UpdateTextBox()
         {
-            if (TextBox != null)
+            if (_isUpdatingPasswordBox || _textBox == null)
             {
-                TextBox.Text = _passwordBox.Password;
+                return;
+            }
+
+            string text = string.Empty;
+            if (PasswordRevealMode != PasswordRevealMode.Hidden && _textBox.IsVisible)
+            {
+                // Password creates a managed plaintext string, so only read it
+                // while the template is intentionally displaying plaintext.
+                text = _passwordBox.Password;
+            }
+
+            if (_textBox.Text != text)
+            {
+                _isUpdatingTextBox = true;
+                try
+                {
+                    _textBox.Text = text;
+                }
+                finally
+                {
+                    _isUpdatingTextBox = false;
+                }
             }
         }
 
@@ -296,7 +354,7 @@ namespace ModernWpf.Controls.Primitives
                 switch (PasswordRevealMode)
                 {
                     case PasswordRevealMode.Peek:
-                        buttonVisible = !_hideRevealButton && !string.IsNullOrEmpty(_passwordBox.Password);
+                        buttonVisible = !_hideRevealButton && HasPassword();
                         break;
                     case PasswordRevealMode.Hidden:
                     case PasswordRevealMode.Visible:

--- a/test/ModernWpf.WinUI.Tests/CommonStyles/PasswordBoxHelperSecurityTests.cs
+++ b/test/ModernWpf.WinUI.Tests/CommonStyles/PasswordBoxHelperSecurityTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Markup;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModernWpf.Controls;
+using ModernWpf.Controls.Primitives;
+using ModernWpf.WinUI.TestApp;
+using ModernWpf.WinUI.TestInfra;
+
+namespace ModernWpf.WinUI.Tests.CommonStyles;
+
+[TestClass]
+public class PasswordBoxHelperSecurityTests
+{
+    [TestMethod]
+    public void PasswordBoxHelperDoesNotReadPlaintextForPasswordState()
+    {
+        var source = System.IO.File.ReadAllText(
+            System.IO.Path.Combine(
+                FindRepoRoot(),
+                "ModernWpf",
+                "Controls",
+                "Primitives",
+                "PasswordBoxHelper.cs"));
+
+        Assert.AreEqual(
+            2,
+            System.Text.RegularExpressions.Regex.Matches(
+                source,
+                @"_passwordBox\.Password(?!Changed)").Count,
+            "Only the intentional visible-mode getter and setter may access PasswordBox.Password.");
+        Assert.IsTrue(
+            source.Contains("using var password = _passwordBox.SecurePassword;", StringComparison.Ordinal),
+            "Password state checks should use SecurePassword instead of creating plaintext strings.");
+        Assert.IsTrue(
+            source.Contains(
+                "PasswordRevealMode != PasswordRevealMode.Hidden && _textBox.IsVisible",
+                StringComparison.Ordinal),
+            "The plaintext getter must remain guarded by actual reveal visibility.");
+    }
+
+    [TestMethod]
+    public void RevealTextBoxOnlyContainsPasswordWhilePlaintextIsVisible()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var passwordBox = new PasswordBox
+            {
+                Template = CreateRevealTemplate(),
+                Width = 240
+            };
+            PasswordBoxHelper.SetIsEnabled(passwordBox, true);
+
+            using var host = new TestWindowHost(passwordBox, width: 320, height: 120);
+            var revealTextBox = GetRevealTextBox(passwordBox);
+            const string password = "issue-331-regression-value";
+
+            passwordBox.Password = password;
+            host.UpdateLayout();
+
+            Assert.AreEqual(
+                0,
+                revealTextBox.Text.Length,
+                "A collapsed reveal TextBox must not retain a managed plaintext password copy.");
+
+            revealTextBox.Visibility = Visibility.Visible;
+            host.UpdateLayout();
+
+            Assert.IsTrue(
+                string.Equals(password, revealTextBox.Text, StringComparison.Ordinal),
+                "The password should be copied only while the reveal TextBox is visible.");
+
+            revealTextBox.Visibility = Visibility.Collapsed;
+            host.UpdateLayout();
+
+            Assert.AreEqual(
+                0,
+                revealTextBox.Text.Length,
+                "Hiding the reveal TextBox must clear its managed plaintext password copy.");
+
+            PasswordBoxHelper.SetPasswordRevealMode(passwordBox, PasswordRevealMode.Hidden);
+            revealTextBox.Visibility = Visibility.Visible;
+            host.UpdateLayout();
+
+            Assert.AreEqual(
+                0,
+                revealTextBox.Text.Length,
+                "Hidden reveal mode must not populate a visible template TextBox.");
+
+            PasswordBoxHelper.SetPasswordRevealMode(passwordBox, PasswordRevealMode.Visible);
+            host.UpdateLayout();
+
+            Assert.IsTrue(
+                string.Equals(password, revealTextBox.Text, StringComparison.Ordinal),
+                "Visible reveal mode should continue to support intentional plaintext display.");
+
+            const string updatedPassword = "issue-331-updated-value";
+            revealTextBox.Text = updatedPassword;
+            host.UpdateLayout();
+
+            Assert.IsTrue(
+                string.Equals(updatedPassword, passwordBox.Password, StringComparison.Ordinal),
+                "Editing in visible reveal mode should continue to update the PasswordBox.");
+
+            PasswordBoxHelper.SetIsEnabled(passwordBox, false);
+
+            Assert.AreEqual(
+                0,
+                revealTextBox.Text.Length,
+                "Detaching the helper must clear any remaining managed plaintext password copy.");
+
+            using var securePassword = passwordBox.SecurePassword;
+            Assert.AreEqual(
+                updatedPassword.Length,
+                securePassword.Length,
+                "Detaching the helper must not clear the PasswordBox's secure value.");
+        });
+    }
+
+    private static TextBox GetRevealTextBox(PasswordBox passwordBox)
+    {
+        return passwordBox.Template.FindName("TextBox", passwordBox) as TextBox
+            ?? throw new AssertFailedException("Expected the test template to contain the reveal TextBox.");
+    }
+
+    private static ControlTemplate CreateRevealTemplate()
+    {
+        const string xaml = """
+            <ControlTemplate
+                xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                TargetType="{x:Type PasswordBox}">
+                <Grid>
+                    <ScrollViewer x:Name="PART_ContentHost" />
+                    <TextBox x:Name="TextBox" Visibility="Collapsed" />
+                </Grid>
+            </ControlTemplate>
+            """;
+
+        return (ControlTemplate)XamlReader.Parse(xaml);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new System.IO.DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory != null)
+        {
+            if (System.IO.File.Exists(System.IO.Path.Combine(directory.FullName, "ModernWpf.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        Assert.Fail("Could not locate ModernWpf.sln from the test output directory.");
+        return string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary

- add a root `AGENTS.md` with the ModernWpf 1.x compatibility, implementation, and validation guardrails
- use `SecurePassword` for password-presence checks so hidden input does not create managed plaintext strings
- populate the reveal `TextBox` only while plaintext is intentionally visible, and clear it when hidden, retemplated, or detached
- preserve visible-mode editing while preventing synchronization loops
- add runtime and source regression guards for issue #331

## Root cause

`PasswordBoxHelper` read `PasswordBox.Password` on every password and focus-state update and mirrored that value into a collapsed `TextBox`. Reading `Password` creates a managed plaintext string, so masked input left searchable plaintext copies in process memory.

The fix uses `SecurePassword.Length` for state checks and limits the remaining `Password` getter to the intentional visible-reveal path.

## User impact

Masked password entry no longer creates or retains a hidden plaintext mirror. `PasswordRevealMode.Visible` and visible editing continue to work as before.

## Validation

- `dotnet build .\ModernWpf.sln --configuration Release --no-restore`: 0 warnings, 0 errors
- focused `PasswordBoxHelperSecurityTests`: 2 passed
- final WinUI suite excluding one environment-dependent real-pointer case: 1,014 passed, 0 failed, 0 skipped
- `GalleryPrimaryCommandReceivesRealMousePointerStates` was excluded from the final aggregate after failing both the full run and an isolated retry because Windows reported `DirectlyOver=<null>`; it is unrelated to the PasswordBox changes

Fixes #331
