### PR TITLE
Keep disabled caption buttons inert

### DIFF
--- a/ModernWpf/TitleBar/TitleBarButton.cs
+++ b/ModernWpf/TitleBar/TitleBarButton.cs
@@ -304,7 +304,10 @@ namespace ModernWpf.Controls.Primitives
 
         internal void DoClick()
         {
-            OnClick();
+            if (IsEnabled)
+            {
+                OnClick();
+            }
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
@@ -361,7 +364,7 @@ namespace ModernWpf.Controls.Primitives
 
                         if (IsMousePositionWithin(lParam))
                         {
-                            OnClick();
+                            DoClick();
                         }
 
                         handled = true;

--- a/docs/window-wpf-fluent-source-audit.md
+++ b/docs/window-wpf-fluent-source-audit.md
@@ -50,6 +50,9 @@ ModernWpf now follows the compatible parts of that source shape:
   bit. Applications can remove that bit during `SourceInitialized` while
   retaining `WindowHelper.UseModernWindowStyle`; the custom command is then
   disabled and cannot minimize the window.
+- Disabled custom caption buttons remain inert when Windows 11 routes their
+  input through non-client messages. In particular, `ResizeMode=CanMinimize`
+  keeps the disabled maximize button from invoking its command.
 
 ## WPF Substitutions
 
@@ -83,7 +86,8 @@ surface.
   the High Contrast chrome-resource override.
 - `TitleBarApiTests` verifies that removing `WS_MINIMIZEBOX` during
   `SourceInitialized` disables the ModernWpf minimize button and its routed
-  command.
+  command, and that the non-client click bridge cannot invoke the disabled
+  maximize button when `ResizeMode=CanMinimize`.
 - `WindowVisualStateTests` statically guards `Styles\Window.xaml` against
   `ContentPresenterEx`, `MS.Internal`, `Fluent.Controls`, and `System.Runtime`
   source markers.

--- a/test/ModernWpf.WinUI.Tests/TitleBar/TitleBarApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/TitleBar/TitleBarApiTests.cs
@@ -261,6 +261,53 @@ public class TitleBarApiTests
     }
 
     [TestMethod]
+    public void CanMinimizeWindowCannotInvokeDisabledMaximizeButton()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var window = new Window
+            {
+                Width = 420,
+                Height = 180,
+                Left = -32000,
+                Top = -32000,
+                ShowInTaskbar = false,
+                ResizeMode = ResizeMode.CanMinimize,
+                WindowStartupLocation = WindowStartupLocation.Manual
+            };
+            WindowHelper.SetUseModernWindowStyle(window, true);
+
+            try
+            {
+                window.Show();
+                WpfTestHost.DoEvents();
+                window.UpdateLayout();
+                WpfTestHost.DoEvents();
+
+                var titleBarControl = VisualTreeTestHelper.EnumerateDescendants(window)
+                    .OfType<TitleBarControl>()
+                    .Single();
+                var maximizeButton = FindNamedDescendant<TitleBarButton>(
+                    titleBarControl,
+                    "PART_MaximizeRestoreButton");
+
+                Assert.IsFalse(maximizeButton.IsEnabled);
+
+                maximizeButton.DoClick();
+                WpfTestHost.DoEvents();
+                Assert.AreEqual(WindowState.Normal, window.WindowState);
+            }
+            finally
+            {
+                window.Close();
+                WpfTestHost.DoEvents();
+            }
+        });
+    }
+
+    [TestMethod]
     public void VerifyTitleBarControlAutomationPeerMatchesCurrentWinUI()
     {
         WpfTestHost.Run(() =>


### PR DESCRIPTION
Fixes #558

## Summary
- make the Windows 11 non-client caption click bridge respect `TitleBarButton.IsEnabled`
- route the non-client release path through the guarded internal click helper
- add a regression for `ResizeMode="CanMinimize"` proving the disabled maximize button cannot change `WindowState`
- record the behavior in the required window Fluent source audit

## Validation
- Before the product fix, `CanMinimizeWindowCannotInvokeDisabledMaximizeButton` failed: expected `WindowState.Normal`, actual `WindowState.Maximized` (0 passed, 1 failed, 0 skipped)
- Focused regression after the fix: 1 passed, 0 failed, 0 skipped
- `TitleBarApiTests`: 10 passed, 0 failed, 0 skipped
- `dotnet format ModernWpf.sln whitespace --no-restore --include ModernWpf\TitleBar\TitleBarButton.cs test\ModernWpf.WinUI.Tests\TitleBar\TitleBarApiTests.cs --verbosity minimal`
- `dotnet restore ModernWpf.sln`
- `dotnet build ModernWpf.sln --configuration Release --no-restore` — succeeded with 0 warnings and 0 errors
- `dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-build --no-restore --logger "console;verbosity=minimal"` — 1,020 passed, 0 failed, 0 skipped
- `git diff --check`