### PR TITLE
Fix German resource fallback for neutral and regional cultures

### DIFF
--- a/ModernWpf.Controls/NavigationView/Strings/Resources.de.resx
+++ b/ModernWpf.Controls/NavigationView/Strings/Resources.de.resx
@@ -117,12 +117,48 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ProgressRingIndeterminateStatus" xml:space="preserve">
-    <value>Beschäftigt</value>
-    <comment>This is used to announce Indeterminate state.</comment>
+  <data name="NavigationButtonClosedName" xml:space="preserve">
+    <value>Navigation öffnen</value>
+    <comment>Automation name for the hamburger button when it is in a closed state</comment>
   </data>
-  <data name="ProgressRingName" xml:space="preserve">
-    <value>Statuskreis</value>
-    <comment>This is used to announce Progress Ring Name.</comment>
+  <data name="NavigationButtonOpenName" xml:space="preserve">
+    <value>Navigation schließen</value>
+    <comment>Automation name and tooltip caption for the hamburger button when it is in an open state, and tooltip caption for the close button</comment>
+  </data>
+  <data name="NavigationViewItemDefaultControlName" xml:space="preserve">
+    <value>NavigationViewItem</value>
+    <comment>Default automation id if no name or id is provided</comment>
+  </data>
+  <data name="SettingsButtonName" xml:space="preserve">
+    <value>Einstellungen</value>
+    <comment>Automation name for the settings button</comment>
+  </data>
+  <data name="NavigationViewSearchButtonName" xml:space="preserve">
+    <value>Klicken, um zu suchen</value>
+    <comment>Name for the compact view search button</comment>
+  </data>
+  <data name="NavigationBackButtonName" xml:space="preserve">
+    <value>Zurück</value>
+    <comment>Automation name for the nav view provided back button</comment>
+  </data>
+  <data name="NavigationBackButtonToolTip" xml:space="preserve">
+    <value>Zurück</value>
+    <comment>ToolTip caption for the back button</comment>
+  </data>
+  <data name="NavigationCloseButtonName" xml:space="preserve">
+    <value>Schließen</value>
+    <comment>Automation name for the nav view provided close button</comment>
+  </data>
+  <data name="NavigationOverflowButtonName" xml:space="preserve">
+    <value>Mehr</value>
+    <comment>Automation name for the nav view more button when panel is on top</comment>
+  </data>
+  <data name="NavigationOverflowButtonText" xml:space="preserve">
+    <value>Mehr</value>
+    <comment>Text for the nav view more button when panel is on top</comment>
+  </data>
+  <data name="NavigationOverflowButtonToolTip" xml:space="preserve">
+    <value>Mehr</value>
+    <comment>ToolTip caption for the nav view more button when panel is on top</comment>
   </data>
 </root>

--- a/ModernWpf.Controls/NumberBox/Strings/Resources.de.resx
+++ b/ModernWpf.Controls/NumberBox/Strings/Resources.de.resx
@@ -117,22 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AppBarMoreButtonClosedToolTip" xml:space="preserve">
-    <value>Weitere Infos</value>
+  <data name="NumberBoxDownSpinButtonName" xml:space="preserve">
+    <value>Verringerung</value>
+    <comment>Automation name for the down button</comment>
   </data>
-  <data name="AppBarMoreButtonName" xml:space="preserve">
-    <value>Mehr (App-Leiste)</value>
-  </data>
-  <data name="AppBarMoreButtonOpenToolTip" xml:space="preserve">
-    <value>Weniger anzeigen</value>
-  </data>
-  <data name="IgnoreMenuItemLabel" xml:space="preserve">
-    <value>Ignorieren</value>
-  </data>
-  <data name="ToggleSwitchOff" xml:space="preserve">
-    <value>Aus</value>
-  </data>
-  <data name="ToggleSwitchOn" xml:space="preserve">
-    <value>Ein</value>
+  <data name="NumberBoxUpSpinButtonName" xml:space="preserve">
+    <value>Anstieg</value>
+    <comment>Automation name for the up button</comment>
   </data>
 </root>

