### PR TITLE
Fix cross-thread theme resource updates

### DIFF
--- a/ModernWpf/Helpers/ColorsHelper.cs
+++ b/ModernWpf/Helpers/ColorsHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Media;
@@ -176,6 +177,27 @@ namespace ModernWpf
 
         public static void UpdateBrushes(ResourceDictionary themeDictionary, ResourceDictionary colors)
         {
+            UpdateBrushes(
+                themeDictionary,
+                colors,
+                new HashSet<ResourceDictionary>());
+        }
+
+        private static void UpdateBrushes(
+            ResourceDictionary themeDictionary,
+            ResourceDictionary colors,
+            HashSet<ResourceDictionary> visited)
+        {
+            if (!visited.Add(themeDictionary))
+            {
+                return;
+            }
+
+            foreach (var mergedDictionary in themeDictionary.MergedDictionaries)
+            {
+                UpdateBrushes(mergedDictionary, colors, visited);
+            }
+
             foreach (DictionaryEntry entry in themeDictionary)
             {
                 if (entry.Value is SolidColorBrush brush && !brush.IsFrozen)

--- a/ModernWpf/Helpers/ResourceDictionaryHelper.cs
+++ b/ModernWpf/Helpers/ResourceDictionaryHelper.cs
@@ -1,4 +1,6 @@
 ﻿using System.Windows;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace ModernWpf
 {
@@ -17,15 +19,7 @@ namespace ModernWpf
                 {
                     if (!freezable.CanFreeze)
                     {
-                        var enumerator = freezable.GetLocalValueEnumerator();
-                        while (enumerator.MoveNext())
-                        {
-                            var property = enumerator.Current.Property;
-                            if (DependencyPropertyHelper.GetValueSource(freezable, property).IsExpression)
-                            {
-                                freezable.SetValue(property, freezable.GetValue(property));
-                            }
-                        }
+                        SnapshotExpressions(freezable, new HashSet<Freezable>());
                     }
 
                     if (!freezable.IsFrozen)
@@ -48,6 +42,51 @@ namespace ModernWpf
                 {
                     SealValues(td);
                 }
+            }
+        }
+
+        private static void SnapshotExpressions(
+            Freezable value,
+            HashSet<Freezable> visited)
+        {
+            if (!visited.Add(value))
+            {
+                return;
+            }
+
+            var localProperties = new List<DependencyProperty>();
+            var enumerator = value.GetLocalValueEnumerator();
+            while (enumerator.MoveNext())
+            {
+                localProperties.Add(enumerator.Current.Property);
+            }
+
+            foreach (var property in localProperties)
+            {
+                if (DependencyPropertyHelper.GetValueSource(value, property).IsExpression)
+                {
+                    value.SetValue(property, value.GetValue(property));
+                }
+
+                SnapshotChild(value.GetValue(property), visited);
+            }
+
+            if (value is IEnumerable children)
+            {
+                foreach (var child in children)
+                {
+                    SnapshotChild(child, visited);
+                }
+            }
+        }
+
+        private static void SnapshotChild(
+            object value,
+            HashSet<Freezable> visited)
+        {
+            if (value is Freezable freezable)
+            {
+                SnapshotExpressions(freezable, visited);
             }
         }
     }

--- a/ModernWpf/ThemeManager.cs
+++ b/ModernWpf/ThemeManager.cs
@@ -236,6 +236,11 @@ namespace ModernWpf
                 {
                     ColorsHelper.Current.UpdateBrushes(themeDictionary);
                 }
+
+                if (ThemeResources.Current.CanBeAccessedAcrossThreads)
+                {
+                    ThemeResources.Current.RefreshResources();
+                }
             }
         }
 
