### PR TITLE
Fix tapped input event leak

### DIFF
--- a/ModernWpf/Input/InputHelper.cs
+++ b/ModernWpf/Input/InputHelper.cs
@@ -98,8 +98,8 @@ namespace ModernWpf.Input
         internal static void RaiseTapped(UIElement element, int timestamp)
         {
             var e = new TappedRoutedEventArgs { RoutedEvent = TappedEvent, Source = element, Timestamp = timestamp };
-            _lastTappedArgs = e;
             element.RaiseEvent(e);
+            _lastHandledTapTimestamp = e.Handled ? timestamp : (int?)null;
         }
 
         #endregion
@@ -107,6 +107,7 @@ namespace ModernWpf.Input
         private static void OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             var element = (UIElement)sender;
+            _lastHandledTapTimestamp = null;
 
             if (!GetIsPressed(element))
             {
@@ -122,9 +123,7 @@ namespace ModernWpf.Input
             {
                 SetIsPressed((UIElement)sender, false);
 
-                var lastArgs = _lastTappedArgs;
-
-                if (lastArgs != null && lastArgs.Handled && lastArgs.Timestamp == e.Timestamp)
+                if (_lastHandledTapTimestamp == e.Timestamp)
                 {
                     // Handled by a child element, don't raise
                 }
@@ -149,6 +148,7 @@ namespace ModernWpf.Input
             SetIsPressed((UIElement)sender, false);
         }
 
-        private static TappedRoutedEventArgs _lastTappedArgs;
+        [System.ThreadStatic]
+        private static int? _lastHandledTapTimestamp;
     }
 }

--- a/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewApiTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
@@ -12,6 +13,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ModernWpf;
 using ModernWpf.Automation.Peers;
 using ModernWpf.Controls.Primitives;
+using ModernWpf.Input;
 using ModernWpf.WinUI.TestApp;
 using ModernWpf.WinUI.TestInfra;
 
@@ -628,6 +630,26 @@ public class NavigationViewApiTests
 
             GC.Collect();
             menuItem.IsSelected = !menuItem.IsSelected;
+        });
+    }
+
+    [TestMethod]
+    public void HandledTapDoesNotKeepSourceAlive()
+    {
+        WpfTestHost.Run(() =>
+        {
+            var sourceReference = RaiseHandledTapAndReleaseSource();
+
+            for (int i = 0; i < 3 && sourceReference.IsAlive; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            }
+
+            Assert.IsFalse(
+                sourceReference.IsAlive,
+                "The last handled tap state must not root its routed-event source.");
         });
     }
 
@@ -2718,6 +2740,21 @@ public class NavigationViewApiTests
         };
         chevron.RaiseEvent(mouseUp);
         Assert.IsTrue(mouseUp.Handled);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference RaiseHandledTapAndReleaseSource()
+    {
+        var source = new Border();
+        InputHelper.AddTappedHandler(source, MarkTapHandled);
+        InputHelper.RaiseTapped(source, Environment.TickCount);
+        InputHelper.RemoveTappedHandler(source, MarkTapHandled);
+        return new WeakReference(source);
+    }
+
+    private static void MarkTapHandled(object sender, TappedRoutedEventArgs args)
+    {
+        args.Handled = true;
     }
 
     private static T FindNamedDescendant<T>(DependencyObject root, string name)


### PR DESCRIPTION
Fixes #416

## Summary

- replace the static retained `TappedRoutedEventArgs` with a thread-scoped nullable timestamp
- preserve parent tap suppression only when a child handled the same mouse sequence
- add a GC regression proving a handled tap no longer keeps its source element alive
- keep the public API surface unchanged

## Reproduction

The new `HandledTapDoesNotKeepSourceAlive` regression was run against the original implementation before the fix. It failed (0 passed, 1 failed) because the tapped source remained alive after three full GC cycles.

## Validation

- focused leak regression: 1 passed, 0 failed, 0 skipped
- NavigationView tests: 58 passed, 0 failed, 0 skipped
- `dotnet restore ModernWpf.sln`: succeeded
- `dotnet build ModernWpf.sln --configuration Release --no-restore`: succeeded with 0 warnings and 0 errors
- complete ModernWpf.WinUI.Tests final run: 1,023 passed, 0 failed, 0 skipped

An initial complete-suite run had one environmental synthetic-pointer miss (1,022 passed, 1 failed). That exact test passed immediately in isolation, and the complete-suite rerun passed 1,023/1,023.