--- a/ModernWpf.Controls/PersonPicture/Strings/Resources.de.resx
+++ b/ModernWpf.Controls/PersonPicture/Strings/Resources.de.resx
@@ -117,16 +117,56 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ProgressBarErrorStatus" xml:space="preserve">
-    <value>Fehler</value>
-    <comment>This is used to announce Error state.</comment>
+  <data name="BadgeItemPlural1" xml:space="preserve">
+    <value>{0}, {1:d} Elemente</value>
+    <comment>This text is used to show the number of items in the person picture badging area, when that number is 21,31,41,etc. {0} is the contact name and {1} is the number of items.</comment>
   </data>
-  <data name="ProgressBarIndeterminateStatus" xml:space="preserve">
-    <value>Beschäftigt</value>
-    <comment>This is used to announce Indeterminate state.</comment>
+  <data name="BadgeItemPlural2" xml:space="preserve">
+    <value>{0}, {1:d} Elemente</value>
+    <comment>This text is used to show the number of items in the person picture badging area, when that number is 3-4. {0} is the contact name and {1} is the number of items.</comment>
   </data>
-  <data name="ProgressBarPausedStatus" xml:space="preserve">
-    <value>Angehalten</value>
-    <comment>This is used to announce Paused state.</comment>
+  <data name="BadgeItemPlural3" xml:space="preserve">
+    <value>{0}, {1:d} Elemente</value>
+    <comment>This text is used to show the number of items in the person picture badging area, when that number is  22-24, 32-34, 42-44, etc. {0} is the contact name and {1} is the number of items.</comment>
+  </data>
+  <data name="BadgeItemPlural4" xml:space="preserve">
+    <value>{0}, {1:d} Elemente</value>
+    <comment>This text is used to show the number of items in the person picture badging area, when that number is  0, 20, 25-30, 35-40, etc. (fallback plural). {0} is the contact name and {1} is the number of items.</comment>
+  </data>
+  <data name="BadgeItemPlural5" xml:space="preserve">
+    <value>{0}, {1:d} Elemente</value>
+    <comment>This text is used to show the number of items in the person picture badging area, when that number is  5-10. {0} is the contact name and {1} is the number of items.</comment>
+  </data>
+  <data name="BadgeItemPlural6" xml:space="preserve">
+    <value>{0}, {1:d} Elemente</value>
+    <comment>This text is used to show the number of items in the person picture badging area, when that number is  11-19. {0} is the contact name and {1} is the number of items.</comment>
+  </data>
+  <data name="BadgeItemPlural7" xml:space="preserve">
+    <value>{0}, {1:d} Elemente</value>
+    <comment>This text is used to show the number of items in the person picture badging area, when that number is  2. {0} is the contact name and {1} is the number of items.</comment>
+  </data>
+  <data name="BadgeItemSingular" xml:space="preserve">
+    <value>{0}, {1:d} Element</value>
+    <comment>This text is used to show the number of items in the person picture badging area, when that number is  1. {0} is the contact name and {1} is the number of items.</comment>
+  </data>
+  <data name="BadgeItemTextOverride" xml:space="preserve">
+    <value>{0}, {1:d} {2}</value>
+    <comment>This format string is used for the automation name. It is 'Person Name, badgenumber badgetext', where badge text is a user specified string overriding 'item(s)'.</comment>
+  </data>
+  <data name="BadgeIcon" xml:space="preserve">
+    <value>{0}, Symbol</value>
+    <comment>This text is used with the badging glyph. {0} is the contact name.</comment>
+  </data>
+  <data name="BadgeIconTextOverride" xml:space="preserve">
+    <value>{0}, {1}</value>
+    <comment>This format string is used for the automation name. It is 'Person Name, badgetext', where badgetext is a user specified string like skype.</comment>
+  </data>
+  <data name="PersonName" xml:space="preserve">
+    <value>Person</value>
+    <comment>This text is used as the generic narrator text when there is no display name or initials.</comment>
+  </data>
+  <data name="GroupName" xml:space="preserve">
+    <value>Gruppe</value>
+    <comment>This text is used as the generic narrator text when the group glyph is showing.</comment>
   </data>
 </root>