@@ -758,15 +763,14 @@ namespace ModernWpf
         {
             if (!_defaultThemeDictionaries.TryGetValue(key, out ResourceDictionary dictionary))
             {
-                dictionary = new ResourceDictionary { Source = GetDefaultSource(key) };
+                // Keep a stable outer dictionary so frozen sourced resources can be
+                // reloaded without replacing every consumer's merged dictionary.
+                dictionary = new ResourceDictionary();
+                dictionary.MergedDictionaries.Add(
+                    new ResourceDictionary { Source = GetDefaultSource(key) });
                 _defaultThemeDictionaries[key] = dictionary;
             }
             return dictionary;
-        }
-
-        internal static void SetDefaultThemeDictionary(string key, ResourceDictionary dictionary)
-        {
-            _defaultThemeDictionaries[key] = dictionary;
         }
 
         private static ApplicationTheme GetDefaultAppTheme()

--- a/ModernWpf/ThemeResources.cs
+++ b/ModernWpf/ThemeResources.cs
@@ -252,6 +252,24 @@ namespace ModernWpf
             }
         }
 
+        internal void RefreshResources()
+        {
+            if (_lightResources != null)
+            {
+                RefreshThemeResources(_lightResources);
+            }
+
+            if (_darkResources != null)
+            {
+                RefreshThemeResources(_darkResources);
+            }
+
+            if (_highContrastResources != null)
+            {
+                RefreshThemeResources(_highContrastResources);
+            }
+        }
+
         internal void ApplyApplicationTheme(ApplicationTheme theme)
         {
             int targetIndex = DesignMode.DesignModeEnabled ? 1 : 0;
@@ -260,14 +278,12 @@ namespace ModernWpf
             {
                 EnsureHighContrastResources();
 
-                if (IsMerged(_highContrastResources))
+                if (CanBeAccessedAcrossThreads)
                 {
-                    if (CanBeAccessedAcrossThreads)
-                    {
-                        RefreshHighContrastResources();
-                    }
+                    RefreshThemeResources(_highContrastResources);
                 }
-                else
+
+                if (!IsMerged(_highContrastResources))
                 {
                     MergedDictionaries.InsertOrReplace(targetIndex, _highContrastResources);
                     MergedDictionaries.RemoveIfNotNull(_lightResources);
@@ -279,12 +295,24 @@ namespace ModernWpf
                 if (theme == ApplicationTheme.Light)
                 {
                     EnsureLightResources();
+
+                    if (CanBeAccessedAcrossThreads)
+                    {
+                        RefreshThemeResources(_lightResources);
+                    }
+
                     MergedDictionaries.InsertOrReplace(targetIndex, _lightResources);
                     MergedDictionaries.RemoveIfNotNull(_darkResources);
                 }
                 else if (theme == ApplicationTheme.Dark)
                 {
                     EnsureDarkResources();
+
+                    if (CanBeAccessedAcrossThreads)
+                    {
+                        RefreshThemeResources(_darkResources);
+                    }
+
                     MergedDictionaries.InsertOrReplace(targetIndex, _darkResources);
                     MergedDictionaries.RemoveIfNotNull(_lightResources);
                 }
@@ -390,13 +418,9 @@ namespace ModernWpf
             }
         }
 
-        private void RefreshHighContrastResources()
+        private static void RefreshThemeResources(ResourceDictionary resources)
         {
-            Debug.Assert(_highContrastResources != null);
-
-            var hcResources = _highContrastResources;
-            var mergedDictionaries = hcResources.MergedDictionaries;
-            var oldDefault = ThemeManager.GetDefaultThemeDictionary(ThemeManager.HighContrastKey);
+            var mergedDictionaries = resources.MergedDictionaries;
 
             for (int i = 0; i < mergedDictionaries.Count; i++)
             {
@@ -405,11 +429,11 @@ namespace ModernWpf
                 {
                     var newMD = new ResourceDictionary { Source = md.Source };
                     newMD.SealValues();
-                    if (md == oldDefault)
-                    {
-                        ThemeManager.SetDefaultThemeDictionary(ThemeManager.HighContrastKey, newMD);
-                    }
                     mergedDictionaries[i] = newMD;
+                }
+                else
+                {
+                    RefreshThemeResources(md);
                 }
             }
         }

--- a/test/ModernWpf.Theme.Tests/ColorsHelperTests.cs
+++ b/test/ModernWpf.Theme.Tests/ColorsHelperTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ModernWpf.WinUI.TestInfra;
@@ -9,6 +11,93 @@ namespace ModernWpf.Theme.Tests;
 [TestClass]
 public class ColorsHelperTests
 {
+    [TestMethod]
+    public void FrozenThemeResourcesRefreshWhenAccentChanges()
+    {
+        WpfTestHost.Run(() =>
+        {
+            ThemeTestApplication.EnsureInitialized();
+            Assert.IsTrue(ThemeResources.Current.CanBeAccessedAcrossThreads);
+
+            var themeManager = ThemeManager.Current;
+            var originalTheme = themeManager.ApplicationTheme;
+            var originalAccent = themeManager.AccentColor;
+
+            try
+            {
+                themeManager.ApplicationTheme = ApplicationTheme.Light;
+                var themeResources = ThemeResources.Current;
+
+                var target = new Border();
+                target.SetResourceReference(
+                    Border.BackgroundProperty,
+                    "SystemControlForegroundAccentBrush");
+
+                using var host = new TestWindowHost(target, width: 120, height: 80);
+                host.UpdateLayout();
+                WpfTestHost.DoEvents();
+
+                var updatedAccent = Color.FromRgb(0x12, 0xA4, 0x6C);
+                themeManager.AccentColor = updatedAccent;
+                WpfTestHost.DoEvents();
+
+                var accentBrush = (SolidColorBrush)target.Background;
+                Assert.AreEqual(updatedAccent, accentBrush.Color);
+                Assert.IsTrue(accentBrush.IsFrozen);
+                Assert.AreEqual(
+                    updatedAccent,
+                    Task.Run(() => accentBrush.Color).GetAwaiter().GetResult());
+
+                AssertFrozenBrushColor(
+                    themeResources.GetThemeDictionary(ThemeManager.LightKey),
+                    "SystemControlForegroundAccentBrush",
+                    updatedAccent);
+                AssertFrozenBrushColor(
+                    themeResources.GetThemeDictionary(ThemeManager.DarkKey),
+                    "SystemControlForegroundAccentBrush",
+                    updatedAccent);
+                AssertFrozenBrushColor(
+                    themeResources.GetThemeDictionary(ThemeManager.HighContrastKey),
+                    "SystemAccentColorDark1Brush",
+                    (Color)ColorsHelper.Current.Colors["SystemAccentColorDark1"]);
+
+                var focusedBorder = (LinearGradientBrush)themeResources
+                    .GetThemeDictionary(ThemeManager.LightKey)["TextControlElevationBorderFocusedBrush"];
+                Assert.IsTrue(focusedBorder.IsFrozen);
+                Assert.AreEqual(
+                    focusedBorder.GradientStops[0].Color,
+                    Task.Run(() => focusedBorder.GradientStops[0].Color).GetAwaiter().GetResult());
+            }
+            finally
+            {
+                themeManager.AccentColor = originalAccent;
+                themeManager.ApplicationTheme = originalTheme;
+                WpfTestHost.DoEvents();
+            }
+        });
+    }
+
+    [TestMethod]
+    public void UpdateBrushesTraversesMergedDictionaries()
+    {
+        var accent = Color.FromRgb(0x30, 0x80, 0xD0);
+        var accentBrush = new SolidColorBrush();
+        ThemeResourceHelper.SetColorKey(accentBrush, "SystemAccentColor");
+
+        var child = new ResourceDictionary
+        {
+            ["SystemControlForegroundAccentBrush"] = accentBrush
+        };
+        var root = new ResourceDictionary();
+        root.MergedDictionaries.Add(child);
+
+        ColorsHelper.UpdateBrushes(
+            root,
+            new ResourceDictionary { ["SystemAccentColor"] = accent });
+
+        Assert.AreEqual(accent, accentBrush.Color);
+    }
+
     [TestMethod]
     [DataRow("Light", "SystemAccentColorDark1")]
     [DataRow("Dark", "SystemAccentColorLight2")]
@@ -90,5 +179,19 @@ public class ColorsHelperTests
         Assert.AreEqual(accentLight1, palette["SystemAccentColorLight1"]);
         Assert.AreEqual(accentLight2, palette["SystemAccentColorLight2"]);
         Assert.AreEqual(accentLight3, palette["SystemAccentColorLight3"]);
+    }
+
+    private static void AssertFrozenBrushColor(
+        ResourceDictionary resources,
+        object key,
+        Color expected)
+    {
+        var brush = (SolidColorBrush)resources[key];
+        Assert.AreEqual(expected, brush.Color, key.ToString());
+        Assert.IsTrue(brush.IsFrozen, key.ToString());
+        Assert.AreEqual(
+            expected,
+            Task.Run(() => ((SolidColorBrush)resources[key]).Color).GetAwaiter().GetResult(),
+            key.ToString());
     }
 }

