### PR TITLE
Fix targeted color palette refresh

### DIFF
--- a/ModernWpf/ColorPaletteResources.cs
+++ b/ModernWpf/ColorPaletteResources.cs
@@ -415,7 +415,35 @@ namespace ModernWpf
             var overrides = new ResourceDictionary();
             var originalsToOverrides = new Dictionary<SolidColorBrush, SolidColorBrush>();
 
-            // TODO: recursive
+            AddBrushOverrides(
+                originals,
+                overrides,
+                originalsToOverrides,
+                new HashSet<ResourceDictionary>());
+
+            MergedDictionaries.Add(overrides);
+        }
+
+        private void AddBrushOverrides(
+            ResourceDictionary originals,
+            ResourceDictionary overrides,
+            Dictionary<SolidColorBrush, SolidColorBrush> originalsToOverrides,
+            HashSet<ResourceDictionary> visited)
+        {
+            if (!visited.Add(originals))
+            {
+                return;
+            }
+
+            foreach (var mergedDictionary in originals.MergedDictionaries)
+            {
+                AddBrushOverrides(
+                    mergedDictionary,
+                    overrides,
+                    originalsToOverrides,
+                    visited);
+            }
+
             foreach (DictionaryEntry entry in originals)
             {
                 if (entry.Value is SolidColorBrush originalBrush)
@@ -429,12 +457,10 @@ namespace ModernWpf
                             overrideBrush.Color = (Color)this[colorKey];
                             originalsToOverrides[originalBrush] = overrideBrush;
                         }
-                        overrides.Add(entry.Key, overrideBrush);
+                        overrides[entry.Key] = overrideBrush;
                     }
                 }
             }
-
-            MergedDictionaries.Add(overrides);
         }
 
         #region ISupportInitialize

--- a/test/ModernWpf.Theme.Tests/ColorsHelperTests.cs
+++ b/test/ModernWpf.Theme.Tests/ColorsHelperTests.cs
@@ -99,6 +99,40 @@ public class ColorsHelperTests
     }
 
     [TestMethod]
+    public void TargetedColorPaletteKeepsCustomAccentAcrossGlobalPaletteRefresh()
+    {
+        WpfTestHost.Run(() =>
+        {
+            ThemeTestApplication.EnsureInitialized();
+
+            var themeManager = ThemeManager.Current;
+            var originalAccent = themeManager.AccentColor;
+            var customAccent = Color.FromRgb(0xE0, 0x20, 0x30);
+            var palette = new ColorPaletteResources
+            {
+                TargetTheme = ApplicationTheme.Light,
+                Accent = customAccent
+            };
+            var accentBrush =
+                (SolidColorBrush)palette["SystemControlForegroundAccentBrush"];
+            Assert.AreEqual(customAccent, accentBrush.Color);
+
+            try
+            {
+                themeManager.AccentColor = Color.FromRgb(0x20, 0x60, 0xC0);
+                WpfTestHost.DoEvents();
+
+                Assert.AreEqual(customAccent, accentBrush.Color);
+            }
+            finally
+            {
+                themeManager.AccentColor = originalAccent;
+                WpfTestHost.DoEvents();
+            }
+        });
+    }
+
+    [TestMethod]
     [DataRow("Light", "SystemAccentColorDark1")]
     [DataRow("Dark", "SystemAccentColorLight2")]
     [DataRow("HighContrast", "SystemAccentColorLight2")]


### PR DESCRIPTION
## Summary

- recurse through merged default-theme dictionaries when `ColorPaletteResources` creates targeted brush overrides
- preserve WPF resource precedence while sharing clones for aliased brush resources
- add a regression proving a targeted custom accent survives a global accent refresh

## Context

While validating #356, the supported `TargetTheme` path exposed a current 1.x regression: the stable default-theme wrapper introduced by #701 moved the source brushes into a merged dictionary, but `ColorPaletteResources` still scanned only the outer dictionary. As a result, it created no targeted brush overrides.

The original #356 markup also needs `TargetTheme="Light"` and `TargetTheme="Dark"` on its per-theme palettes; this PR restores that supported path.

## Validation

- pre-fix focused repro: 0 passed, 1 failed (missing targeted brush override)
- `dotnet test .\test\ModernWpf.Theme.Tests\ModernWpf.Theme.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-restore --filter "FullyQualifiedName~TargetedColorPaletteKeepsCustomAccentAcrossGlobalPaletteRefresh" --logger "console;verbosity=minimal"`: 1 passed, 0 failed, 0 skipped
- same project, `ColorsHelperTests` filter with `--no-build --no-restore`: 7 passed, 0 failed, 0 skipped
- complete affected project on `net8.0-windows7.0`: 17 passed, 0 failed, 0 skipped
- complete affected project on `net10.0-windows7.0`: 20 passed, 0 failed, 0 skipped
- `dotnet restore ModernWpf.sln`: succeeded
- `dotnet build ModernWpf.sln --configuration Release --no-restore --verbosity minimal`: succeeded with 0 warnings and 0 errors

No public API or public resource-key shape changed, so package-surface verification was not required.