--- a/ModernWpf.Controls/ProgressRing/Strings/Resources.de.resx
+++ b/ModernWpf.Controls/ProgressRing/Strings/Resources.de.resx
@@ -117,8 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="SplitButtonSecondaryButtonName" xml:space="preserve">
-    <value>Weitere Optionen</value>
-    <comment>Automation name for the secondary button.</comment>
+  <data name="ProgressRingIndeterminateStatus" xml:space="preserve">
+    <value>Beschäftigt</value>
+    <comment>This is used to announce Indeterminate state.</comment>
+  </data>
+  <data name="ProgressRingName" xml:space="preserve">
+    <value>Statuskreis</value>
+    <comment>This is used to announce Progress Ring Name.</comment>
   </data>
 </root>

--- a/ModernWpf.Controls/RatingControl/Strings/Resources.de.resx
+++ b/ModernWpf.Controls/RatingControl/Strings/Resources.de.resx
@@ -117,98 +117,20 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ProofingMenuItemLabel" xml:space="preserve">
-    <value>Dokumentprüfung</value>
-    <comment>The label for the text command bar flyout menu item that provides the proofing menu.</comment>
+  <data name="BasicRatingString" xml:space="preserve">
+    <value>Bewertung, {0} von {1}</value>
+    <comment>English example: Rating, 1.0 of 5.</comment>
   </data>
-  <data name="TextCommandDescriptionBold" xml:space="preserve">
-    <value>Ausgewählten Text fett formatieren</value>
+  <data name="CommunityRatingString" xml:space="preserve">
+    <value>Community-Bewertung, {0} von {1}</value>
+    <comment>English example: Community Rating, 3.3 of 6.</comment>
   </data>
-  <data name="TextCommandDescriptionCopy" xml:space="preserve">
-    <value>Ausgewählten Inhalt in die Zwischenablage kopieren</value>
+  <data name="RatingUnset" xml:space="preserve">
+    <value>Bewertung nicht gesetzt</value>
+    <comment>This text is used to show the number of stars none are selected.</comment>
   </data>
