### PR TITLE
Fix right-to-left CheckBox glyph

### DIFF
--- a/ModernWpf/Styles/CheckBox.xaml
+++ b/ModernWpf/Styles/CheckBox.xaml
@@ -73,6 +73,7 @@
                                             FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                             FontSize="{StaticResource CheckBoxIconSize}"
                                             FontWeight="Bold"
+                                            FlowDirection="LeftToRight"
                                             Foreground="{DynamicResource CheckBoxCheckGlyphForeground}"
                                             Text="{StaticResource CheckBoxCheckedGlyph}"
                                             Visibility="Collapsed" />

--- a/docs/checkbox-wpf-fluent-source-audit.md
+++ b/docs/checkbox-wpf-fluent-source-audit.md
@@ -46,6 +46,11 @@ than WinUI 3 common styles.
 - Official WPF Fluent uses `DefaultControlFocusVisualStyle`; ModernWpf keeps
   `{x:Static SystemParameters.FocusVisualStyleKey}` plus
   `FocusVisualHelper.UseSystemFocusVisuals` and `FocusVisualHelper.FocusVisualMargin`.
+- ModernWpf explicitly keeps the direction-neutral check glyph
+  `FlowDirection="LeftToRight"` so an inherited right-to-left application
+  flow reorders the CheckBox layout and content without mirroring the check.
+  The override is scoped to `ControlIcon`, avoiding application-wide `Path`
+  styles that would also reverse directional menu and scrollbar glyphs.
 - Existing ModernWpf brush aliases such as `CheckBoxBackgroundUnchecked` and
   `CheckBoxCheckBackgroundFillChecked` are retained because they already map to
   Fluent color concepts and are part of the public resource surface.
@@ -59,6 +64,9 @@ than WinUI 3 common styles.
   native trigger matrix, and disabled resource application.
 - `CheckBoxVisualStateTests.CheckedAndIndeterminateStatesUseOfficialWpfFluentResources`
   verifies checked and indeterminate glyph/chrome resources at runtime.
+- `CheckBoxVisualStateTests.RightToLeftCheckBoxKeepsCheckGlyphOrientation`
+  verifies that the CheckBox layout and content inherit right-to-left flow
+  while only the direction-neutral check glyph remains left-to-right.
 - `CheckBoxVisualStateTests.ThemeDictionariesExposeOfficialCheckBoxGlyphResources`
   verifies the new official glyph brush aliases across Light, Dark, and HighContrast.
 

--- a/test/ModernWpf.WinUI.Tests/CommonStyles/CheckBoxVisualStateTests.cs
+++ b/test/ModernWpf.WinUI.Tests/CommonStyles/CheckBoxVisualStateTests.cs
@@ -128,6 +128,33 @@ public class CheckBoxVisualStateTests
     }
 
     [TestMethod]
+    public void RightToLeftCheckBoxKeepsCheckGlyphOrientation()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var checkBox = CreateCheckBox();
+            checkBox.Content = "خيار";
+            checkBox.IsChecked = true;
+            checkBox.FlowDirection = FlowDirection.RightToLeft;
+            using var host = new TestWindowHost(checkBox, width: 180, height: 80);
+            host.UpdateLayout();
+
+            var rootGrid = GetTemplateChild<Grid>(checkBox, "RootGrid");
+            var controlIcon = GetTemplateChild<TextBlock>(checkBox, "ControlIcon");
+            var contentPresenter = GetTemplateChild<ContentPresenter>(checkBox, "ContentPresenter");
+
+            Assert.AreEqual(FlowDirection.RightToLeft, rootGrid.FlowDirection);
+            Assert.AreEqual(FlowDirection.RightToLeft, contentPresenter.FlowDirection);
+            Assert.AreEqual(
+                FlowDirection.LeftToRight,
+                controlIcon.FlowDirection,
+                "Only the direction-neutral check glyph should opt out of the inherited right-to-left layout.");
+        });
+    }
+
+    [TestMethod]
     public void ThemeDictionariesExposeOfficialCheckBoxGlyphResources()
     {
         WpfTestHost.Run(() =>


### PR DESCRIPTION
Fixes #415

## Summary

- keep the internal direction-neutral CheckBox symbol glyph left-to-right
- preserve inherited right-to-left flow for the CheckBox grid and content
- avoid application-wide `Path` overrides that would also reverse menu and scrollbar arrows
- document the scoped WPF adaptation in the CheckBox source audit
- keep the public API and public resource-key surfaces unchanged

## Reproduction

The new `RightToLeftCheckBoxKeepsCheckGlyphOrientation` regression was run against the original 1.x template before the fix. It failed (0 passed, 1 failed, 0 skipped): the internal `ControlIcon` inherited `RightToLeft` instead of remaining `LeftToRight`. A temporary render probe also confirmed the right-to-left glyph was closer to the horizontally mirrored check than to the normal orientation.

## Validation

- focused RTL regression: 1 passed, 0 failed, 0 skipped
- all `CheckBoxVisualStateTests`: 5 passed, 0 failed, 0 skipped
- `dotnet restore ModernWpf.sln`: succeeded
- `dotnet build ModernWpf.sln --configuration Release --no-restore`: succeeded with 0 warnings and 0 errors
- complete ModernWpf.WinUI.Tests: 1,024 passed, 0 failed, 0 skipped

No separate manual gallery screenshot comparison was performed; the runtime regression verifies that layout/content remain RTL while only the check glyph is scoped to LTR.