### PR TITLE
Fix initial TextBox validation adorner cleanup

### DIFF
--- a/ModernWpf/Controls/Primitives/ValidationHelper.cs
+++ b/ModernWpf/Controls/Primitives/ValidationHelper.cs
@@ -30,9 +30,41 @@ namespace ModernWpf.Controls.Primitives
             var element = (FrameworkElement)d;
             if ((bool)e.NewValue)
             {
-                Debug.Assert(element.TemplatedParent != null);
+                var templatedParent = element.TemplatedParent;
+                Debug.Assert(templatedParent != null);
                 Validation.SetErrorTemplate(element, null);
-                Validation.SetValidationAdornerSiteFor(element, element.TemplatedParent);
+
+                if (templatedParent != null &&
+                    Validation.GetHasError(templatedParent) &&
+                    Validation.GetErrorTemplate(templatedParent) is ControlTemplate errorTemplate)
+                {
+                    var valueSource = DependencyPropertyHelper.GetValueSource(
+                        templatedParent,
+                        Validation.ErrorTemplateProperty);
+                    bool restoreLocalValue =
+                        valueSource.BaseValueSource == BaseValueSource.Local &&
+                        !valueSource.IsExpression;
+
+                    templatedParent.SetCurrentValue(Validation.ErrorTemplateProperty, null);
+                    Validation.SetValidationAdornerSiteFor(element, templatedParent);
+                    templatedParent.Dispatcher.BeginInvoke(
+                        System.Windows.Threading.DispatcherPriority.Loaded,
+                        new System.Action(() =>
+                        {
+                            if (restoreLocalValue)
+                            {
+                                Validation.SetErrorTemplate(templatedParent, errorTemplate);
+                            }
+                            else
+                            {
+                                templatedParent.InvalidateProperty(Validation.ErrorTemplateProperty);
+                            }
+                        }));
+                }
+                else
+                {
+                    Validation.SetValidationAdornerSiteFor(element, templatedParent);
+                }
             }
             else
             {

--- a/docs/textbox-passwordbox-wpf-fluent-source-audit.md
+++ b/docs/textbox-passwordbox-wpf-fluent-source-audit.md
@@ -42,7 +42,12 @@ the stock WPF `TextBox`, `TextBoxBase`, and `PasswordBox` templates.
   existing text-control context menu integration remains available.
 - ModernWpf keeps `Validation.ErrorTemplate` and
   `ValidationHelper.IsTemplateValidationAdornerSite` for `TextBox` and
-  `TextBoxBase` validation chrome.
+  `TextBoxBase` validation chrome. When validation is already invalid before
+  the template is applied, the helper suppresses the deferred original-site
+  adorner while redirecting validation to the template border, then restores
+  the existing error-template value source at dispatcher `Loaded` priority.
+  This prevents the original-site adorner from remaining after validation
+  succeeds.
 - Official WPF Fluent's `TextBox` clear button invokes the newer WPF
   `TemplateButtonCommand`. ModernWpf older targets do not expose that platform
   property, so the clear button uses the existing
@@ -59,8 +64,9 @@ the stock WPF `TextBox`, `TextBoxBase`, and `PasswordBox` templates.
 
 - `test\ModernWpf.WinUI.Tests\CommonStyles\TextBoxPasswordBoxVisualStateTests.cs`
   covers the official WPF Fluent style setter surfaces, template parts,
-  trigger shapes, clear-button substitution, `DataGridTextBoxStyle`, and
-  deletion of the old WinUI-derived template branches.
+  trigger shapes, clear-button substitution, `DataGridTextBoxStyle`,
+  initial-error validation-adorners, and deletion of the old WinUI-derived
+  template branches.
 - `test\ModernWpf.WinUI.Tests\TemplateParityTests.cs` classifies
   `ModernWpf\Styles\TextBox.xaml` and
   `ModernWpf\Styles\PasswordBox.xaml` as official WPF Fluent stock templates

--- a/test/ModernWpf.WinUI.Tests/CommonStyles/TextBoxPasswordBoxVisualStateTests.cs
+++ b/test/ModernWpf.WinUI.Tests/CommonStyles/TextBoxPasswordBoxVisualStateTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Markup;
@@ -45,6 +46,19 @@ public class TextBoxPasswordBoxVisualStateTests
             AssertTextBoxTriggerShape(textBox.Template);
             AssertTextBoxClearButtonSubstitutionClearsText(textBox);
             AssertDisabledTextControlTemplateResources(textBox);
+        });
+    }
+
+    [TestMethod]
+    public void InitialTextBoxValidationErrorAdornerClearsWhenValueBecomesValid()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            AssertInitialTextBoxValidationErrorClears();
+            AssertInitialTextBoxValidationErrorClears(
+                (ControlTemplate)Application.Current.FindResource("DataGridTextControlValidationErrorTemplate"));
         });
     }
 