-  <data name="TextCommandDescriptionCut" xml:space="preserve">
-    <value>Ausgewählten Inhalt entfernen und in der Zwischenablage ablegen</value>
-  </data>
-  <data name="TextCommandDescriptionItalic" xml:space="preserve">
-    <value>Ausgewählten Text kursiv formatieren</value>
-  </data>
-  <data name="TextCommandDescriptionPaste" xml:space="preserve">
-    <value>Inhalte der Zwischenablage an der aktuellen Position einfügen</value>
-  </data>
-  <data name="TextCommandDescriptionRedo" xml:space="preserve">
-    <value>Die zuletzt rückgängig gemachte Aktion wiederholen</value>
-  </data>
-  <data name="TextCommandDescriptionSelectAll" xml:space="preserve">
-    <value>Alle Inhalte auswählen</value>
-  </data>
-  <data name="TextCommandDescriptionUnderline" xml:space="preserve">
-    <value>Ausgewählten Text unterstreichen</value>
-  </data>
-  <data name="TextCommandDescriptionUndo" xml:space="preserve">
-    <value>Die zuletzt ausgeführte Aktion rückgängig machen</value>
-  </data>
-  <data name="TextCommandKeyboardAcceleratorKeyBold" xml:space="preserve">
-    <value>B</value>
-    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for bolding - Ctrl+B. Must be unique with respect to every other keyboard accelerator in this file.</comment>
-  </data>
-  <data name="TextCommandKeyboardAcceleratorKeyCopy" xml:space="preserve">
-    <value>C</value>
-    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for copying - Ctrl+C. Must be unique with respect to every other keyboard accelerator in this file.</comment>
-  </data>
-  <data name="TextCommandKeyboardAcceleratorKeyCut" xml:space="preserve">
-    <value>X</value>
-    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for cutting - Ctrl+X. Must be unique with respect to every other keyboard accelerator in this file.</comment>
-  </data>
-  <data name="TextCommandKeyboardAcceleratorKeyItalic" xml:space="preserve">
-    <value>I</value>
-    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for italicizing - Ctrl+I. Must be unique with respect to every other keyboard accelerator in this file.</comment>
-  </data>
-  <data name="TextCommandKeyboardAcceleratorKeyPaste" xml:space="preserve">
-    <value>V</value>
-    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for pasting - Ctrl+V. Must be unique with respect to every other keyboard accelerator in this file.</comment>
-  </data>
-  <data name="TextCommandKeyboardAcceleratorKeyRedo" xml:space="preserve">
-    <value>Y</value>
-    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for redoing - Ctrl+Y. Must be unique with respect to every other keyboard accelerator in this file.</comment>
-  </data>
-  <data name="TextCommandKeyboardAcceleratorKeySelectAll" xml:space="preserve">
-    <value>A</value>
-    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for selecting all - Ctrl+A. Must be unique with respect to every other keyboard accelerator in this file.</comment>
-  </data>
-  <data name="TextCommandKeyboardAcceleratorKeyUnderline" xml:space="preserve">
-    <value>U</value>
-    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for underlining - Ctrl+U. Must be unique with respect to every other keyboard accelerator in this file.</comment>
-  </data>
-  <data name="TextCommandKeyboardAcceleratorKeyUndo" xml:space="preserve">
-    <value>Z</value>
-    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for undoing - Ctrl+Z. Must be unique with respect to every other keyboard accelerator in this file.</comment>
-  </data>
-  <data name="TextCommandLabelBold" xml:space="preserve">
-    <value>Fett</value>
-  </data>
-  <data name="TextCommandLabelCopy" xml:space="preserve">
-    <value>Kopieren</value>
-  </data>
-  <data name="TextCommandLabelCut" xml:space="preserve">
-    <value>Ausschneiden</value>
-  </data>
-  <data name="TextCommandLabelItalic" xml:space="preserve">
-    <value>Kursiv</value>
-  </data>
-  <data name="TextCommandLabelPaste" xml:space="preserve">
-    <value>Einfügen</value>
-  </data>
-  <data name="TextCommandLabelRedo" xml:space="preserve">
-    <value>Wiederholen</value>
-  </data>
-  <data name="TextCommandLabelSelectAll" xml:space="preserve">
-    <value>Alles auswählen</value>
-  </data>
-  <data name="TextCommandLabelUnderline" xml:space="preserve">
-    <value>Unterstreichen</value>
-  </data>
-  <data name="TextCommandLabelUndo" xml:space="preserve">
-    <value>Rückgängig machen</value>
+  <data name="RatingLocalizedControlType" xml:space="preserve">
+    <value>Schieberegler zur Bewertung</value>
+    <comment>A simple description of the control for UIA</comment>
   </data>
 </root>

--- a/ModernWpf.Controls/SplitButton/Strings/Resources.de.resx
+++ b/ModernWpf.Controls/SplitButton/Strings/Resources.de.resx
@@ -117,48 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NavigationButtonClosedName" xml:space="preserve">
-    <value>Navigation öffnen</value>
-    <comment>Automation name for the hamburger button when it is in a closed state</comment>
-  </data>
-  <data name="NavigationButtonOpenName" xml:space="preserve">
-    <value>Navigation schließen</value>
-    <comment>Automation name and tooltip caption for the hamburger button when it is in an open state, and tooltip caption for the close button</comment>
-  </data>
-  <data name="NavigationViewItemDefaultControlName" xml:space="preserve">
-    <value>NavigationViewItem</value>
-    <comment>Default automation id if no name or id is provided</comment>
-  </data>
-  <data name="SettingsButtonName" xml:space="preserve">
-    <value>Einstellungen</value>
-    <comment>Automation name for the settings button</comment>
-  </data>
-  <data name="NavigationViewSearchButtonName" xml:space="preserve">
-    <value>Klicken, um zu suchen</value>
-    <comment>Name for the compact view search button</comment>
-  </data>
-  <data name="NavigationBackButtonName" xml:space="preserve">
-    <value>Zurück</value>
-    <comment>Automation name for the nav view provided back button</comment>
-  </data>
-  <data name="NavigationBackButtonToolTip" xml:space="preserve">
-    <value>Zurück</value>
-    <comment>ToolTip caption for the back button</comment>
-  </data>
-  <data name="NavigationCloseButtonName" xml:space="preserve">
-    <value>Schließen</value>
-    <comment>Automation name for the nav view provided close button</comment>
-  </data>
-  <data name="NavigationOverflowButtonName" xml:space="preserve">
-    <value>Mehr</value>
-    <comment>Automation name for the nav view more button when panel is on top</comment>
-  </data>
-  <data name="NavigationOverflowButtonText" xml:space="preserve">
-    <value>Mehr</value>
-    <comment>Text for the nav view more button when panel is on top</comment>
-  </data>
-  <data name="NavigationOverflowButtonToolTip" xml:space="preserve">
-    <value>Mehr</value>
-    <comment>ToolTip caption for the nav view more button when panel is on top</comment>
+  <data name="SplitButtonSecondaryButtonName" xml:space="preserve">
+    <value>Weitere Optionen</value>
+    <comment>Automation name for the secondary button.</comment>
   </data>
 </root>

