### PR TITLE
Fix white flicker while resizing modern windows on Windows 11

### DIFF
--- a/ModernWpf/Styles/Window.xaml
+++ b/ModernWpf/Styles/Window.xaml
@@ -24,12 +24,21 @@
         </Setter>
     </Style>
 
-    <WindowChrome
+    <primitives:ModernWindowChrome
         x:Key="DefaultWindowChrome"
         x:Shared="False"
         CaptionHeight="{DynamicResource {x:Static local:TitleBar.HeightKey}}"
         CornerRadius="0"
         GlassFrameThickness="{x:Static WindowChrome.GlassFrameCompleteThickness}"
+        UseAeroCaptionButtons="False" />
+
+    <primitives:ModernWindowChrome
+        x:Key="HighContrastWindowChrome"
+        x:Shared="False"
+        CaptionHeight="{DynamicResource {x:Static local:TitleBar.HeightKey}}"
+        CornerRadius="0"
+        GlassFrameThickness="{x:Static WindowChrome.GlassFrameCompleteThickness}"
+        NonClientFrameEdges="None"
         UseAeroCaptionButtons="False" />
 
     <Style x:Key="BaseWindowStyle" TargetType="Window">
@@ -140,6 +149,9 @@
             </Setter.Value>
         </Setter>
         <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true">
+                <Setter Property="WindowChrome.WindowChrome" Value="{DynamicResource HighContrastWindowChrome}" />
+            </DataTrigger>
             <Trigger Property="WindowChrome.WindowChrome" Value="{x:Null}">
                 <Setter Property="primitives:WindowHelper.FixMaximizedWindow" Value="False" />
             </Trigger>

--- a/ModernWpf/TitleBar/ModernWindowChrome.cs
+++ b/ModernWpf/TitleBar/ModernWindowChrome.cs
@@ -1,0 +1,36 @@
+using System.Windows;
+using System.Windows.Shell;
+
+namespace ModernWpf.Controls.Primitives
+{
+    internal sealed class ModernWindowChrome : WindowChrome
+    {
+        public ModernWindowChrome()
+        {
+            // High Contrast swaps in an explicit None-edge chrome resource.
+            // Keep the normal resource OS-only so it restores correctly.
+            NonClientFrameEdges = GetPreferredNonClientFrameEdges(
+                isHighContrast: false,
+                OSVersionHelper.IsWindows11OrGreater);
+        }
+
+        internal static NonClientFrameEdges GetPreferredNonClientFrameEdges(
+            bool isHighContrast,
+            bool isWindows11OrGreater)
+        {
+            if (isHighContrast || !isWindows11OrGreater)
+            {
+                return NonClientFrameEdges.None;
+            }
+
+            return NonClientFrameEdges.Left |
+                NonClientFrameEdges.Right |
+                NonClientFrameEdges.Bottom;
+        }
+
+        protected override Freezable CreateInstanceCore()
+        {
+            return new ModernWindowChrome();
+        }
+    }
+}

--- a/docs/window-wpf-fluent-source-audit.md
+++ b/docs/window-wpf-fluent-source-audit.md
@@ -12,6 +12,7 @@ shell pieces as documented WPF substitutions.
 - `D:\repos\wpf\src\Microsoft.DotNet.Wpf\src\Themes\PresentationFramework.Fluent\Resources\Theme\Light.xaml`
 - `D:\repos\wpf\src\Microsoft.DotNet.Wpf\src\Themes\PresentationFramework.Fluent\Resources\Theme\Dark.xaml`
 - `D:\repos\wpf\src\Microsoft.DotNet.Wpf\src\Themes\PresentationFramework.Fluent\Resources\Theme\HC.xaml`
