### PR TITLE
Ignore transient transparent system accents

### DIFF
--- a/ModernWpf/Helpers/ColorsHelper.cs
+++ b/ModernWpf/Helpers/ColorsHelper.cs
@@ -54,14 +54,58 @@ namespace ModernWpf
         public void FetchSystemAccentColors()
         {
             var uiSettings = new UISettings();
-            _colors[AccentKey] = uiSettings.GetColorValue(UIColorType.Accent).ToColor();
-            _colors[AccentDark1Key] = uiSettings.GetColorValue(UIColorType.AccentDark1).ToColor();
-            _colors[AccentDark2Key] = uiSettings.GetColorValue(UIColorType.AccentDark2).ToColor();
-            _colors[AccentDark3Key] = uiSettings.GetColorValue(UIColorType.AccentDark3).ToColor();
-            _colors[AccentLight1Key] = uiSettings.GetColorValue(UIColorType.AccentLight1).ToColor();
-            _colors[AccentLight2Key] = uiSettings.GetColorValue(UIColorType.AccentLight2).ToColor();
-            _colors[AccentLight3Key] = uiSettings.GetColorValue(UIColorType.AccentLight3).ToColor();
-            UpdateSystemAccentResources();
+            if (TryApplySystemAccentPalette(
+                _colors,
+                uiSettings.GetColorValue(UIColorType.Accent).ToColor(),
+                uiSettings.GetColorValue(UIColorType.AccentDark1).ToColor(),
+                uiSettings.GetColorValue(UIColorType.AccentDark2).ToColor(),
+                uiSettings.GetColorValue(UIColorType.AccentDark3).ToColor(),
+                uiSettings.GetColorValue(UIColorType.AccentLight1).ToColor(),
+                uiSettings.GetColorValue(UIColorType.AccentLight2).ToColor(),
+                uiSettings.GetColorValue(UIColorType.AccentLight3).ToColor()))
+            {
+                UpdateSystemAccentResources();
+            }
+            else if (!_colors.Contains(AccentKey))
+            {
+                SetAccent(DefaultAccentColor);
+            }
+        }
+
+        internal static bool TryApplySystemAccentPalette(
+            ResourceDictionary colors,
+            Color accent,
+            Color accentDark1,
+            Color accentDark2,
+            Color accentDark3,
+            Color accentLight1,
+            Color accentLight2,
+            Color accentLight3)
+        {
+            if (!IsUsableSystemColor(accent) ||
+                !IsUsableSystemColor(accentDark1) ||
+                !IsUsableSystemColor(accentDark2) ||
+                !IsUsableSystemColor(accentDark3) ||
+                !IsUsableSystemColor(accentLight1) ||
+                !IsUsableSystemColor(accentLight2) ||
+                !IsUsableSystemColor(accentLight3))
+            {
+                return false;
+            }
+
+            colors[AccentKey] = accent;
+            colors[AccentDark1Key] = accentDark1;
+            colors[AccentDark2Key] = accentDark2;
+            colors[AccentDark3Key] = accentDark3;
+            colors[AccentLight1Key] = accentLight1;
+            colors[AccentLight2Key] = accentLight2;
+            colors[AccentLight3Key] = accentLight3;
+            return true;
+        }
+
+        private static bool IsUsableSystemColor(Color color)
+        {
+            return color.A != 0;
         }
 
         public void SetAccent(Color accent)
@@ -157,7 +201,10 @@ namespace ModernWpf
             }
 
             _systemBackground = _uiSettings.GetColorValue(UIColorType.Background).ToColor();
-            _systemAccent = _uiSettings.GetColorValue(UIColorType.Accent).ToColor();
+            var systemAccent = _uiSettings.GetColorValue(UIColorType.Accent).ToColor();
+            _systemAccent = IsUsableSystemColor(systemAccent)
+                ? systemAccent
+                : DefaultAccentColor;
             UpdateSystemAppTheme();
         }
 
@@ -188,7 +235,7 @@ namespace ModernWpf
             }
 
             var accent = _uiSettings.GetColorValue(UIColorType.Accent).ToColor();