--- a/ModernWpf/ProgressBar/Strings/Resources.de.resx
+++ b/ModernWpf/ProgressBar/Strings/Resources.de.resx
@@ -117,12 +117,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NumberBoxDownSpinButtonName" xml:space="preserve">
-    <value>Verringerung</value>
-    <comment>Automation name for the down button</comment>
+  <data name="ProgressBarErrorStatus" xml:space="preserve">
+    <value>Fehler</value>
+    <comment>This is used to announce Error state.</comment>
   </data>
-  <data name="NumberBoxUpSpinButtonName" xml:space="preserve">
-    <value>Anstieg</value>
-    <comment>Automation name for the up button</comment>
+  <data name="ProgressBarIndeterminateStatus" xml:space="preserve">
+    <value>Beschäftigt</value>
+    <comment>This is used to announce Indeterminate state.</comment>
+  </data>
+  <data name="ProgressBarPausedStatus" xml:space="preserve">
+    <value>Angehalten</value>
+    <comment>This is used to announce Paused state.</comment>
   </data>
 </root>

--- a/ModernWpf/Resources/Strings.de.resx
+++ b/ModernWpf/Resources/Strings.de.resx
@@ -117,56 +117,22 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="BadgeItemPlural1" xml:space="preserve">
-    <value>{0}, {1:d} Elemente</value>
-    <comment>This text is used to show the number of items in the person picture badging area, when that number is 21,31,41,etc. {0} is the contact name and {1} is the number of items.</comment>
+  <data name="AppBarMoreButtonClosedToolTip" xml:space="preserve">
+    <value>Weitere Infos</value>
   </data>
-  <data name="BadgeItemPlural2" xml:space="preserve">
-    <value>{0}, {1:d} Elemente</value>
-    <comment>This text is used to show the number of items in the person picture badging area, when that number is 3-4. {0} is the contact name and {1} is the number of items.</comment>
+  <data name="AppBarMoreButtonName" xml:space="preserve">
+    <value>Mehr (App-Leiste)</value>
   </data>
-  <data name="BadgeItemPlural3" xml:space="preserve">
-    <value>{0}, {1:d} Elemente</value>
-    <comment>This text is used to show the number of items in the person picture badging area, when that number is  22-24, 32-34, 42-44, etc. {0} is the contact name and {1} is the number of items.</comment>
+  <data name="AppBarMoreButtonOpenToolTip" xml:space="preserve">
+    <value>Weniger anzeigen</value>
   </data>
-  <data name="BadgeItemPlural4" xml:space="preserve">
-    <value>{0}, {1:d} Elemente</value>
-    <comment>This text is used to show the number of items in the person picture badging area, when that number is  0, 20, 25-30, 35-40, etc. (fallback plural). {0} is the contact name and {1} is the number of items.</comment>
+  <data name="IgnoreMenuItemLabel" xml:space="preserve">
+    <value>Ignorieren</value>
   </data>
-  <data name="BadgeItemPlural5" xml:space="preserve">
-    <value>{0}, {1:d} Elemente</value>
-    <comment>This text is used to show the number of items in the person picture badging area, when that number is  5-10. {0} is the contact name and {1} is the number of items.</comment>
+  <data name="ToggleSwitchOff" xml:space="preserve">
+    <value>Aus</value>
   </data>
