### PR TITLE
Honor the native minimize window style

### DIFF
--- a/ModernWpf/TitleBar/TitleBarControl.cs
+++ b/ModernWpf/TitleBar/TitleBarControl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
@@ -35,7 +36,10 @@ namespace ModernWpf.Controls.Primitives
 
         public TitleBarControl()
         {
-            CommandBindings.Add(new CommandBinding(SystemCommands.MinimizeWindowCommand, MinimizeWindow));
+            CommandBindings.Add(new CommandBinding(
+                SystemCommands.MinimizeWindowCommand,
+                MinimizeWindow,
+                CanMinimizeWindow));
             CommandBindings.Add(new CommandBinding(SystemCommands.MaximizeWindowCommand, MaximizeWindow));
             CommandBindings.Add(new CommandBinding(SystemCommands.RestoreWindowCommand, RestoreWindow));
             CommandBindings.Add(new CommandBinding(SystemCommands.CloseWindowCommand, CloseWindow));
@@ -475,10 +479,27 @@ namespace ModernWpf.Controls.Primitives
 
         private void MinimizeWindow(object sender, ExecutedRoutedEventArgs e)
         {
-            if (TemplatedParent is Window window)
+            if (TemplatedParent is Window window && CanMinimizeWindow(window))
             {
                 SystemCommands.MinimizeWindow(window);
             }
+        }
+
+        private void CanMinimizeWindow(object sender, CanExecuteRoutedEventArgs e)
+        {
+            e.CanExecute = TemplatedParent is Window window && CanMinimizeWindow(window);
+            e.Handled = true;
+        }
+
+        private static bool CanMinimizeWindow(Window window)
+        {
+            var handle = new WindowInteropHelper(window).Handle;
+            if (handle == IntPtr.Zero)
+            {
+                return window.ResizeMode != ResizeMode.NoResize;
+            }
+
+            return (GetWindowLong(handle, GwlStyle) & WsMinimizeBox) != 0;
         }
 
         private void MaximizeWindow(object sender, ExecutedRoutedEventArgs e)
@@ -528,6 +549,12 @@ namespace ModernWpf.Controls.Primitives
                 }
             }
         }
