### PR TITLE
Fix ContentDialog lifecycle when owner is minimized

### DIFF
--- a/ModernWpf.Controls/ContentDialog/ContentDialog.cs
+++ b/ModernWpf.Controls/ContentDialog/ContentDialog.cs
@@ -515,9 +515,29 @@ namespace ModernWpf.Controls
             }
             else
             {
+                if (IsShowing && IsOwnerChainMinimized(m_openDialogOwner))
+                {
+                    return;
+                }
+
                 m_closeTimer.Stop();
                 OnClosed();
             }
+        }
+
+        private static bool IsOwnerChainMinimized(Window window)
+        {
+            while (window != null)
+            {
+                if (window.WindowState == WindowState.Minimized)
+                {
+                    return true;
+                }
+
+                window = window.Owner;
+            }
+
+            return false;
         }
 
         private void OnLayoutRootKeyDown(object sender, KeyEventArgs e)

--- a/test/ModernWpf.WinUI.Tests/ContentDialog/ContentDialogApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/ContentDialog/ContentDialogApiTests.cs
@@ -476,6 +476,70 @@ public class ContentDialogApiTests
     }
 
     [TestMethod]
+    public void MinimizingParentWindowKeepsOwnedWindowDialogOpen()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            using var mainHost = new TestWindowHost(new Grid(), width: 640, height: 480);
+            var childWindow = new Window
+            {
+                Owner = mainHost.Window,
+                Width = 480,
+                Height = 360,
+                Left = -32000,
+                Top = -32000,
+                ShowInTaskbar = false,
+                WindowStartupLocation = WindowStartupLocation.Manual,
+                Content = new Grid()
+            };
+
+            try
+            {
+                childWindow.Show();
+                WpfTestHost.DoEvents();
+
+                var dialog = CreateDialog();
+                dialog.Owner = childWindow;
+                var closedCount = 0;
+                dialog.Closed += (_, _) => closedCount++;
+
+                var showTask = dialog.ShowAsync();
+                WpfTestHost.DoEvents();
+                Assert.IsFalse(showTask.IsCompleted);
+
+                mainHost.Window.WindowState = WindowState.Minimized;
+                WpfTestHost.DoEvents();
+                mainHost.Window.WindowState = WindowState.Normal;
+                WpfTestHost.DoEvents();
+
+                Assert.IsFalse(
+                    showTask.IsCompleted,
+                    "Temporarily hiding an owned window must not close its ContentDialog.");
+                Assert.AreEqual(0, closedCount);
+
+                dialog.Hide();
+                Assert.AreEqual(ContentDialogResult.None, WaitForResult(showTask));
+
+                var reopenTask = dialog.ShowAsync();
+                WpfTestHost.DoEvents();
+                Assert.IsFalse(reopenTask.IsCompleted);
+
+                dialog.Hide();
+                Assert.AreEqual(ContentDialogResult.None, WaitForResult(reopenTask));
+                Assert.AreEqual(2, closedCount);
+            }
+            finally
+            {
+                childWindow.Content = null;
+                childWindow.Close();
+                WpfTestHost.DoEvents();
+            }
+        });
+    }
+
+    [TestMethod]
     public void DefaultButtonVisualStatesApplyAccentStyle()
     {
         WpfTestHost.Run(() =>


### PR DESCRIPTION
## Summary

- keep a ContentDialog open when its owner window, or an owning parent window, is minimized
- avoid running close cleanup for the temporary visibility transition caused by minimizing an owner chain
- cover the reported two-window minimize/restore sequence and verify the same dialog can still close and reopen normally

Closes #506

## Validation

- Red regression: `dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-restore --filter "FullyQualifiedName~MinimizingParentWindowKeepsOwnedWindowDialogOpen"` — 0 passed, 1 failed before the fix
- Focused regression after fix — 1 passed, 0 failed, 0 skipped
- `dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-build --no-restore --filter "FullyQualifiedName~ContentDialog"` — 20 passed, 0 failed, 0 skipped
- `dotnet restore .\ModernWpf.sln` — succeeded
- `dotnet build .\ModernWpf.sln --configuration Release --no-restore` — succeeded, 0 warnings, 0 errors
- `dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-build --no-restore` — 1,022 passed, 0 failed, 0 skipped