-  <data name="BadgeItemPlural6" xml:space="preserve">
-    <value>{0}, {1:d} Elemente</value>
-    <comment>This text is used to show the number of items in the person picture badging area, when that number is  11-19. {0} is the contact name and {1} is the number of items.</comment>
-  </data>
-  <data name="BadgeItemPlural7" xml:space="preserve">
-    <value>{0}, {1:d} Elemente</value>
-    <comment>This text is used to show the number of items in the person picture badging area, when that number is  2. {0} is the contact name and {1} is the number of items.</comment>
-  </data>
-  <data name="BadgeItemSingular" xml:space="preserve">
-    <value>{0}, {1:d} Element</value>
-    <comment>This text is used to show the number of items in the person picture badging area, when that number is  1. {0} is the contact name and {1} is the number of items.</comment>
-  </data>
-  <data name="BadgeItemTextOverride" xml:space="preserve">
-    <value>{0}, {1:d} {2}</value>
-    <comment>This format string is used for the automation name. It is 'Person Name, badgenumber badgetext', where badge text is a user specified string overriding 'item(s)'.</comment>
-  </data>
-  <data name="BadgeIcon" xml:space="preserve">
-    <value>{0}, Symbol</value>
-    <comment>This text is used with the badging glyph. {0} is the contact name.</comment>
-  </data>
-  <data name="BadgeIconTextOverride" xml:space="preserve">
-    <value>{0}, {1}</value>
-    <comment>This format string is used for the automation name. It is 'Person Name, badgetext', where badgetext is a user specified string like skype.</comment>
-  </data>
-  <data name="PersonName" xml:space="preserve">
-    <value>Person</value>
-    <comment>This text is used as the generic narrator text when there is no display name or initials.</comment>
-  </data>
-  <data name="GroupName" xml:space="preserve">
-    <value>Gruppe</value>
-    <comment>This text is used as the generic narrator text when the group glyph is showing.</comment>
+  <data name="ToggleSwitchOn" xml:space="preserve">
+    <value>Ein</value>
   </data>
 </root>

--- a/ModernWpf/TextContextMenu/Strings/Resources.de.resx
+++ b/ModernWpf/TextContextMenu/Strings/Resources.de.resx
@@ -117,20 +117,98 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="BasicRatingString" xml:space="preserve">
-    <value>Bewertung, {0} von {1}</value>
-    <comment>English example: Rating, 1.0 of 5.</comment>
+  <data name="ProofingMenuItemLabel" xml:space="preserve">
+    <value>Dokumentprüfung</value>
+    <comment>The label for the text command bar flyout menu item that provides the proofing menu.</comment>
   </data>
-  <data name="CommunityRatingString" xml:space="preserve">
-    <value>Community-Bewertung, {0} von {1}</value>
-    <comment>English example: Community Rating, 3.3 of 6.</comment>
+  <data name="TextCommandDescriptionBold" xml:space="preserve">
+    <value>Ausgewählten Text fett formatieren</value>
   </data>
-  <data name="RatingUnset" xml:space="preserve">
-    <value>Bewertung nicht gesetzt</value>
-    <comment>This text is used to show the number of stars none are selected.</comment>
+  <data name="TextCommandDescriptionCopy" xml:space="preserve">
+    <value>Ausgewählten Inhalt in die Zwischenablage kopieren</value>
   </data>
