### PR TITLE
Update gradient brushes when accent changes

### DIFF
--- a/ModernWpf/Helpers/ColorsHelper.cs
+++ b/ModernWpf/Helpers/ColorsHelper.cs
@@ -180,12 +180,30 @@ namespace ModernWpf
             {
                 if (entry.Value is SolidColorBrush brush && !brush.IsFrozen)
                 {
-                    object colorKey = ThemeResourceHelper.GetColorKey(brush);
-                    if (colorKey != null && colors.Contains(colorKey))
+                    UpdateColor(brush, SolidColorBrush.ColorProperty, colors);
+                }
+                else if (entry.Value is GradientBrush gradientBrush && !gradientBrush.IsFrozen)
+                {
+                    foreach (GradientStop gradientStop in gradientBrush.GradientStops)
                     {
-                        brush.SetCurrentValue(SolidColorBrush.ColorProperty, (Color)colors[colorKey]);
+                        if (!gradientStop.IsFrozen)
+                        {
+                            UpdateColor(gradientStop, GradientStop.ColorProperty, colors);
+                        }
                     }
                 }
+            }
+        }
+
+        private static void UpdateColor(
+            DependencyObject target,
+            DependencyProperty colorProperty,
+            ResourceDictionary colors)
+        {
+            object colorKey = ThemeResourceHelper.GetColorKey(target);
+            if (colorKey != null && colors.Contains(colorKey))
+            {
+                target.SetCurrentValue(colorProperty, (Color)colors[colorKey]);
             }
         }
 

--- a/ModernWpf/Helpers/ThemeResourceHelper.cs
+++ b/ModernWpf/Helpers/ThemeResourceHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System.Windows;
-using System.Windows.Media;
 
 namespace ModernWpf
 {
@@ -11,12 +10,12 @@ namespace ModernWpf
                 typeof(object),
                 typeof(ThemeResourceHelper));
 
-        internal static object GetColorKey(SolidColorBrush element)
+        internal static object GetColorKey(DependencyObject element)
         {
             return element.GetValue(ColorKeyProperty);
         }
 
-        internal static void SetColorKey(SolidColorBrush element, object value)
+        internal static void SetColorKey(DependencyObject element, object value)
         {
             element.SetValue(ColorKeyProperty, value);
         }

--- a/ModernWpf/Markup/DynamicColorExtension.cs
+++ b/ModernWpf/Markup/DynamicColorExtension.cs
@@ -25,9 +25,10 @@ namespace ModernWpf.Markup
 
             if (serviceProvider?.GetService(typeof(IProvideValueTarget)) is IProvideValueTarget provideValueTarget)
             {
-                if (provideValueTarget.TargetObject is SolidColorBrush solidColorBrush)
+                if (provideValueTarget.TargetObject is DependencyObject targetObject &&
+                    (targetObject is SolidColorBrush || targetObject is GradientStop))
                 {
-                    ThemeResourceHelper.SetColorKey(solidColorBrush, ResourceKey);
+                    ThemeResourceHelper.SetColorKey(targetObject, ResourceKey);
                 }
             }
 

--- a/ModernWpf/ThemeResources/Dark.xaml
+++ b/ModernWpf/ThemeResources/Dark.xaml
@@ -1960,7 +1960,7 @@
             <ScaleTransform ScaleY="-1" CenterY="0.5"/>
         </LinearGradientBrush.RelativeTransform>
         <LinearGradientBrush.GradientStops>
-            <GradientStop Offset="1.0" Color="{DynamicResource SystemAccentColorLight2}"/>
+            <GradientStop Offset="1.0" Color="{m:DynamicColor SystemAccentColorLight2}"/>
             <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}"/>
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>

--- a/ModernWpf/ThemeResources/HighContrast.xaml
+++ b/ModernWpf/ThemeResources/HighContrast.xaml
@@ -1930,7 +1930,7 @@
             <ScaleTransform ScaleY="-1" CenterY="0.5"/>
         </LinearGradientBrush.RelativeTransform>
         <LinearGradientBrush.GradientStops>
-            <GradientStop Offset="1.0" Color="{DynamicResource SystemAccentColorLight2}"/>
+            <GradientStop Offset="1.0" Color="{m:DynamicColor SystemAccentColorLight2}"/>
             <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}"/>
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>

--- a/ModernWpf/ThemeResources/Light.xaml
+++ b/ModernWpf/ThemeResources/Light.xaml
@@ -1962,7 +1962,7 @@
             <ScaleTransform ScaleY="-1" CenterY="0.5"/>
         </LinearGradientBrush.RelativeTransform>
         <LinearGradientBrush.GradientStops>
