### PR TITLE
Fix the PowerShell sample runner

### DIFF
--- a/samples/PowerShellSample/PowerShellSample.csproj
+++ b/samples/PowerShellSample/PowerShellSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net462;net8.0-windows7.0;net10.0-windows7.0</TargetFrameworks>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 

--- a/samples/PowerShellSample/README.md
+++ b/samples/PowerShellSample/README.md
@@ -1,0 +1,56 @@
+# PowerShell sample
+
+This sample loads ModernWpf from a PowerShell-hosted WPF window. Run
+`.\run.ps1` from Windows PowerShell 5.1 or from PowerShell 7 on .NET 8 or
+later. The script builds the sample first and selects the compatible supported
+target automatically:
+
+- Windows PowerShell uses `net462`.
+- PowerShell 7 on .NET 8 or 9 uses `net8.0-windows7.0`.
+- PowerShell 7 on .NET 10 or later uses `net10.0-windows7.0`.
+
+The WPF thread must use the STA apartment state. If the current host is not
+STA, restart it with the `-STA` option.
+
+## Runner options
+
+```powershell
+.\run.ps1 -Configuration Release
+.\run.ps1 -NoBuild
+.\run.ps1 -ValidateOnly
+```
+
+`-NoBuild` reuses the selected configuration's existing output.
+`-ValidateOnly` loads the assemblies and parses the window without displaying
+it, which is useful for automated checks.
+
+## Finding named controls
+
+For one control, give it an `x:Name` in XAML and call `FindName`:
+
+```xaml
+<ui:NavigationView x:Name="Navigation" />
+```
+
+```powershell
+$navigation = $window.FindName('Navigation')
+```
+
+To collect every `x:Name`, query the attribute in the XAML namespace and read
+the attribute value. `XmlElement.Name` is the element name (for example,
+`NavigationView`), not the value of `x:Name`.
+
+```powershell
+[xml] $document = Get-Content -LiteralPath '.\MainWindow.xaml' -Raw
+$xamlNamespace = 'http://schemas.microsoft.com/winfx/2006/xaml'
+$namespaceManager = [System.Xml.XmlNamespaceManager]::new($document.NameTable)
+$namespaceManager.AddNamespace('x', $xamlNamespace)
+
+$document.SelectNodes('//*[@x:Name]', $namespaceManager) | ForEach-Object {
+    $name = $_.GetAttribute('Name', $xamlNamespace)
+    Set-Variable -Scope Script -Name $name -Value $window.FindName($name)
+}
+```
+
+Keep all WPF control access on the window's dispatcher. Background runspaces
+must marshal UI work through `$window.Dispatcher`.