-  <data name="RatingLocalizedControlType" xml:space="preserve">
-    <value>Schieberegler zur Bewertung</value>
-    <comment>A simple description of the control for UIA</comment>
+  <data name="TextCommandDescriptionCut" xml:space="preserve">
+    <value>Ausgewählten Inhalt entfernen und in der Zwischenablage ablegen</value>
+  </data>
+  <data name="TextCommandDescriptionItalic" xml:space="preserve">
+    <value>Ausgewählten Text kursiv formatieren</value>
+  </data>
+  <data name="TextCommandDescriptionPaste" xml:space="preserve">
+    <value>Inhalte der Zwischenablage an der aktuellen Position einfügen</value>
+  </data>
+  <data name="TextCommandDescriptionRedo" xml:space="preserve">
+    <value>Die zuletzt rückgängig gemachte Aktion wiederholen</value>
+  </data>
+  <data name="TextCommandDescriptionSelectAll" xml:space="preserve">
+    <value>Alle Inhalte auswählen</value>
+  </data>
+  <data name="TextCommandDescriptionUnderline" xml:space="preserve">
+    <value>Ausgewählten Text unterstreichen</value>
+  </data>
+  <data name="TextCommandDescriptionUndo" xml:space="preserve">
+    <value>Die zuletzt ausgeführte Aktion rückgängig machen</value>
+  </data>
+  <data name="TextCommandKeyboardAcceleratorKeyBold" xml:space="preserve">
+    <value>B</value>
+    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for bolding - Ctrl+B. Must be unique with respect to every other keyboard accelerator in this file.</comment>
+  </data>
+  <data name="TextCommandKeyboardAcceleratorKeyCopy" xml:space="preserve">
+    <value>C</value>
+    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for copying - Ctrl+C. Must be unique with respect to every other keyboard accelerator in this file.</comment>
+  </data>
+  <data name="TextCommandKeyboardAcceleratorKeyCut" xml:space="preserve">
+    <value>X</value>
+    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for cutting - Ctrl+X. Must be unique with respect to every other keyboard accelerator in this file.</comment>
+  </data>
+  <data name="TextCommandKeyboardAcceleratorKeyItalic" xml:space="preserve">
+    <value>I</value>
+    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for italicizing - Ctrl+I. Must be unique with respect to every other keyboard accelerator in this file.</comment>
+  </data>
+  <data name="TextCommandKeyboardAcceleratorKeyPaste" xml:space="preserve">
+    <value>V</value>
+    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for pasting - Ctrl+V. Must be unique with respect to every other keyboard accelerator in this file.</comment>
+  </data>
+  <data name="TextCommandKeyboardAcceleratorKeyRedo" xml:space="preserve">
+    <value>Y</value>
+    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for redoing - Ctrl+Y. Must be unique with respect to every other keyboard accelerator in this file.</comment>
+  </data>
+  <data name="TextCommandKeyboardAcceleratorKeySelectAll" xml:space="preserve">
+    <value>A</value>
+    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for selecting all - Ctrl+A. Must be unique with respect to every other keyboard accelerator in this file.</comment>
+  </data>
+  <data name="TextCommandKeyboardAcceleratorKeyUnderline" xml:space="preserve">
+    <value>U</value>
+    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for underlining - Ctrl+U. Must be unique with respect to every other keyboard accelerator in this file.</comment>
+  </data>
+  <data name="TextCommandKeyboardAcceleratorKeyUndo" xml:space="preserve">
+    <value>Z</value>
+    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for undoing - Ctrl+Z. Must be unique with respect to every other keyboard accelerator in this file.</comment>
+  </data>
+  <data name="TextCommandLabelBold" xml:space="preserve">
+    <value>Fett</value>
+  </data>
+  <data name="TextCommandLabelCopy" xml:space="preserve">
+    <value>Kopieren</value>
+  </data>
+  <data name="TextCommandLabelCut" xml:space="preserve">
+    <value>Ausschneiden</value>
+  </data>
+  <data name="TextCommandLabelItalic" xml:space="preserve">
+    <value>Kursiv</value>
+  </data>
+  <data name="TextCommandLabelPaste" xml:space="preserve">
+    <value>Einfügen</value>
+  </data>
+  <data name="TextCommandLabelRedo" xml:space="preserve">
+    <value>Wiederholen</value>
+  </data>
+  <data name="TextCommandLabelSelectAll" xml:space="preserve">
+    <value>Alles auswählen</value>
+  </data>
+  <data name="TextCommandLabelUnderline" xml:space="preserve">
+    <value>Unterstreichen</value>
+  </data>
+  <data name="TextCommandLabelUndo" xml:space="preserve">
+    <value>Rückgängig machen</value>
   </data>
 </root>