+
+        private const int GwlStyle = -16;
+        private const int WsMinimizeBox = 0x00020000;
+
+        [DllImport("user32.dll", EntryPoint = "GetWindowLongW")]
+        private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
 
         private class GoBackCommand : ICommand
         {

--- a/docs/window-wpf-fluent-source-audit.md
+++ b/docs/window-wpf-fluent-source-audit.md
@@ -46,6 +46,10 @@ ModernWpf now follows the compatible parts of that source shape:
   borders remain non-client edges. This follows the current Microsoft WPF
   Gallery shell policy and prevents full-client glass from exposing an
   unpainted compositor surface while a dark window is resized.
+- The custom minimize button honors the native `WS_MINIMIZEBOX` window-style
+  bit. Applications can remove that bit during `SourceInitialized` while
+  retaining `WindowHelper.UseModernWindowStyle`; the custom command is then
+  disabled and cannot minimize the window.
 
 ## WPF Substitutions
 
@@ -77,6 +81,9 @@ surface.
 - `WindowVisualStateTests` verifies the guarded Windows 11 resize-edge policy,
   the legacy and High Contrast fallbacks, the complete-glass requirement, and
   the High Contrast chrome-resource override.
+- `TitleBarApiTests` verifies that removing `WS_MINIMIZEBOX` during
+  `SourceInitialized` disables the ModernWpf minimize button and its routed
+  command.
 - `WindowVisualStateTests` statically guards `Styles\Window.xaml` against
   `ContentPresenterEx`, `MS.Internal`, `Fluent.Controls`, and `System.Runtime`
   source markers.

--- a/test/ModernWpf.WinUI.Tests/TitleBar/TitleBarApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/TitleBar/TitleBarApiTests.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Interop;
 using System.Windows.Media;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ModernWpf;
@@ -200,6 +202,61 @@ public class TitleBarApiTests
             Assert.AreEqual("Minimize", AutomationProperties.GetName(FindNamedDescendant<TitleBarButton>(titleBarControl, "MinimizeButton")));
             Assert.AreEqual("Maximize", AutomationProperties.GetName(FindNamedDescendant<TitleBarButton>(titleBarControl, "PART_MaximizeRestoreButton")));
             Assert.AreEqual("Close", AutomationProperties.GetName(FindNamedDescendant<TitleBarButton>(titleBarControl, "CloseButton")));
+        });
+    }
+
+    [TestMethod]
+    public void ModernWindowMinimizeButtonHonorsNativeWindowStyle()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var window = new Window
+            {
+                Width = 420,
+                Height = 180,
+                Left = -32000,
+                Top = -32000,
+                ShowInTaskbar = false,
+                WindowStartupLocation = WindowStartupLocation.Manual
+            };
+            WindowHelper.SetUseModernWindowStyle(window, true);
+
+            window.SourceInitialized += (_, _) =>
+            {
+                var handle = new WindowInteropHelper(window).Handle;
+                var style = GetWindowLong(handle, GwlStyle);
+                Assert.AreNotEqual(0, style);
+                SetWindowLong(handle, GwlStyle, style & ~WsMinimizeBox);
+            };
+
+            try
+            {
+                window.Show();
+                WpfTestHost.DoEvents();
+                window.UpdateLayout();
+                WpfTestHost.DoEvents();
+
+                var titleBarControl = VisualTreeTestHelper.EnumerateDescendants(window)
+                    .OfType<TitleBarControl>()
+                    .Single();
+                var minimizeButton = FindNamedDescendant<TitleBarButton>(
+                    titleBarControl,
+                    "MinimizeButton");
+
+                Assert.IsFalse(minimizeButton.IsEnabled);
+                Assert.IsFalse(SystemCommands.MinimizeWindowCommand.CanExecute(null, titleBarControl));
+
+                minimizeButton.DoClick();
+                WpfTestHost.DoEvents();
+                Assert.AreEqual(WindowState.Normal, window.WindowState);
+            }
+            finally
+            {
+                window.Close();
+                WpfTestHost.DoEvents();
+            }
         });
     }
 
@@ -494,4 +551,13 @@ public class TitleBarApiTests
         throw new InvalidOperationException(
             $"Could not find {typeof(T).Name} descendant named '{name}'. Descendants: {string.Join(", ", VisualTreeTestHelper.EnumerateDescendants(root).OfType<FrameworkElement>().Select(element => element.Name).Where(elementName => !string.IsNullOrEmpty(elementName)))}");
     }
+
+    private const int GwlStyle = -16;
+    private const int WsMinimizeBox = 0x00020000;
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongW", SetLastError = true)]
+    private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongW", SetLastError = true)]
+    private static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
 }


### PR DESCRIPTION
Fixes #565

## Summary
- make the ModernWpf title-bar minimize command honor the native `WS_MINIMIZEBOX` style
- keep command execution guarded as well as disabling the custom caption button
- add a WPF-hosted regression that removes the style during `SourceInitialized`, matching the reported integration path
- document the behavior in the window Fluent source audit

## Validation
- Red test before the product fix: `ModernWindowMinimizeButtonHonorsNativeWindowStyle` failed because the custom minimize button remained enabled (0/1 passed)
- `dotnet format ModernWpf.sln whitespace --no-restore --include ModernWpf\TitleBar\TitleBarControl.cs test\ModernWpf.WinUI.Tests\TitleBar\TitleBarApiTests.cs --verbosity minimal`
- Focused regression after the fix: 1 passed, 0 failed, 0 skipped
- `TitleBarApiTests`: 9 passed, 0 failed, 0 skipped
- `dotnet restore ModernWpf.sln`
- `dotnet build ModernWpf.sln --configuration Release --no-restore` — succeeded with 0 warnings and 0 errors
- `dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-build --no-restore --logger "console;verbosity=minimal"` — 1,019 passed, 0 failed, 0 skipped
- `git diff --check`