--- a/samples/PowerShellSample/run.ps1
+++ b/samples/PowerShellSample/run.ps1
@@ -1,11 +1,65 @@
-﻿Set-Location $PSScriptRoot
-[IO.Directory]::SetCurrentDirectory($PSScriptRoot)
+[CmdletBinding()]
+param(
+    [ValidateSet('Debug', 'Release')]
+    [string] $Configuration = 'Debug',
+
+    [switch] $NoBuild,
+
+    [switch] $ValidateOnly
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ([Threading.Thread]::CurrentThread.ApartmentState -ne 'STA') {
+    throw 'The PowerShell sample requires an STA thread. Start PowerShell with the -STA option.'
+}
+
+if ($PSVersionTable.PSEdition -eq 'Desktop') {
+    $targetFramework = 'net462'
+}
+elseif ([Environment]::Version.Major -ge 10) {
+    $targetFramework = 'net10.0-windows7.0'
+}
+elseif ([Environment]::Version.Major -ge 8) {
+    $targetFramework = 'net8.0-windows7.0'
+}
+else {
+    throw 'PowerShell Core must run on .NET 8 or later.'
+}
+
+$projectPath = Join-Path $PSScriptRoot 'PowerShellSample.csproj'
+$outputDirectory = Join-Path $PSScriptRoot "bin\$Configuration\$targetFramework"
+
+if (-not $NoBuild) {
+    & dotnet build $projectPath --configuration $Configuration --framework $targetFramework --nologo
+    if ($LASTEXITCODE -ne 0) {
+        throw "Building PowerShellSample for $targetFramework failed with exit code $LASTEXITCODE."
+    }
+}
 
 Add-Type -AssemblyName PresentationFramework
-[Reflection.Assembly]::LoadFrom('bin\Debug\net45\System.ValueTuple.dll') | Out-Null
-[Reflection.Assembly]::LoadFrom('bin\Debug\net45\ModernWpf.dll') | Out-Null
-[Reflection.Assembly]::LoadFrom('bin\Debug\net45\ModernWpf.Controls.dll') | Out-Null
 
-$xaml = Get-Content "MainWindow.xaml" -Raw
+$valueTuplePath = Join-Path $outputDirectory 'System.ValueTuple.dll'
+if (Test-Path -LiteralPath $valueTuplePath) {
+    [Reflection.Assembly]::LoadFrom($valueTuplePath) | Out-Null
+}
+
+foreach ($assemblyName in @('ModernWpf.dll', 'ModernWpf.Controls.dll')) {
+    $assemblyPath = Join-Path $outputDirectory $assemblyName
+    if (-not (Test-Path -LiteralPath $assemblyPath)) {
+        throw "Required assembly not found: $assemblyPath. Run without -NoBuild first."
+    }
+
+    [Reflection.Assembly]::LoadFrom($assemblyPath) | Out-Null
+}
+
+$xamlPath = Join-Path $PSScriptRoot 'MainWindow.xaml'
+$xaml = Get-Content -LiteralPath $xamlPath -Raw
 $window = [Windows.Markup.XamlReader]::Parse($xaml)
-$window.ShowDialog()
+
+if ($ValidateOnly) {
+    Write-Output "PowerShellSample validation passed ($targetFramework): $($window.GetType().FullName)"
+    return
+}
+
+$window.ShowDialog() | Out-Null

--- a/test/ModernWpf.Tools.Tests/PowerShellSampleTests.cs
+++ b/test/ModernWpf.Tools.Tests/PowerShellSampleTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ModernWpf.Tools.Tests;
+
+[TestClass]
+public class PowerShellSampleTests
+{
+    [TestMethod]
+    public void RunnerBuildsSupportedTargetsAndProvidesNonInteractiveValidation()
+    {
+        var repoRoot = FindRepoRoot();
+        var sampleDirectory = Path.Combine(repoRoot, "samples", "PowerShellSample");
+        var project = File.ReadAllText(Path.Combine(sampleDirectory, "PowerShellSample.csproj"));
+        var runner = File.ReadAllText(Path.Combine(sampleDirectory, "run.ps1"));
+        var readme = File.ReadAllText(Path.Combine(sampleDirectory, "README.md"));
+
+        StringAssert.Contains(project, "<TargetFrameworks>net462;net8.0-windows7.0;net10.0-windows7.0</TargetFrameworks>");
+
+        StringAssert.Contains(runner, "$targetFramework = 'net462'");
+        StringAssert.Contains(runner, "$targetFramework = 'net8.0-windows7.0'");
+        StringAssert.Contains(runner, "$targetFramework = 'net10.0-windows7.0'");
+        StringAssert.Contains(runner, "& dotnet build $projectPath");
+        StringAssert.Contains(runner, "@('ModernWpf.dll', 'ModernWpf.Controls.dll')");
+        StringAssert.Contains(runner, "Join-Path $outputDirectory $assemblyName");
+        StringAssert.Contains(runner, "if ($ValidateOnly)");
+        StringAssert.Contains(runner, "[Windows.Markup.XamlReader]::Parse($xaml)");
+        Assert.IsFalse(runner.Contains(@"bin\Debug\net45", StringComparison.Ordinal));
+
+        StringAssert.Contains(readme, @".\run.ps1 -ValidateOnly");
+        StringAssert.Contains(readme, "$window.FindName('Navigation')");
+        StringAssert.Contains(readme, "GetAttribute('Name', $xamlNamespace)");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "ModernWpf.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        Assert.Fail("Could not locate ModernWpf.sln from the test output directory.");
+        return string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary

- replace the retired hard-coded `bin\Debug\net45` assembly paths with automatic selection of the supported target for the current PowerShell host
- build the sample on first run, use absolute paths, fail fast, and add `-Configuration`, `-NoBuild`, and `-ValidateOnly` runner options
- support Windows PowerShell through `net462` and PowerShell 7 through the active `net8.0-windows7.0` / `net10.0-windows7.0` targets
- document STA/runspace requirements and the correct namespace-aware way to collect `x:Name` controls
- add a regression test that locks the supported target matrix, build/load flow, validation path, and removal of the retired `net45` path

Fixes #447

## Reproduction

Before this change, running `samples\PowerShellSample\run.ps1` on current `master` produced three `FileNotFoundException` errors for `bin\Debug\net45`, then an unknown `TitleBar.ExtendViewIntoTitleBar` XAML member error, followed by a null-window error. The project now targets `net462`, so the script and project had drifted apart.

## Validation

- `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\samples\PowerShellSample\run.ps1 -ValidateOnly`
  - automatic `net462` build: 0 warnings, 0 errors
  - parsed `System.Windows.Window` successfully
- `pwsh.exe -NoLogo -NoProfile -File .\samples\PowerShellSample\run.ps1 -ValidateOnly`
  - automatic `net10.0-windows7.0` build: 0 warnings, 0 errors
  - parsed `System.Windows.Window` successfully
- focused `PowerShellSampleTests`: 1 passed, 0 failed, 0 skipped
- complete `ModernWpf.Tools.Tests`: 7 passed, 0 failed, 0 skipped
- `dotnet restore .\ModernWpf.sln`: succeeded
- `dotnet build .\ModernWpf.sln --configuration Release --no-restore`: succeeded with 0 warnings and 0 errors
- final Release `-NoBuild -ValidateOnly` checks passed in both Windows PowerShell (`net462`) and PowerShell 7 (`net10.0-windows7.0`)

The net8/net10 builds print the repository's existing `Failed to resolve WinRT.Runtime.dll.` informational diagnostic; the builds still report 0 warnings and 0 errors. No tests were skipped. Broader test projects were not run locally because this change is isolated to the sample runner/documentation and its tooling regression; the required PR gate covers the repository-wide checks.