### PR TITLE
Fix NavigationView XAML pane state order

### DIFF
--- a/ModernWpf.Controls/NavigationView/NavigationView.cs
+++ b/ModernWpf.Controls/NavigationView/NavigationView.cs
@@ -4210,10 +4210,6 @@ namespace ModernWpf.Controls
             }
             else if (property == PaneDisplayModeProperty)
             {
-                // m_wasForceClosed is set to true because ToggleButton is clicked and Pane is closed.
-                // When PaneDisplayMode is changed, reset the force flag to make the Pane can be opened automatically again.
-                m_wasForceClosed = false;
-
                 UpdatePaneToggleButtonVisibility();
                 UpdatePaneDisplayMode((NavigationViewPaneDisplayMode)args.OldValue, (NavigationViewPaneDisplayMode)args.NewValue);
                 UpdatePaneTitleFrameworkElementParents();
@@ -4491,6 +4487,11 @@ namespace ModernWpf.Controls
             {
                 return;
             }
+
+            // m_wasForceClosed is set to true because ToggleButton is clicked and Pane is closed.
+            // When PaneDisplayMode changes after template application, reset the force flag so the pane can open automatically.
+            // Before template application, preserving the flag keeps the initial IsPaneOpen value independent of XAML attribute order.
+            m_wasForceClosed = false;
 
             UpdatePaneDisplayMode();
 

--- a/docs/navigationview-winui3-source-audit.md
+++ b/docs/navigationview-winui3-source-audit.md
@@ -138,6 +138,12 @@ API controls are covered by the focused Gallery regression.
   therefore completes the source display-mode deferral through the dispatcher
   when template application is late and explicitly reconciles the paired pane
   and list-size visual-state groups.
+- WPF XAML applies `NavigationView` attributes sequentially before the control
+  template exists. The port therefore resets the source `m_wasForceClosed`
+  state for `PaneDisplayMode` changes only after template application. This
+  keeps an explicitly closed initial pane closed regardless of whether
+  `IsPaneOpen` appears before or after `PaneDisplayMode`, while runtime display
+  mode changes retain the source automatic open/close behavior.
 - WinUI `ItemsRepeater`, `SplitView`, `Flyout`, popup/XamlRoot services, focus
   movement, top overflow measurement, gamepad/access-key paths, composition
   animations, x:Bind phases, and recycle metadata use the existing documented
@@ -217,7 +223,7 @@ API controls are covered by the focused Gallery regression.
 - The WPF initial-window-layout substitute defers SplitView's state replay when
   dispatcher processing is suspended; the existing launch-state regression
   now covers the path without a nested-dispatcher exception.
-- NavigationView product/source-audit tests pass 57/57; SplitView product tests
+- NavigationView product/source-audit tests pass 59/59; SplitView product tests
   pass 14/14; the focused Gallery sample/source-shape slice passes 7/7 on net8
   and net10. Gallery builds successfully on net462, net8, and net10 with zero
   errors; current target builds retain existing unrelated warnings.

--- a/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewApiTests.cs
@@ -7,6 +7,7 @@ using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Markup;
 using System.Windows.Media;
 using System.Windows.Shapes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -777,6 +778,36 @@ public class NavigationViewApiTests
             using var host = CreateNavigationViewHost(out var navView, paneDisplayMode, isPaneOpen, displayMode);
             Assert.AreEqual(expectedIsPaneOpen, navView.IsPaneOpen);
         }
+    }
+
+    [TestMethod]
+    public void XamlPaneStateDoesNotDependOnAttributeOrder()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            foreach (string attributes in new[]
+            {
+                "IsPaneOpen='False' PaneDisplayMode='Left'",
+                "PaneDisplayMode='Left' IsPaneOpen='False'"
+            })
+            {
+                var navView = (ModernWpf.Controls.NavigationView)XamlReader.Parse(
+                    $@"<ui:NavigationView
+                            xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                            xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                            xmlns:ui='http://schemas.modernwpf.com/2019'
+                            Width='800'
+                            Height='600'
+                            {attributes} />");
+
+                Assert.IsFalse(navView.IsPaneOpen, attributes);
+                using var host = new TestWindowHost(navView);
+                host.UpdateLayout();
+                Assert.IsFalse(navView.IsPaneOpen, attributes);
+            }
+        });
     }
 
     [TestMethod]


### PR DESCRIPTION
Fixes #409

## Summary

- preserve an explicitly closed initial pane while XAML attributes are being applied before the template exists
- reset NavigationView's force-closed state only when a `PaneDisplayMode` change is actually processed after template application
- retain the existing WinUI automatic open/close behavior for runtime display-mode changes
- cover both XAML attribute orders and document the WPF lifecycle adaptation
- keep public API and resource-key surfaces unchanged

## Reproduction

The new `XamlPaneStateDoesNotDependOnAttributeOrder` regression parses and hosts both:

- `IsPaneOpen="False" PaneDisplayMode="Left"`
- `PaneDisplayMode="Left" IsPaneOpen="False"`

Against the original implementation it failed (0 passed, 1 failed, 0 skipped): the first order parsed with `IsPaneOpen=false`, but template application changed it back to `true`.

## Validation

- focused two-order XAML regression: 1 passed, 0 failed, 0 skipped
- XAML regression plus existing launch/runtime pane-mode contracts: 3 passed, 0 failed, 0 skipped
- all NavigationView tests: 59 passed, 0 failed, 0 skipped
- `dotnet restore ModernWpf.sln`: succeeded
- `dotnet build ModernWpf.sln --configuration Release --no-restore`: succeeded with 0 warnings and 0 errors
- complete ModernWpf.WinUI.Tests: 1,025 passed, 0 failed, 0 skipped

No separate Visual Studio designer session was performed; the runtime XAML regression exercises the sequential attribute application and subsequent template-load transition that caused the reported state change.