-            <GradientStop Offset="1.0" Color="{DynamicResource SystemAccentColorDark1}"/>
+            <GradientStop Offset="1.0" Color="{m:DynamicColor SystemAccentColorDark1}"/>
             <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}"/>
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>

--- a/docs/textbox-passwordbox-wpf-fluent-source-audit.md
+++ b/docs/textbox-passwordbox-wpf-fluent-source-audit.md
@@ -53,6 +53,10 @@ the stock WPF `TextBox`, `TextBoxBase`, and `PasswordBox` templates.
   property, so the clear button uses the existing
   `TextBoxHelper.IsDeleteButton` click hook while retaining the official
   template shape and trigger matrix.
+- ModernWpf tags the accent `GradientStop` in
+  `TextControlElevationBorderFocusedBrush` with `DynamicColor`. This preserves
+  the official focused-border gradient while allowing runtime accent changes
+  to update the existing brush in Light, Dark, and High Contrast themes.
 - `DataGridTextBoxStyle` is retained as a ModernWpf support style because the
   callers that reference it directly; the stock DataGrid template no longer
   wires it through `DataGridHelper`.
@@ -71,3 +75,6 @@ the stock WPF `TextBox`, `TextBoxBase`, and `PasswordBox` templates.
   `ModernWpf\Styles\TextBox.xaml` and
   `ModernWpf\Styles\PasswordBox.xaml` as official WPF Fluent stock templates
   that should not use `VisualStateEx`.
+- `test\ModernWpf.Theme.Tests\ColorsHelperTests.cs` verifies that runtime
+  accent updates reach the focused-border gradient in Light, Dark, and High
+  Contrast themes.

--- a/test/ModernWpf.Theme.Tests/ColorsHelperTests.cs
+++ b/test/ModernWpf.Theme.Tests/ColorsHelperTests.cs
@@ -1,12 +1,44 @@
+using System;
 using System.Windows;
 using System.Windows.Media;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModernWpf.WinUI.TestInfra;
 
 namespace ModernWpf.Theme.Tests;
 
 [TestClass]
 public class ColorsHelperTests
 {
+    [TestMethod]
+    [DataRow("Light", "SystemAccentColorDark1")]
+    [DataRow("Dark", "SystemAccentColorLight2")]
+    [DataRow("HighContrast", "SystemAccentColorLight2")]
+    public void FocusedTextControlBorderTracksDynamicAccentColor(
+        string themeName,
+        string accentColorKey)
+    {
+        WpfTestHost.Run(() =>
+        {
+            var themeDictionary = new ResourceDictionary
+            {
+                Source = new Uri(
+                    $"pack://application:,,,/ModernWpf;component/ThemeResources/{themeName}.xaml",
+                    UriKind.Absolute)
+            };
+            var focusedBorder =
+                (LinearGradientBrush)themeDictionary["TextControlElevationBorderFocusedBrush"];
+            var expectedAccent = Color.FromRgb(0xC2, 0x39, 0xB3);
+            var palette = new ResourceDictionary
+            {
+                [accentColorKey] = expectedAccent
+            };
+
+            ColorsHelper.UpdateBrushes(themeDictionary, palette);
+
+            Assert.AreEqual(expectedAccent, focusedBorder.GradientStops[0].Color);
+        });
+    }
+
     [TestMethod]
     public void TransparentSystemAccentSnapshotDoesNotReplaceDynamicColorBrush()
     {


### PR DESCRIPTION
## Summary

- retain dynamic color metadata on accent-backed gradient stops
- update mutable gradient stops alongside solid brushes when the accent palette changes
- apply the dynamic accent marker to the focused TextBox border in Light, Dark, and High Contrast resources
- add a three-theme regression and document the ModernWpf adaptation in the TextBox/PasswordBox source audit

## Validation

- regression before fix: `FocusedTextControlBorderTracksDynamicAccentColor` — 0 passed, 3 failed
- regression after fix: `FocusedTextControlBorderTracksDynamicAccentColor` — 3 passed, 0 failed, 0 skipped
- complete Theme tests (`net8.0-windows7.0`) — 14 passed, 0 failed, 0 skipped
- complete Theme tests (`net10.0-windows7.0`) — 17 passed, 0 failed, 0 skipped
- focused `TextBoxPasswordBoxVisualStateTests` + `TemplateParityTests` — 31 passed, 0 failed, 0 skipped
- `dotnet restore ModernWpf.sln` — succeeded
- `dotnet build ModernWpf.sln --configuration Release --no-restore --maxcpucount:1` — succeeded with 0 warnings and 0 errors
- `git diff --check` — clean

Closes #491