--- a/test/ModernWpf.Theme.Tests/ThemeTestApplication.cs
+++ b/test/ModernWpf.Theme.Tests/ThemeTestApplication.cs
@@ -16,7 +16,12 @@ internal static class ThemeTestApplication
                 Resources = new ResourceDictionary()
             };
 
-            var themeResources = new ThemeResources();
+            // Exercise the frozen resource path here; the other test applications use
+            // the default mutable resource path.
+            var themeResources = new ThemeResources
+            {
+                CanBeAccessedAcrossThreads = true
+            };
             ((ISupportInitialize)themeResources).BeginInit();
             ((ISupportInitialize)themeResources).EndInit();
 


### PR DESCRIPTION
Fixes #420.

## Summary

- keep each default theme dictionary behind a stable outer container so frozen sourced resources can be reloaded without replacing every consumer
- reload initialized Light, Dark, and nested High Contrast dictionaries after accent changes and before cross-thread theme switches
- preserve mutable-resource accent updates by traversing merged dictionaries
- snapshot nested Freezable expressions (including GradientStops) before freezing, restoring `CanBeAccessedAcrossThreads` initialization for the current 1.x resource set
- run the Theme test application in frozen-resource mode and cover dynamic-resource invalidation, inactive themes, nested High Contrast resources, gradient freezing, and worker-thread lookup

The reload approach builds on the reproduction/fix proposed in veselink1/ModernWpf@03a18040cfad79001889f223f07bf3ee42d26cac, extended for the current nested resource shape and current gradient resources.

## Reproduction

The focused regression failed before the fix because `SystemControlForegroundAccentBrush` remained `#FF0078D4` after changing the accent to `#FF12A46C`. The current resource set also exposed an earlier initialization failure: the frozen path could not freeze a `LinearGradientBrush` whose dynamic expression lives on a nested GradientStop.

## Validation

- `dotnet restore .\ModernWpf.sln`
- `dotnet build .\ModernWpf.sln --configuration Release --no-restore` — succeeded, 0 warnings, 0 errors; includes `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0` product builds
- focused cross-thread/merged-dictionary tests — 2 passed, 0 failed, 0 skipped on `net8.0-windows7.0`
- complete `ModernWpf.Theme.Tests` — 16 passed, 0 failed, 0 skipped on `net8.0-windows7.0`
- complete `ModernWpf.Theme.Tests` — 19 passed, 0 failed, 0 skipped on `net10.0-windows7.0`
- complete `ModernWpf.WinUI.Tests` — 1,022 passed, 0 failed, 0 skipped on `net8.0-windows7.0`