### PR TITLE
Honor scoped client-area animation settings

### DIFF
--- a/ModernWpf/VisualStateManager/SimpleVisualStateManager.cs
+++ b/ModernWpf/VisualStateManager/SimpleVisualStateManager.cs
@@ -21,7 +21,9 @@ namespace ModernWpf
         {
             if (state != null)
             {
-                useTransitions &= Helper.IsAnimationsEnabled;
+                useTransitions &= AreAnimationsEnabled(
+                    stateGroupsRoot ?? control,
+                    Helper.IsAnimationsEnabled);
 
                 if (group.Transitions.Count > 0 && VisualStateGroupHelper.IsSupported)
                 {
@@ -34,6 +36,20 @@ namespace ModernWpf
             }
 
             return false;
+        }
+
+        internal static bool AreAnimationsEnabled(
+            FrameworkElement resourceScope,
+            bool systemAnimationsEnabled)
+        {
+            if (!systemAnimationsEnabled)
+            {
+                return false;
+            }
+
+            return resourceScope == null ||
+                   !(resourceScope.TryFindResource(SystemParameters.ClientAreaAnimationKey) is bool isEnabled) ||
+                   isEnabled;
         }
 
         #region VisualStateGroups

--- a/docs/contentdialog-winui3-source-audit.md
+++ b/docs/contentdialog-winui3-source-audit.md
@@ -135,6 +135,11 @@ unrelated warnings.
   window-scoped ownership.
 - WinUI compositor shadows and DComp validation are represented through
   `ThemeShadowChrome` with the source depth rather than native composition.
+- WPF visual-state transitions keep the operating-system animation preference
+  and render tier as an upper bound. A scoped
+  `SystemParameters.ClientAreaAnimationKey=false` resource can additionally
+  suppress the ContentDialog transition, matching standard WPF resource
+  customization without forcing animation when the system has disabled it.
 - WinUI `XamlUICommand` label, keyboard-accelerator, description, and tooltip
   binding has no direct ModernWpf command type; WPF `ICommand` execution and
   parameters are preserved.

--- a/test/ModernWpf.WinUI.Tests/VisualStateManager/VisualStateSetterTests.cs
+++ b/test/ModernWpf.WinUI.Tests/VisualStateManager/VisualStateSetterTests.cs
@@ -314,6 +314,70 @@ public class VisualStateSetterTests
     }
 
     [TestMethod]
+    public void ClientAreaAnimationResourceCanDisableTransitions()
+    {
+        WpfTestHost.Run(() =>
+        {
+            var control = CreateControl(
+                """
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualStateGroup.Transitions>
+                        <VisualTransition To="PointerOver">
+                            <Storyboard>
+                                <DoubleAnimation
+                                    Storyboard.TargetName="TargetBorder"
+                                    Storyboard.TargetProperty="Opacity"
+                                    To="0.25"
+                                    Duration="0:0:10" />
+                            </Storyboard>
+                        </VisualTransition>
+                    </VisualStateGroup.Transitions>
+                    <VisualState x:Name="Normal">
+                        <Storyboard>
+                            <DoubleAnimation
+                                Storyboard.TargetName="TargetBorder"
+                                Storyboard.TargetProperty="Opacity"
+                                To="1"
+                                Duration="0" />
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="PointerOver">
+                        <Storyboard>
+                            <DoubleAnimation
+                                Storyboard.TargetName="TargetBorder"
+                                Storyboard.TargetProperty="Opacity"
+                                To="0.25"
+                                Duration="0" />
+                        </Storyboard>
+                    </VisualState>
+                </VisualStateGroup>
+                """,
+                """
+                <Border x:Name="TargetBorder" Opacity="1" />
+                """);
+
+            using var host = new TestWindowHost(control);
+            var target = FindTemplateChild<Border>(control, "TargetBorder");
+
+            control.Resources[SystemParameters.ClientAreaAnimationKey] = true;
+            Assert.IsTrue(SimpleVisualStateManager.AreAnimationsEnabled(control, true));
+            Assert.IsFalse(SimpleVisualStateManager.AreAnimationsEnabled(control, false));
+
+            control.Resources[SystemParameters.ClientAreaAnimationKey] = false;
+            Assert.IsFalse(SimpleVisualStateManager.AreAnimationsEnabled(control, true));
+            Assert.IsFalse(SimpleVisualStateManager.AreAnimationsEnabled(control, false));
+
+            Assert.IsTrue(System.Windows.VisualStateManager.GoToState(control, "Normal", false));
+            WpfTestHost.DoEvents();
+            Assert.AreEqual(1.0, target.Opacity, 0.01);
+
+            Assert.IsTrue(System.Windows.VisualStateManager.GoToState(control, "PointerOver", true));
+            WpfTestHost.DoEvents();
+            Assert.AreEqual(0.25, target.Opacity, 0.01);
+        });
+    }
+
+    [TestMethod]
     public void VisualStateExThrowsForMissingTarget()
     {
         WpfTestHost.Run(() =>


### PR DESCRIPTION
Fixes #365.

## Summary
- let ModernWpf visual-state transitions honor a scoped `SystemParameters.ClientAreaAnimationKey=false` resource
- retain the operating-system animation preference and render tier as an upper bound, so an application cannot force animations when Windows has disabled them
- document the WPF ContentDialog adaptation and add a focused transition regression

## Validation
- red regression before fix: 0 passed, 1 failed (`expected 0.25`, `actual 1`)
- focused regression after fix: 1 passed, 0 failed, 0 skipped
- VisualStateManager + ContentDialog slices: 31 passed, 0 failed, 0 skipped
- `dotnet restore ModernWpf.sln`
- `dotnet build ModernWpf.sln --configuration Release --no-restore` — 0 warnings, 0 errors
- complete `ModernWpf.WinUI.Tests` on `net8.0-windows7.0`: 1,033 passed, 0 failed, 0 skipped