+- [Microsoft WPF Gallery `MainWindow.xaml.cs`](https://github.com/microsoft/WPF-Samples/blob/30ee5948dd92d2a81ef6a54d25b1b921463da107/Sample%20Applications/WPFGallery/MainWindow.xaml.cs)
 
 ## ModernWpf Files
 
@@ -41,6 +42,10 @@ ModernWpf now follows the compatible parts of that source shape:
   instead of `ContentPresenterEx`.
 - `DefaultWindowStyle` remains based on `BaseWindowStyle`, preserving the
   ModernWpf shell contract.
+- On Windows 11 outside High Contrast, the left, right, and bottom resize
+  borders remain non-client edges. This follows the current Microsoft WPF
+  Gallery shell policy and prevents full-client glass from exposing an
+  unpainted compositor surface while a dark window is resized.
 
 ## WPF Substitutions
 
@@ -50,6 +55,7 @@ ModernWpf now follows the compatible parts of that source shape:
 | Transparent backdrop default with `MS.Internal.FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop` and `Standard.Utility.IsOSWindows11OrNewer` guards | Always resolve the visible window background through `WindowBackground` | ModernWpf does not own .NET WPF Fluent's platform backdrop implementation; using the fallback resource is the stable WPF substitute. |
 | Plain `AdornerDecorator` / `ContentPresenter` content host | Same plain WPF `ContentPresenter` inside ModernWpf's title-bar grid | The content presenter is source-compatible while the surrounding custom chrome remains ModernWpf-owned. |
 | Stock `WindowTemplateKey` template swap for resize grip | Existing resize-grip trigger inside the custom shell template | Preserves ModernWpf's title bar, high-contrast border, and maximized-window handling while keeping the source `ResizeMode=CanResizeWithGrip` / `WindowState=Normal` visibility rule. |
+| Stock content window with platform-owned non-client chrome | Full-glass custom title bar with Windows 11 left, right, and bottom `NonClientFrameEdges` | Matches the Microsoft WPF Gallery shell adaptation, preserves the top client title bar and snap-layout hit testing, and prevents resize-time white flashes reported in issue #683. High Contrast and pre-Windows 11 retain `NonClientFrameEdges.None`. |
 
 ## Intentional Differences
 
@@ -68,6 +74,9 @@ surface.
   `WindowForeground`, `WindowBackground`, `DefaultWindowChrome`, and
   `WindowHelper.FixMaximizedWindow`, and that the applied window template keeps
   `TitleBarControl`, `ResizeGrip`, and a plain WPF content presenter.
+- `WindowVisualStateTests` verifies the guarded Windows 11 resize-edge policy,
+  the legacy and High Contrast fallbacks, the complete-glass requirement, and
+  the High Contrast chrome-resource override.
 - `WindowVisualStateTests` statically guards `Styles\Window.xaml` against
   `ContentPresenterEx`, `MS.Internal`, `Fluent.Controls`, and `System.Runtime`
   source markers.

--- a/test/ModernWpf.WinUI.Tests/CommonStyles/WindowVisualStateTests.cs
+++ b/test/ModernWpf.WinUI.Tests/CommonStyles/WindowVisualStateTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Shell;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ModernWpf.Controls.Primitives;
@@ -32,6 +33,64 @@ public class WindowVisualStateTests
             AssertStyleSetter(baseStyle, Control.BorderThicknessProperty, new Thickness(1));
             AssertStyleSetter(baseStyle, WindowHelper.FixMaximizedWindowProperty, true);
             AssertStyleSetter(defaultStyle, FrameworkElement.OverridesDefaultStyleProperty, true);
+        });
+    }
+
+    [TestMethod]
+    public void DefaultWindowChromeKeepsWindows11ResizeEdgesOutOfFullClientGlass()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var baseStyle = AssertStyle("BaseWindowStyle");
+            var chrome = Application.Current.FindResource("DefaultWindowChrome") as WindowChrome;
+            var highContrastChrome = Application.Current.FindResource("HighContrastWindowChrome") as WindowChrome;
+            Assert.IsNotNull(chrome);
+            Assert.IsNotNull(highContrastChrome);
+            Assert.IsInstanceOfType<ModernWindowChrome>(chrome);
+            Assert.IsInstanceOfType<ModernWindowChrome>(highContrastChrome);
+            Assert.AreEqual(WindowChrome.GlassFrameCompleteThickness, chrome!.GlassFrameThickness);
+            Assert.AreEqual(WindowChrome.GlassFrameCompleteThickness, highContrastChrome!.GlassFrameThickness);
+            Assert.AreEqual(NonClientFrameEdges.None, highContrastChrome!.NonClientFrameEdges);
+
+            var resizeEdges =
+                NonClientFrameEdges.Left |
+                NonClientFrameEdges.Right |
+                NonClientFrameEdges.Bottom;
+            Assert.AreEqual(
+                resizeEdges,
+                ModernWindowChrome.GetPreferredNonClientFrameEdges(
+                    isHighContrast: false,
+                    isWindows11OrGreater: true));
+            Assert.AreEqual(
+                NonClientFrameEdges.None,
+                ModernWindowChrome.GetPreferredNonClientFrameEdges(
+                    isHighContrast: true,
+                    isWindows11OrGreater: true));
+            Assert.AreEqual(
+                NonClientFrameEdges.None,
+                ModernWindowChrome.GetPreferredNonClientFrameEdges(
+                    isHighContrast: false,
+                    isWindows11OrGreater: false));
+            Assert.AreEqual(
+                ModernWindowChrome.GetPreferredNonClientFrameEdges(
+                    isHighContrast: false,
+                    OSVersionHelper.IsWindows11OrGreater),
+                chrome.NonClientFrameEdges);
+
+            var highContrastTrigger = baseStyle.Triggers
+                .OfType<DataTrigger>()
+                .Single(trigger => trigger.Setters
+                    .OfType<Setter>()
+                    .Any(setter => setter.Property == WindowChrome.WindowChromeProperty));
+            Assert.IsInstanceOfType<Binding>(highContrastTrigger.Binding);
+            var chromeSetter = highContrastTrigger.Setters
+                .OfType<Setter>()
+                .Single(setter => setter.Property == WindowChrome.WindowChromeProperty);
+            var highContrastResource = chromeSetter.Value as DynamicResourceExtension;
+            Assert.IsNotNull(highContrastResource);
+            Assert.AreEqual("HighContrastWindowChrome", highContrastResource!.ResourceKey);
         });
     }
 
