### PR TITLE
Fix modern window client hit testing below the title bar

### DIFF
--- a/ModernWpf/TitleBar/TitleBarButton.cs
+++ b/ModernWpf/TitleBar/TitleBarButton.cs
@@ -382,9 +382,11 @@ namespace ModernWpf.Controls.Primitives
         private bool IsMousePositionWithin(IntPtr lParam)
         {
             var mousePosScreen = new Point(Utility.GET_X_LPARAM(lParam), Utility.GET_Y_LPARAM(lParam));
-            var bounds = new Rect(new Point(), RenderSize);
             var mousePosRelative = PointFromScreen(mousePosScreen);
-            return bounds.Contains(mousePosRelative);
+            return mousePosRelative.X >= 0 &&
+                mousePosRelative.X < RenderSize.Width &&
+                mousePosRelative.Y >= 0 &&
+                mousePosRelative.Y < RenderSize.Height;
         }
     }
 }

--- a/ModernWpf/TitleBar/TitleBarControl.cs
+++ b/ModernWpf/TitleBar/TitleBarControl.cs
@@ -8,6 +8,8 @@ using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Shell;
+using Standard;
 using static Windows.Win32.PInvoke;
 
 namespace ModernWpf.Controls.Primitives
@@ -26,6 +28,7 @@ namespace ModernWpf.Controls.Primitives
         private const string RightSystemOverlayName = "PART_RightSystemOverlay";
 
         private Window _parentWindow;
+        private HwndSource _parentHwndSource;
         private KeyBinding _altLeftBinding;
 
         static TitleBarControl()
@@ -45,6 +48,9 @@ namespace ModernWpf.Controls.Primitives
             CommandBindings.Add(new CommandBinding(SystemCommands.CloseWindowCommand, CloseWindow));
 
             SetInsideTitleBar(this, true);
+
+            Loaded += OnLoaded;
+            Unloaded += OnUnloaded;
         }
 
         #region IsActive