-            if (_systemAccent != accent)
+            if (IsUsableSystemColor(accent) && _systemAccent != accent)
             {
                 _systemAccent = accent;
                 SystemAccentColorChanged?.Invoke(null, EventArgs.Empty);

--- a/docs/modernwpf-core-resource-source-coverage.md
+++ b/docs/modernwpf-core-resource-source-coverage.md
@@ -39,3 +39,20 @@ shell resources retained as documented WPF substitutions.
 | `Themes/TextContextMenu.xaml` | ModernWpf compatibility resource | `docs\textbox-passwordbox-wpf-fluent-source-audit.md`, `docs\richtextbox-wpf-fluent-source-audit.md` |
 | `TitleBar/TitleBarButton.xaml` | Official WPF Fluent shell substitution | `docs\window-wpf-fluent-source-audit.md`, `docs\winui-visualstate-setters-audit.md` |
 | `TitleBar/TitleBarControl.xaml` | Official WPF Fluent shell substitution | `docs\window-wpf-fluent-source-audit.md`, `docs\winui-visualstate-setters-audit.md` |
+
+## Dynamic System Colors
+
+`DynamicColorExtension` tags mutable `SolidColorBrush` resources with their
+source color key. `ColorsHelper` updates those brush instances when the Windows
+accent palette changes so existing `DynamicResource` consumers keep their
+resource identity.
+
+Windows color-change notifications can produce a transient fully transparent
+palette while the session is locking or resuming. ModernWpf rejects any such
+incomplete system palette and retains the last valid colors; if the first
+system read is invalid, it uses `DefaultAccentColor` until Windows supplies a
+valid snapshot. Explicit application `ThemeManager.AccentColor` values still
+flow through the separate `SetAccent` path.
+
+`ColorsHelperTests.TransparentSystemAccentSnapshotDoesNotReplaceDynamicColorBrush`
+guards the palette and brush behavior.

--- a/test/ModernWpf.Theme.Tests/ColorsHelperTests.cs
+++ b/test/ModernWpf.Theme.Tests/ColorsHelperTests.cs
@@ -1,0 +1,62 @@
+using System.Windows;
+using System.Windows.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ModernWpf.Theme.Tests;
+
+[TestClass]
+public class ColorsHelperTests
+{
+    [TestMethod]
+    public void TransparentSystemAccentSnapshotDoesNotReplaceDynamicColorBrush()
+    {
+        var palette = new ResourceDictionary();
+        var accent = Color.FromRgb(0x10, 0x70, 0xC0);
+        var accentDark1 = Color.FromRgb(0x0E, 0x60, 0xA0);
+        var accentDark2 = Color.FromRgb(0x0C, 0x50, 0x80);
+        var accentDark3 = Color.FromRgb(0x0A, 0x40, 0x60);
+        var accentLight1 = Color.FromRgb(0x38, 0x88, 0xC8);
+        var accentLight2 = Color.FromRgb(0x60, 0xA0, 0xD0);
+        var accentLight3 = Color.FromRgb(0x88, 0xB8, 0xD8);
+
+        Assert.IsTrue(ColorsHelper.TryApplySystemAccentPalette(
+            palette,
+            accent,
+            accentDark1,
+            accentDark2,
+            accentDark3,
+            accentLight1,
+            accentLight2,
+            accentLight3));
+
+        var accentBrush = new SolidColorBrush();
+        ThemeResourceHelper.SetColorKey(accentBrush, "SystemAccentColor");
+        var themeDictionary = new ResourceDictionary
+        {
+            ["SystemControlForegroundAccentBrush"] = accentBrush
+        };
+
+        ColorsHelper.UpdateBrushes(themeDictionary, palette);
+        Assert.AreEqual(accent, accentBrush.Color);
+
+        Assert.IsFalse(ColorsHelper.TryApplySystemAccentPalette(
+            palette,
+            Colors.Transparent,
+            Colors.Transparent,
+            Colors.Transparent,
+            Colors.Transparent,
+            Colors.Transparent,
+            Colors.Transparent,
+            Colors.Transparent));
+
+        ColorsHelper.UpdateBrushes(themeDictionary, palette);
+        Assert.AreEqual(accent, accentBrush.Color);
+        Assert.AreEqual(accent, palette["SystemAccentColor"]);
+        Assert.AreEqual(accentDark1, palette["SystemAccentColorDark1"]);
+        Assert.AreEqual(accentDark2, palette["SystemAccentColorDark2"]);
+        Assert.AreEqual(accentDark3, palette["SystemAccentColorDark3"]);
+        Assert.AreEqual(accentLight1, palette["SystemAccentColorLight1"]);
+        Assert.AreEqual(accentLight2, palette["SystemAccentColorLight2"]);
+        Assert.AreEqual(accentLight3, palette["SystemAccentColorLight3"]);
+    }
+}


### PR DESCRIPTION
Fixes #549

## Summary
- validate the full Windows accent palette before replacing DynamicColor source values
- retain the last valid palette when lock/resume notifications yield a transient fully transparent snapshot
- fall back to the default accent only when the first system palette read is invalid
- keep explicit application `ThemeManager.AccentColor` handling on its existing separate path
- add an atomic palette/brush regression and document the behavior

## Validation
- Before the guard, `TransparentSystemAccentSnapshotDoesNotReplaceDynamicColorBrush` failed because the transparent palette was accepted (0 passed, 1 failed, 0 skipped)
- Focused regression after the fix: net8 1 passed; net10 1 passed; 0 failed/skipped
- `dotnet format ModernWpf.sln whitespace --no-restore --include ModernWpf\Helpers\ColorsHelper.cs test\ModernWpf.Theme.Tests\ColorsHelperTests.cs --verbosity minimal`
- `dotnet restore ModernWpf.sln`
- `dotnet build ModernWpf.sln --configuration Release --no-restore` — succeeded with 0 warnings and 0 errors
- Complete Theme tests, net8: 11 passed, 0 failed, 0 skipped
- Complete Theme tests, net10: 14 passed, 0 failed, 0 skipped
- Complete WinUI tests, net8: 1,020 passed, 0 failed, 0 skipped
- `git diff --check`