@@ -77,6 +136,8 @@ public class WindowVisualStateTests
         Assert.IsTrue(text.Contains("TitleBarControl", System.StringComparison.Ordinal));
         Assert.IsTrue(text.Contains("WindowChrome.WindowChrome", System.StringComparison.Ordinal));
         Assert.IsTrue(text.Contains("WindowHelper.FixMaximizedWindow", System.StringComparison.Ordinal));
+        Assert.IsTrue(text.Contains("Path=(SystemParameters.HighContrast)", System.StringComparison.Ordinal));
+        Assert.IsTrue(text.Contains("HighContrastWindowChrome", System.StringComparison.Ordinal));
         Assert.IsFalse(text.Contains("ContentPresenterEx", System.StringComparison.Ordinal));
         Assert.IsFalse(text.Contains("MS.Internal", System.StringComparison.Ordinal));
         Assert.IsFalse(text.Contains("Fluent.Controls", System.StringComparison.Ordinal));


### PR DESCRIPTION
## Summary

- keep the Windows 11 left, right, and bottom resize borders in the non-client frame while retaining full-glass custom title-bar behavior
- preserve the existing `NonClientFrameEdges.None` path on pre-Windows 11 and in High Contrast
- add focused regression coverage and document the Microsoft WPF Gallery source-backed adaptation

## Reproduction and cause

Reproduced the report on Windows 11 with a black `WindowHelper.UseModernWindowStyle` window. The full `GlassFrameCompleteThickness` path leaves every resize edge in full-client glass, allowing the compositor's unpainted surface to flash white during live resize. The guarded edge policy matches Microsoft WPF Gallery's current shell implementation while preserving the top client title bar and Windows 11 snap-layout hit testing.

## Validation

- `dotnet restore ModernWpf.sln` — passed
- `dotnet build ModernWpf.sln --configuration Release --no-restore` — passed for `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0`; 0 warnings, 0 errors
- focused regression before fix — failed 0/1 with expected `Left, Right, Bottom`, actual `None`
- focused regression after fix — passed 1/1, 0 skipped
- `WindowVisualStateTests` — passed 4/4, 0 skipped
- initial full net8 WinUI run — 1,017 passed, 1 unrelated pointer-state test failed, 0 skipped; the isolated test then passed 1/1
- complete net8 WinUI rerun — passed 1,018/1,018, 0 skipped
- complete theme/resource contract project — net8 passed 10/10 and net10 passed 13/13, 0 skipped

The WinUI test project targets net8 only; net10 product coverage comes from the successful full solution build.

Fixes #683