--- a/test/ModernWpf.WinUI.Tests/Localization/GermanResourceFallbackTests.cs
+++ b/test/ModernWpf.WinUI.Tests/Localization/GermanResourceFallbackTests.cs
@@ -1,0 +1,103 @@
+using System.Globalization;
+using System.Reflection;
+using System.Resources;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModernWpf.Controls;
+
+namespace ModernWpf.WinUI.Tests.Localization;
+
+[TestClass]
+public class GermanResourceFallbackTests
+{
+    [TestMethod]
+    [DataRow("de-DE")]
+    [DataRow("de-CH")]
+    [DataRow("de")]
+    public void GermanResourcesFallBackAcrossGermanCultures(string cultureName)
+    {
+        var culture = CultureInfo.GetCultureInfo(cultureName);
+
+        foreach (var resource in GetGermanResources())
+        {
+            var resourceManager = new ResourceManager(resource.BaseName, resource.Assembly);
+            Assert.AreEqual(
+                resource.ExpectedValue,
+                resourceManager.GetString(resource.Key, culture),
+                $"{resource.BaseName}.{resource.Key} did not use German for {cultureName}.");
+        }
+    }
+
+    private static GermanResource[] GetGermanResources()
+    {
+        var coreAssembly = typeof(TextContextMenu).Assembly;
+        var controlsAssembly = typeof(global::ModernWpf.Controls.NumberBox).Assembly;
+
+        return new[]
+        {
+            new GermanResource(
+                coreAssembly,
+                "ModernWpf.ProgressBar.Strings.Resources",
+                "ProgressBarErrorStatus",
+                "Fehler"),
+            new GermanResource(
+                coreAssembly,
+                "ModernWpf.Resources.Strings",
+                "AppBarMoreButtonClosedToolTip",
+                "Weitere Infos"),
+            new GermanResource(
+                coreAssembly,
+                "ModernWpf.TextContextMenu.Strings.Resources",
+                "ProofingMenuItemLabel",
+                "Dokumentprüfung"),
+            new GermanResource(
+                controlsAssembly,
+                "ModernWpf.Controls.NavigationView.Strings.Resources",
+                "NavigationButtonClosedName",
+                "Navigation öffnen"),
+            new GermanResource(
+                controlsAssembly,
+                "ModernWpf.Controls.NumberBox.Strings.Resources",
+                "NumberBoxDownSpinButtonName",
+                "Verringerung"),
+            new GermanResource(
+                controlsAssembly,
+                "ModernWpf.Controls.PersonPicture.Strings.Resources",
+                "BadgeItemPlural1",
+                "{0}, {1:d} Elemente"),
+            new GermanResource(
+                controlsAssembly,
+                "ModernWpf.Controls.ProgressRing.Strings.Resources",
+                "ProgressRingIndeterminateStatus",
+                "Beschäftigt"),
+            new GermanResource(
+                controlsAssembly,
+                "ModernWpf.Controls.RatingControl.Strings.Resources",
+                "BasicRatingString",
+                "Bewertung, {0} von {1}"),
+            new GermanResource(
+                controlsAssembly,
+                "ModernWpf.Controls.SplitButton.Strings.Resources",
+                "SplitButtonSecondaryButtonName",
+                "Weitere Optionen")
+        };
+    }
+
+    private sealed class GermanResource
+    {
+        public GermanResource(Assembly assembly, string baseName, string key, string expectedValue)
+        {
+            Assembly = assembly;
+            BaseName = baseName;
+            Key = key;
+            ExpectedValue = expectedValue;
+        }
+
+        public Assembly Assembly { get; }
+
+        public string BaseName { get; }
+
+        public string Key { get; }
+
+        public string ExpectedValue { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- move the existing German resources from the region-specific `de-DE` satellite to the neutral `de` satellite
- preserve `de-DE` behavior while enabling standard .NET fallback for `de-CH` and neutral `de`
- add a regression that checks all nine German resource packs in both assemblies across `de-DE`, `de-CH`, and `de`

## Reproduction
Before the fix, the new regression passed for `de-DE` but failed for `de-CH` and `de`: `ResourceManager` returned English (`Error`) instead of German (`Fehler`).

## Validation
- focused German fallback regression: 3/3 passed
- `dotnet restore ModernWpf.sln`
- Release solution build: 0 warnings, 0 errors
- complete `ModernWpf.WinUI.Tests` suite: 1,031/1,031 passed, zero skips, three consecutive runs
- NuGet package verification passed
- package contains both assemblies under `lib/<tfm>/de/` for all three supported targets and no `de-DE` satellite files
- package consumer smoke matrix: 6/6 passed (`FluentControlsResources` and `XamlControlsResources` on net462, net8, and net10)

Closes #394