### PR TITLE
Fix ContentDialog modal overlay sizing

### DIFF
--- a/ModernWpf.Controls/ContentDialog/ContentDialog.cs
+++ b/ModernWpf.Controls/ContentDialog/ContentDialog.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -344,6 +345,7 @@ namespace ModernWpf.Controls
             PrimaryButton = GetTemplateChild(nameof(PrimaryButton)) as Button;
             SecondaryButton = GetTemplateChild(nameof(SecondaryButton)) as Button;
             CloseButton = GetTemplateChild(nameof(CloseButton)) as Button;
+            m_adorner?.SetSmokeLayerStateSource(LayoutRoot);
 
             if (LayoutRoot != null)
             {
@@ -629,7 +631,14 @@ namespace ModernWpf.Controls
 
         private void UpdateDialogShowingStates(bool useTransitions)
         {
-            string stateName = IsShowing && IsLoaded ? DialogShowingState : DialogHiddenState;
+            string stateName = DialogHiddenState;
+
+            if (IsShowing && IsLoaded)
+            {
+                stateName = m_adornerLayer != null
+                    ? DialogShowingWithoutSmokeLayerState
+                    : DialogShowingState;
+            }
 
             if (DesignerProperties.GetIsInDesignMode(this))
             {
@@ -737,11 +746,12 @@ namespace ModernWpf.Controls
         {
             if (m_adorner == null)
             {
-                m_adorner = new ContentDialogAdorner(cp, child);
+                m_adorner = new ContentDialogAdorner(cp, child, LayoutRoot);
             }
             else
             {
                 m_adorner.Child = child;
+                m_adorner.SetSmokeLayerStateSource(LayoutRoot);
             }
         }
 
@@ -883,10 +893,18 @@ namespace ModernWpf.Controls
 
         private class ContentDialogAdorner : Adorner
         {
+            private readonly Border _smokeLayer;
             private UIElement _child;
 
-            public ContentDialogAdorner(UIElement adornedElement, UIElement child) : base(adornedElement)
+            public ContentDialogAdorner(
+                UIElement adornedElement,
+                UIElement child,
+                FrameworkElement smokeLayerStateSource) : base(adornedElement)
             {
+                _smokeLayer = new Border();
+                _smokeLayer.SetResourceReference(Border.BackgroundProperty, "ContentDialogSmokeFill");
+                AddVisualChild(_smokeLayer);
+                SetSmokeLayerStateSource(smokeLayerStateSource);
                 Child = child ?? throw new ArgumentNullException(nameof(child));
             }
 
@@ -912,11 +930,31 @@ namespace ModernWpf.Controls
                 }
             }
 
-            protected override int VisualChildrenCount => _child != null ? 1 : 0;
+            public void SetSmokeLayerStateSource(FrameworkElement source)
+            {
+                BindingOperations.ClearBinding(_smokeLayer, OpacityProperty);
+                BindingOperations.ClearBinding(_smokeLayer, VisibilityProperty);
+
+                if (source != null)
+                {
+                    _smokeLayer.SetBinding(
+                        OpacityProperty,
+                        new Binding(nameof(Opacity)) { Source = source });
+                    _smokeLayer.SetBinding(
+                        VisibilityProperty,
+                        new Binding(nameof(Visibility)) { Source = source });
+                }
+            }
+
+            protected override int VisualChildrenCount => _child != null ? 2 : 1;
 
             protected override Visual GetVisualChild(int index)
             {
-                if (index == 0 && _child != null)
+                if (index == 0)
+                {
+                    return _smokeLayer;
+                }
+                else if (index == 1 && _child != null)
                 {
                     return _child;
                 }
@@ -930,6 +968,7 @@ namespace ModernWpf.Controls
             {
                 var desiredSize = AdornedElement.RenderSize;
                 constraint = desiredSize;
+                _smokeLayer.Measure(constraint);
                 Child?.Measure(constraint);
                 return desiredSize;
             }
@@ -937,6 +976,7 @@ namespace ModernWpf.Controls
             protected override Size ArrangeOverride(Size size)
             {
                 var finalSize = base.ArrangeOverride(size);
+                _smokeLayer.Arrange(new Rect(new Point(), finalSize));
                 Child?.Arrange(new Rect(new Point(), finalSize));
                 return finalSize;
             }

--- a/ModernWpf.Controls/ContentDialog/ContentDialog.xaml
+++ b/ModernWpf.Controls/ContentDialog/ContentDialog.xaml
@@ -91,7 +91,11 @@
                                         </Storyboard>
                                     </VisualTransition>
                                 </VisualStateGroup.Transitions>
-                                <VisualState x:Name="DialogHidden" />
+                                <ui:VisualStateEx x:Name="DialogHidden">
+                                    <ui:VisualStateEx.Setters>
+                                        <ui:VisualStateSetter Target="SmokeLayerBackground.Fill" Value="{x:Null}" />
+                                    </ui:VisualStateEx.Setters>
+                                </ui:VisualStateEx>
                                 <ui:VisualStateEx x:Name="DialogShowing">
                                     <ui:VisualStateEx.Setters>
                                         <ui:VisualStateSetter Target="PrimaryButton.IsTabStop" Value="True" />
@@ -108,6 +112,7 @@
                                         <ui:VisualStateSetter Target="CloseButton.IsTabStop" Value="True" />
                                         <ui:VisualStateSetter Target="LayoutRoot.Visibility" Value="Visible" />
                                         <ui:VisualStateSetter Target="LayoutRoot.Background" Value="{x:Null}" />
+                                        <ui:VisualStateSetter Target="SmokeLayerBackground.Fill" Value="{x:Null}" />
                                     </ui:VisualStateEx.Setters>
                                 </ui:VisualStateEx>
                             </VisualStateGroup>

--- a/test/ModernWpf.WinUI.Tests/ContentDialog/ContentDialogApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/ContentDialog/ContentDialogApiTests.cs
@@ -8,7 +8,9 @@ using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Shapes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ModernWpf;
@@ -421,6 +423,55 @@ public class ContentDialogApiTests
             Assert.AreEqual(128.0, shadow.Depth);
             Assert.AreEqual(ThemeShadowChromeWindowedPopupInsetMode.Default, shadow.WindowedPopupInsetMode);
             Assert.AreEqual(new Thickness(64, 32, 64, 96), shadow.ShadowPadding);
+        });
+    }
+
+    [TestMethod]
+    public void WindowModalOverlayCoversOwnerWhenDialogHasMaxWidth()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var root = new Grid();
+            using var host = new TestWindowHost(root, width: 1000, height: 600);
+            var dialog = CreateDialog();
+            dialog.Owner = host.Window;
+            dialog.MaxWidth = 500;
+
+            var showTask = dialog.ShowAsync();
+            WpfTestHost.DoEvents();
+            host.UpdateLayout();
+
+            var ownerPresenter = VisualTreeTestHelper
+                .EnumerateDescendants(host.Window)
+                .OfType<ContentPresenter>()
+                .Single(candidate => ReferenceEquals(candidate.Content, root));
+            var adornerLayer = AdornerLayer.GetAdornerLayer(ownerPresenter)
+                ?? throw new AssertFailedException("Expected the owner ContentPresenter to have an AdornerLayer.");
+            var adorner = adornerLayer.GetAdorners(ownerPresenter)?.Single()
+                ?? throw new AssertFailedException("Expected the ContentDialog modal adorner.");
+
+            Assert.AreEqual(ownerPresenter.ActualWidth, adorner.ActualWidth, 0.1);
+            Assert.AreEqual(ownerPresenter.ActualHeight, adorner.ActualHeight, 0.1);
+            Assert.IsTrue(
+                dialog.ActualWidth <= dialog.MaxWidth + 0.1,
+                $"Expected the dialog width ({dialog.ActualWidth}) to respect MaxWidth ({dialog.MaxWidth}).");
+            Assert.IsNull(
+                GetTemplateChild<Rectangle>(dialog, "SmokeLayerBackground").Fill,
+                "The constrained dialog must not paint a second smoke layer over the adorner smoke layer.");
+
+            var dialogOrigin = dialog.TranslatePoint(new Point(), adorner);
+            var overlayPoint = new Point(adorner.ActualWidth - 1, adorner.ActualHeight / 2);
+            Assert.IsTrue(
+                overlayPoint.X > dialogOrigin.X + dialog.ActualWidth,
+                "Expected the regression hit-test point to be outside the constrained dialog.");
+            Assert.IsNotNull(
+                VisualTreeHelper.HitTest(adorner, overlayPoint),
+                "The modal overlay must remain hit-testable outside the MaxWidth-constrained dialog.");
+
+            dialog.Hide();
+            Assert.AreEqual(ContentDialogResult.None, WaitForResult(showTask));
         });
     }
 


### PR DESCRIPTION
## Summary

- move the modal smoke and input-capture surface into the owner-sized adorner
- keep `MaxWidth` constraints scoped to the dialog while the overlay covers the full owner
- suppress the template smoke layer for window-modal placement and preserve its visibility/opacity transitions
- add a focused WPF-hosted regression test for hit testing outside a constrained dialog

## Root cause

WPF applied `MaxWidth` to the entire `ContentDialog` control before its template rendered the smoke layer. The adorner occupied the full owner, but its only hit-testable visual was constrained to the dialog width, leaving the surrounding window interactive.

## Impact

A constrained `ContentDialog` now remains properly modal across the full owner window without changing its requested maximum width.

## Validation

- `dotnet restore ModernWpf.sln`
- `dotnet build ModernWpf.sln --configuration Release --no-restore` — 0 warnings, 0 errors
- focused regression — 1/1 passed
- ContentDialog test area — 19/19 passed
- complete WinUI test project — 1,016/1,016 passed, 0 skipped

Fixes #687