### PR TITLE
Add Frame transition overloads for page instances

### DIFF
--- a/ModernWpf/Navigation/Frame.cs
+++ b/ModernWpf/Navigation/Frame.cs
@@ -265,6 +265,32 @@ namespace ModernWpf.Controls
         }
 
         /// <summary>
+        /// Causes the Frame to load the specified content and use the specified animated transition.
+        /// </summary>
+        /// <param name="content">The content to navigate to.</param>
+        /// <param name="infoOverride">Info about the animated transition.</param>
+        /// <returns>true if navigation is not canceled; otherwise, false.</returns>
+        public bool Navigate(object content, NavigationTransitionInfo infoOverride)
+        {
+            _transitionInfoOverride = infoOverride;
+            return Navigate(content);
+        }
+
+        /// <summary>
+        /// Causes the Frame to load the specified content, pass extra data to the navigation target,
+        /// and use the specified animated transition.
+        /// </summary>
+        /// <param name="content">The content to navigate to.</param>
+        /// <param name="extraData">An object that contains data to be used for processing during navigation.</param>
+        /// <param name="infoOverride">Info about the animated transition.</param>
+        /// <returns>true if navigation is not canceled; otherwise, false.</returns>
+        public bool Navigate(object content, object extraData, NavigationTransitionInfo infoOverride)
+        {
+            _transitionInfoOverride = infoOverride;
+            return Navigate(content, extraData);
+        }
+
+        /// <summary>
         /// Navigates asynchronously to source content located at a uniform resource identifier
         /// (URI), and passes an object that contains data to be used for processing during
         /// navigation, and a value indicating the animated transition to use.

--- a/ModernWpf/PublicAPI.Unshipped.txt
+++ b/ModernWpf/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~ModernWpf.Controls.Frame.Navigate(object content, ModernWpf.Media.Animation.NavigationTransitionInfo infoOverride) -> bool
+~ModernWpf.Controls.Frame.Navigate(object content, object extraData, ModernWpf.Media.Animation.NavigationTransitionInfo infoOverride) -> bool

--- a/test/ModernWpf.WinUI.Tests/Navigation/FrameApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/Navigation/FrameApiTests.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModernWpf.Media.Animation;
+using ModernWpf.WinUI.TestApp;
+using ModernWpf.WinUI.TestInfra;
+
+namespace ModernWpf.WinUI.Tests.Navigation;
+
+[TestClass]
+public class FrameApiTests
+{
+    [TestMethod]
+    public void PageInstanceNavigationTransitionOverloadsAreAvailable()
+    {
+        var frameType = typeof(ModernWpf.Controls.Frame);
+
+        Assert.IsNotNull(
+            frameType.GetMethod(
+                nameof(ModernWpf.Controls.Frame.Navigate),
+                new[] { typeof(object), typeof(NavigationTransitionInfo) }));
+        Assert.IsNotNull(
+            frameType.GetMethod(
+                nameof(ModernWpf.Controls.Frame.Navigate),
+                new[] { typeof(object), typeof(object), typeof(NavigationTransitionInfo) }));
+    }
+
+    [TestMethod]
+    public void PageInstanceNavigationTransitionOverloadsApplyOverrides()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var frame = new ModernWpf.Controls.Frame();
+            using var host = new TestWindowHost(frame, width: 320, height: 240);
+
+            var firstPage = new ModernWpf.Controls.Page();
+            Assert.IsTrue(frame.Navigate(firstPage));
+            host.UpdateLayout();
+            Assert.AreSame(firstPage, frame.Content);
+
+            var transitionOverrideField = typeof(ModernWpf.Controls.Frame).GetField(
+                "_transitionInfoOverride",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new AssertFailedException("Expected Frame to retain the active navigation transition override.");
+
+            NavigationTransitionInfo? observedTransition = null;
+            object? observedExtraData = null;
+            frame.Navigating += (sender, args) =>
+            {
+                observedTransition = transitionOverrideField.GetValue(frame) as NavigationTransitionInfo;
+                observedExtraData = args.ExtraData;
+            };
+
+            var secondPage = new ModernWpf.Controls.Page();
+            var secondTransition = new SuppressNavigationTransitionInfo();
+            Assert.IsTrue(frame.Navigate((object)secondPage, secondTransition));
+            host.UpdateLayout();
+
+            Assert.AreSame(secondPage, frame.Content);
+            Assert.AreSame(secondTransition, observedTransition);
+            Assert.IsNull(observedExtraData);
+            Assert.IsNull(transitionOverrideField.GetValue(frame));
+
+            observedTransition = null;
+            observedExtraData = null;
+            var thirdPage = new ModernWpf.Controls.Page();
+            var extraData = new object();
+            var thirdTransition = new DrillInNavigationTransitionInfo();
+            Assert.IsTrue(frame.Navigate((object)thirdPage, extraData, thirdTransition));
+            host.UpdateLayout();
+
+            Assert.AreSame(thirdPage, frame.Content);
+            Assert.AreSame(thirdTransition, observedTransition);
+            Assert.AreSame(extraData, observedExtraData);
+            Assert.IsNull(transitionOverrideField.GetValue(frame));
+        });
+    }
+}


### PR DESCRIPTION
Fixes #400

## Summary
- add `Frame.Navigate` overloads that accept content instances with a `NavigationTransitionInfo` override
- preserve the extra-data overload and clear the override after navigation through the existing Frame lifecycle
- record the additive public API and add API-shape plus hosted navigation regressions

## Validation
- `dotnet restore ModernWpf.sln`
- `dotnet format ModernWpf.sln analyzers --diagnostics RS0016 --include-generated --no-restore`
- Release solution build: 0 warnings, 0 errors
- focused Frame regressions: 2 passed, 0 skipped
- complete WinUI suite: 1,027 passed, 0 skipped, three consecutive runs (plus isolated release-gate run)
- serialized release test gate: 2,678 passed, 11 documented skips, 0 failed
- NuGet package and symbol package verification passed
- package consumer smoke apps passed for both resource modes on `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0`