@@ -581,6 +595,67 @@ public class TextBoxPasswordBoxVisualStateTests
             ?? throw new AssertFailedException($"Expected {control.GetType().Name} template child '{name}' to be a {typeof(T).Name}.");
     }
 
+    private static void AssertInitialTextBoxValidationErrorClears(ControlTemplate? localErrorTemplate = null)
+    {
+        var model = new RequiredTextModel();
+        var textBox = new TextBox
+        {
+            DataContext = model,
+            Width = 240
+        };
+        if (localErrorTemplate != null)
+        {
+            Validation.SetErrorTemplate(textBox, localErrorTemplate);
+        }
+
+        textBox.SetBinding(
+            TextBox.TextProperty,
+            new Binding(nameof(RequiredTextModel.Value))
+            {
+                Mode = BindingMode.TwoWay,
+                UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
+                ValidatesOnDataErrors = true
+            });
+        WpfTestHost.DoEvents();
+
+        Assert.IsTrue(
+            Validation.GetHasError(textBox),
+            "The binding must be invalid before the TextBox template is applied.");
+
+        using var host = new TestWindowHost(textBox, width: 320, height: 120);
+        host.UpdateLayout();
+
+        var contentBorder = GetTemplateChild<Border>(textBox, "ContentBorder");
+        var adornerLayer = AdornerLayer.GetAdornerLayer(textBox)
+            ?? throw new AssertFailedException("Expected the hosted TextBox to have an AdornerLayer.");
+        Assert.AreSame(
+            localErrorTemplate ?? textBox.TryFindResource("TextControlValidationErrorTemplate"),
+            Validation.GetErrorTemplate(textBox),
+            "Redirecting the validation site must preserve the effective error template.");
+        Assert.IsTrue(
+            GetValidationAdornerCount(adornerLayer, textBox, contentBorder) > 0,
+            "Expected the initial validation error to display an adorner.");
+
+        textBox.Text = "valid";
+        WpfTestHost.DoEvents();
+        host.UpdateLayout();
+
+        Assert.IsFalse(Validation.GetHasError(textBox));
+        Assert.AreEqual(
+            0,
+            GetValidationAdornerCount(adornerLayer, textBox, contentBorder),
+            "The validation adorner must be removed after the initial error is corrected.");
+    }
+
+    private static int GetValidationAdornerCount(
+        AdornerLayer adornerLayer,
+        TextBox textBox,
+        Border contentBorder)
+    {
+        return (adornerLayer.GetAdorners(textBox)?.Length ?? 0)
+            + (adornerLayer.GetAdorners(contentBorder)?.Length ?? 0);
+    }
+
     private static string FindRepoRoot()
     {
         var directory = new System.IO.DirectoryInfo(System.AppContext.BaseDirectory);
@@ -597,5 +672,17 @@ public class TextBoxPasswordBoxVisualStateTests
 
         Assert.Fail("Could not locate ModernWpf.sln from the test output directory.");
         return string.Empty;
+    }
+
+    private sealed class RequiredTextModel : System.ComponentModel.IDataErrorInfo
+    {
+        public string Value { get; set; } = string.Empty;
+
+        public string Error => string.Empty;
+
+        public string this[string columnName] =>
+            columnName == nameof(Value) && string.IsNullOrEmpty(Value)
+                ? "Value is required."
+                : string.Empty;
     }
 }


### PR DESCRIPTION
## Summary

- prevent a deferred pre-template `TextBox` validation adorner from surviving after the value becomes valid
- preserve the effective validation error template, including a locally supplied template, while redirecting validation chrome to the template border
- add a deterministic regression test for initially invalid bindings and document the WPF Fluent adaptation

## Root cause

When a binding is invalid before the `TextBox` template is applied, WPF queues an adorner for the original `TextBox` site at dispatcher `Loaded` priority. ModernWpf later redirects validation to the template's `ContentBorder`, but that earlier queued operation can still create an orphaned adorner on the original site. Clearing validation then removes only the current-site adorner, leaving the original red border visible.

The fix temporarily suppresses the parent's effective error template while the validation site is redirected, then restores its existing value source at the same dispatcher priority. This prevents the obsolete queued operation from creating an adorner and lets WPF render only at the redirected site.

## User impact

A `TextBox` that starts with an `IDataErrorInfo` validation error now removes its validation border after the user enters a valid value. Existing styled and locally supplied error templates remain intact.

## Validation

- `dotnet restore ModernWpf.sln`
- `dotnet build ModernWpf.sln --configuration Release --no-restore` — 0 warnings, 0 errors
- focused regression — 1 passed, 0 skipped
- `TextBoxPasswordBoxVisualStateTests` — 7 passed, 0 skipped
- complete `ModernWpf.WinUI.Tests` (`net8.0-windows7.0`) — 1,017 passed, 0 skipped

Fixes #685