@@ -429,6 +435,67 @@ namespace ModernWpf.Controls.Primitives
             }
         }
 
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            if (_parentWindow == null)
+            {
+                return;
+            }
+
+            var hwndSource = PresentationSource.FromVisual(this) as HwndSource;
+            if (!ReferenceEquals(hwndSource, _parentHwndSource))
+            {
+                RemoveWindowHook();
+                _parentHwndSource = hwndSource;
+                _parentHwndSource?.AddHook(FilterWindowMessage);
+            }
+        }
+
+        private void OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            RemoveWindowHook();
+        }
+
+        private void RemoveWindowHook()
+        {
+            if (_parentHwndSource != null)
+            {
+                _parentHwndSource.RemoveHook(FilterWindowMessage);
+                _parentHwndSource = null;
+            }
+        }
+
+        private IntPtr FilterWindowMessage(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == WmNcHitTest &&
+                _parentWindow != null &&
+                IsVisible &&
+                ActualHeight > 0)
+            {
+                var mousePosition = _parentWindow.PointFromScreen(
+                    new Point(Utility.GET_X_LPARAM(lParam), Utility.GET_Y_LPARAM(lParam)));
+                var titleBarBottom = TranslatePoint(new Point(0, ActualHeight), _parentWindow).Y;
+                var chrome = WindowChrome.GetWindowChrome(_parentWindow);
+                var resizeBorder = chrome?.ResizeBorderThickness ?? default;
+
+                if (mousePosition.Y >= titleBarBottom &&
+                    mousePosition.X >= resizeBorder.Left &&
+                    mousePosition.X < _parentWindow.ActualWidth - resizeBorder.Right &&
+                    mousePosition.Y < _parentWindow.ActualHeight - resizeBorder.Bottom)
+                {
+                    var inputElement = _parentWindow.InputHitTest(mousePosition);
+                    if (inputElement == null ||
+                        WindowChrome.GetResizeGripDirection(inputElement) == ResizeGripDirection.None)
+                    {
+                        handled = true;
+                        return (IntPtr)HtClient;
+                    }
+                }
+            }
+
+            return IntPtr.Zero;
+        }
+
         private void OnBackButtonClick(object sender, RoutedEventArgs e)
         {
             if (TemplatedParent is Window window)
@@ -552,6 +619,8 @@ namespace ModernWpf.Controls.Primitives
 
         private const int GwlStyle = -16;
         private const int WsMinimizeBox = 0x00020000;
+        private const int WmNcHitTest = 0x0084;
+        private const int HtClient = 1;
 
         [DllImport("user32.dll", EntryPoint = "GetWindowLongW")]
         private static extern int GetWindowLong(IntPtr hWnd, int nIndex);

--- a/docs/window-wpf-fluent-source-audit.md
+++ b/docs/window-wpf-fluent-source-audit.md
@@ -53,6 +53,11 @@ ModernWpf now follows the compatible parts of that source shape:
 - Disabled custom caption buttons remain inert when Windows 11 routes their
   input through non-client messages. In particular, `ResizeMode=CanMinimize`
   keeps the disabled maximize button from invoking its command.
+- The rendered client area immediately below `TitleBarControl` is explicitly
+  returned as `HTCLIENT`, avoiding WPF `WindowChrome`'s resize-border addition
+  to `CaptionHeight`. Caption-button bounds use half-open right/bottom edges,
+  while title dragging, side/bottom resize borders, and explicit resize grips
+  retain their native hit-test codes.
 - `WindowStyle=None` suppresses the ModernWpf title bar, detaches the custom
   `WindowChrome`, and lets content fill the captionless client area.
 
@@ -90,6 +95,10 @@ surface.
   `SourceInitialized` disables the ModernWpf minimize button and its routed
   command, and that the non-client click bridge cannot invoke the disabled
   maximize button when `ResizeMode=CanMinimize`.
+- `WindowVisualStateTests` sends native `WM_NCHITTEST` messages across the
+  first four content pixels below the title bar and verifies `HTCLIENT`, while
+  separately retaining `HTCAPTION` for draggable title space and
+  `HTBOTTOMRIGHT` for the explicit resize grip.
 - `WindowVisualStateTests` verifies that `WindowStyle=None` collapses the
   ModernWpf title bar, removes custom chrome/maximized-window compensation, and
   places content at the top of the client area.

--- a/test/ModernWpf.WinUI.Tests/CommonStyles/WindowVisualStateTests.cs
+++ b/test/ModernWpf.WinUI.Tests/CommonStyles/WindowVisualStateTests.cs
@@ -1,9 +1,12 @@
+using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
+using System.Windows.Interop;
 using System.Windows.Shell;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ModernWpf.Controls.Primitives;
@@ -168,6 +171,100 @@ public class WindowVisualStateTests
     }
 
     [TestMethod]
