### PR TITLE
Honor captionless window style

### DIFF
--- a/ModernWpf/Styles/Window.xaml
+++ b/ModernWpf/Styles/Window.xaml
@@ -75,6 +75,7 @@
                                 </Grid.RowDefinitions>
 
                                 <primitives:TitleBarControl
+                                    x:Name="TitleBarControl"
                                     Icon="{TemplateBinding Icon}"
                                     Title="{TemplateBinding Title}"
                                     IsActive="{TemplateBinding IsActive}"
@@ -133,6 +134,9 @@
                             <Setter TargetName="ContentGrid" Property="Margin" Value="0" />
                             <Setter TargetName="HighContrastBorder" Property="Visibility" Value="Collapsed" />
                         </Trigger>
+                        <Trigger Property="WindowStyle" Value="None">
+                            <Setter TargetName="TitleBarControl" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
                         <Trigger Property="local:TitleBar.ExtendViewIntoTitleBar" Value="True">
                             <Setter TargetName="AdornerDecorator" Property="Grid.Row" Value="0" />
                             <Setter TargetName="AdornerDecorator" Property="Grid.RowSpan" Value="2" />
@@ -154,6 +158,9 @@
             </DataTrigger>
             <Trigger Property="WindowChrome.WindowChrome" Value="{x:Null}">
                 <Setter Property="primitives:WindowHelper.FixMaximizedWindow" Value="False" />
+            </Trigger>
+            <Trigger Property="WindowStyle" Value="None">
+                <Setter Property="WindowChrome.WindowChrome" Value="{x:Null}" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/docs/window-wpf-fluent-source-audit.md
+++ b/docs/window-wpf-fluent-source-audit.md
@@ -53,6 +53,8 @@ ModernWpf now follows the compatible parts of that source shape:
 - Disabled custom caption buttons remain inert when Windows 11 routes their
   input through non-client messages. In particular, `ResizeMode=CanMinimize`
   keeps the disabled maximize button from invoking its command.
+- `WindowStyle=None` suppresses the ModernWpf title bar, detaches the custom
+  `WindowChrome`, and lets content fill the captionless client area.
 
 ## WPF Substitutions
 
@@ -88,6 +90,9 @@ surface.
   `SourceInitialized` disables the ModernWpf minimize button and its routed
   command, and that the non-client click bridge cannot invoke the disabled
   maximize button when `ResizeMode=CanMinimize`.
+- `WindowVisualStateTests` verifies that `WindowStyle=None` collapses the
+  ModernWpf title bar, removes custom chrome/maximized-window compensation, and
+  places content at the top of the client area.
 - `WindowVisualStateTests` statically guards `Styles\Window.xaml` against
   `ContentPresenterEx`, `MS.Internal`, `Fluent.Controls`, and `System.Runtime`
   source markers.

--- a/test/ModernWpf.WinUI.Tests/CommonStyles/WindowVisualStateTests.cs
+++ b/test/ModernWpf.WinUI.Tests/CommonStyles/WindowVisualStateTests.cs
@@ -124,6 +124,50 @@ public class WindowVisualStateTests
     }
 
     [TestMethod]
+    public void WindowStyleNoneRemovesModernTitleBarAndChrome()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var content = new Border();
+            var window = new Window
+            {
+                Width = 320,
+                Height = 240,
+                Left = -32000,
+                Top = -32000,
+                BorderThickness = new Thickness(0),
+                Content = content,
+                ShowInTaskbar = false,
+                WindowStartupLocation = WindowStartupLocation.Manual,
+                WindowStyle = WindowStyle.None
+            };
+            WindowHelper.SetUseModernWindowStyle(window, true);
+
+            try
+            {
+                window.Show();
+                WpfTestHost.DoEvents();
+                window.UpdateLayout();
+                WpfTestHost.DoEvents();
+
+                var titleBar = VisualTreeTestHelper.FindDescendant<TitleBarControl>(window);
+                Assert.IsNotNull(titleBar);
+                Assert.AreEqual(Visibility.Collapsed, titleBar!.Visibility);
+                Assert.IsNull(WindowChrome.GetWindowChrome(window));
+                Assert.IsFalse(WindowHelper.GetFixMaximizedWindow(window));
+                Assert.AreEqual(new Point(0, 0), content.TranslatePoint(new Point(), window));
+            }
+            finally
+            {
+                window.Close();
+                WpfTestHost.DoEvents();
+            }
+        });
+    }
+
+    [TestMethod]
     public void WindowStyleDocumentsOfficialWpfFluentSubstitutions()
     {
         var repoRoot = FindRepoRoot();


### PR DESCRIPTION
Fixes #557

## Summary
- collapse the ModernWpf title bar when WPF `WindowStyle=None`
- detach the custom `WindowChrome`, allowing existing null-chrome handling to disable maximized-window compensation
- preserve a full-height captionless content area
- add a hosted WPF regression and update the required window Fluent source audit

## Validation
- Before the fix, `WindowStyleNoneRemovesModernTitleBarAndChrome` failed because the title bar remained `Visible` (0 passed, 1 failed, 0 skipped)
- Focused regression after the fix: 1 passed, 0 failed, 0 skipped
- `WindowVisualStateTests`: 5 passed, 0 failed, 0 skipped
- `dotnet format ModernWpf.sln whitespace --no-restore --include test\ModernWpf.WinUI.Tests\CommonStyles\WindowVisualStateTests.cs --verbosity minimal`
- `dotnet restore ModernWpf.sln`
- `dotnet build ModernWpf.sln --configuration Release --no-restore` — succeeded with 0 warnings and 0 errors
- Complete WinUI tests, net8: 1,021 passed, 0 failed, 0 skipped
- `git diff --check`