+    public void ContentImmediatelyBelowTitleBarUsesClientHitTesting()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var button = new Button
+            {
+                Content = "Button",
+                Width = 120,
+                Height = 32,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                VerticalAlignment = VerticalAlignment.Top
+            };
+            var window = new Window
+            {
+                Width = 420,
+                Height = 240,
+                Left = -30000,
+                Top = -30000,
+                Content = button,
+                ResizeMode = ResizeMode.CanResizeWithGrip,
+                ShowInTaskbar = false,
+                WindowStartupLocation = WindowStartupLocation.Manual
+            };
+            WindowHelper.SetUseModernWindowStyle(window, true);
+
+            try
+            {
+                window.Show();
+                WpfTestHost.DoEvents();
+                window.UpdateLayout();
+                WpfTestHost.DoEvents();
+
+                var handle = new WindowInteropHelper(window).Handle;
+                var buttonTopLeft = button.PointToScreen(new Point());
+                var buttonTopRight = button.PointToScreen(new Point(button.ActualWidth, 0));
+                var screenX = (int)Math.Floor((buttonTopLeft.X + buttonTopRight.X) / 2);
+                var firstButtonPixelY = (int)Math.Ceiling(buttonTopLeft.Y);
+                var hitTests = Enumerable.Range(0, 4)
+                    .Select(offset => SendMessage(
+                        handle,
+                        WmNcHitTest,
+                        IntPtr.Zero,
+                        PackScreenPoint(screenX, firstButtonPixelY + offset)).ToInt32())
+                    .ToArray();
+
+                CollectionAssert.AreEqual(
+                    new[] { HtClient, HtClient, HtClient, HtClient },
+                    hitTests,
+                    $"Expected the first four button rows to be clickable. " +
+                    $"Actual={string.Join(",", hitTests)}, button top={buttonTopLeft.Y}, " +
+                    $"chrome={WindowChrome.GetWindowChrome(window)?.CaptionHeight}, " +
+                    $"resize={WindowChrome.GetWindowChrome(window)?.ResizeBorderThickness.Top}.");
+
+                var titleBar = VisualTreeTestHelper.FindDescendant<TitleBarControl>(window)
+                    ?? throw new AssertFailedException("Expected the modern window title bar.");
+                var titleBarPoint = titleBar.PointToScreen(
+                    new Point(titleBar.ActualWidth / 2, titleBar.ActualHeight / 2));
+                Assert.AreEqual(
+                    HtCaption,
+                    SendMessage(
+                        handle,
+                        WmNcHitTest,
+                        IntPtr.Zero,
+                        PackScreenPoint(
+                            (int)Math.Floor(titleBarPoint.X),
+                            (int)Math.Floor(titleBarPoint.Y))).ToInt32(),
+                    "Empty title-bar space must remain draggable.");
+
+                var resizeGrip = VisualTreeTestHelper.FindDescendant<ResizeGrip>(window)
+                    ?? throw new AssertFailedException("Expected the modern window resize grip.");
+                var resizeGripPoint = resizeGrip.PointToScreen(
+                    new Point(resizeGrip.ActualWidth / 2, resizeGrip.ActualHeight / 2));
+                Assert.AreEqual(
+                    HtBottomRight,
+                    SendMessage(
+                        handle,
+                        WmNcHitTest,
+                        IntPtr.Zero,
+                        PackScreenPoint(
+                            (int)Math.Floor(resizeGripPoint.X),
+                            (int)Math.Floor(resizeGripPoint.Y))).ToInt32(),
+                    "The content client bridge must preserve the explicit resize grip.");
+            }
+            finally
+            {
+                window.Close();
+                WpfTestHost.DoEvents();
+            }
+        });
+    }
+
+    [TestMethod]
     public void WindowStyleDocumentsOfficialWpfFluentSubstitutions()
     {
         var repoRoot = FindRepoRoot();
@@ -229,4 +326,17 @@ public class WindowVisualStateTests
         Assert.Fail("Could not locate ModernWpf.sln from the test output directory.");
         return string.Empty;
     }
+
+    private static IntPtr PackScreenPoint(int x, int y)
+    {
+        return new IntPtr(unchecked((int)((uint)(ushort)x | ((uint)(ushort)y << 16))));
+    }
+
+    private const int WmNcHitTest = 0x0084;
+    private const int HtClient = 1;
+    private const int HtCaption = 2;
+    private const int HtBottomRight = 17;
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto)]
+    private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
 }


### PR DESCRIPTION
Fixes #395

## Summary
- return the rendered client region below `TitleBarControl` as `HTCLIENT` instead of relying on `WindowChrome.CaptionHeight` plus the system resize border
- preserve native title dragging, side/bottom resize borders, and explicit resize-grip hit codes
- make custom caption-button bounds half-open so their bottom edge cannot capture the first content pixel
- add a native `WM_NCHITTEST` regression and document the WPF shell adaptation

## Reproduction
Before the fix, the first four pixel rows of a top-aligned content button returned native hit codes `9, 2, 2, 1` (maximize, caption, caption, client), reproducing the inaccessible rows reported in #395.

## Validation
- focused native regression: 1 passed, 0 skipped; verifies `HTCLIENT` for all four rows, `HTCAPTION` for title drag space, and `HTBOTTOMRIGHT` for the resize grip
- maintained TitleBar/Window suites: 16 passed, 0 skipped
- `dotnet restore ModernWpf.sln`
- Release solution build: 0 warnings, 0 errors
- complete WinUI suite final run: 1,028 passed, 0 skipped

The first complete run passed 1,027/1,028 and hit an unrelated synthetic-mouse state flake in `GalleryPrimaryCommandReceivesRealMousePointerStates`; that test passed immediately in isolation (1/1), and the complete suite then passed 1,028/1,028 from the unchanged binaries.