### PR TITLE
Fix auto-hide taskbar activation for maximized windows

### DIFF
--- a/ModernWpf/Controls/Primitives/MaximizedWindowFixer.cs
+++ b/ModernWpf/Controls/Primitives/MaximizedWindowFixer.cs
@@ -183,21 +183,29 @@ namespace ModernWpf.Controls.Primitives
                         {
                             MONITORINFO info = NativeMethods.GetMonitorInfo(monitor);
                             bool primary = (info.dwFlags & MONITORINFOF_PRIMARY) != 0;
-                            if (primary)
+                            var proposedBounds = new Int32Rect(pos.x, pos.y, pos.cx, pos.cy);
+                            var monitorBounds = new Int32Rect(
+                                info.rcMonitor.Left,
+                                info.rcMonitor.Top,
+                                info.rcMonitor.Width,
+                                info.rcMonitor.Height);
+                            if (primary &&
+                                TryGetTaskbarAdjustedWindowBounds(
+                                    proposedBounds,
+                                    monitorBounds,
+                                    edge,
+                                    out Int32Rect adjustedBounds))
                             {
-                                if (pos.x < 0 &&
-                                    pos.y < 0 &&
-                                    pos.cx > info.rcMonitor.Width &&
-                                    pos.cy > info.rcMonitor.Height)
+                                if (adjustedBounds != proposedBounds)
                                 {
-                                    AdjustWindowPosForTaskbarAutoHide(ref pos, edge);
+                                    pos.x = adjustedBounds.X;
+                                    pos.y = adjustedBounds.Y;
+                                    pos.cx = adjustedBounds.Width;
+                                    pos.cy = adjustedBounds.Height;
                                     Marshal.StructureToPtr(pos, lParam, true);
-                                    windowPosAdjusted = true;
                                 }
-                                else if (pos.x == 0 && pos.y == 0)
-                                {
-                                    windowPosAdjusted = true;
-                                }
+
+                                windowPosAdjusted = true;
                             }
                         }
                     }
@@ -254,64 +262,93 @@ namespace ModernWpf.Controls.Primitives
                 APPBARDATA abd = new APPBARDATA();
                 abd.cbSize = Marshal.SizeOf(abd);
                 abd.hWnd = trayWnd;
-                SHAppBarMessage(ABMsg.ABM_GETTASKBARPOS, ref abd);
-                bool autoHide = Convert.ToBoolean(SHAppBarMessage(ABMsg.ABM_GETSTATE, ref abd));
-                edge = autoHide ? GetEdge(abd.rc) : default;
-                return autoHide;
+                bool hasTaskbarPosition =
+                    SHAppBarMessage(ABMsg.ABM_GETTASKBARPOS, ref abd) != 0;
+                bool autoHide =
+                    IsTaskbarAutoHideState(SHAppBarMessage(ABMsg.ABM_GETSTATE, ref abd));
+                bool hasKnownEdge =
+                    abd.uEdge >= (int)ABEdge.ABE_LEFT &&
+                    abd.uEdge <= (int)ABEdge.ABE_BOTTOM;
+
+                if (hasTaskbarPosition && autoHide && hasKnownEdge)
+                {
+                    edge = (ABEdge)abd.uEdge;
+                    return true;
+                }
             }
 
             edge = default;
             return false;
-
-            static ABEdge GetEdge(RECT rc)
-            {
-                if (rc.Top == rc.Left && rc.Bottom > rc.Right)
-                {
-                    return ABEdge.ABE_LEFT;
-                }
-                else if (rc.Top == rc.Left && rc.Bottom < rc.Right)
-                {
-                    return ABEdge.ABE_TOP;
-                }
-                else if (rc.Top > rc.Left)
-                {
-                    return ABEdge.ABE_BOTTOM;
-                }
-                else
-                {
-                    return ABEdge.ABE_RIGHT;
-                }
-            }
         }
 
-        private static void AdjustWindowPosForTaskbarAutoHide(ref WINDOWPOS pos, ABEdge edge)
+        internal static bool IsTaskbarAutoHideState(uint state)
         {
-            pos.cx += pos.x * 2;
-            pos.cy += pos.y * 2;
-            pos.x = 0;
-            pos.y = 0;
+            return (state & AbsAutoHide) != 0;
+        }
+
+        internal static bool TryGetTaskbarAdjustedWindowBounds(
+            Int32Rect proposedBounds,
+            Int32Rect monitorBounds,
+            ABEdge edge,
+            out Int32Rect adjustedBounds)
+        {
+            adjustedBounds = proposedBounds;
+            Int32Rect taskbarAdjustedBounds =
+                GetTaskbarAdjustedMonitorBounds(monitorBounds, edge);
+
+            if (proposedBounds == taskbarAdjustedBounds)
+            {
+                return true;
+            }
+
+            bool coversMonitor =
+                proposedBounds.X <= monitorBounds.X &&
+                proposedBounds.Y <= monitorBounds.Y &&
+                proposedBounds.X + proposedBounds.Width >=
+                    monitorBounds.X + monitorBounds.Width &&
+                proposedBounds.Y + proposedBounds.Height >=
+                    monitorBounds.Y + monitorBounds.Height;
+
+            if (coversMonitor)
+            {
+                adjustedBounds = taskbarAdjustedBounds;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static Int32Rect GetTaskbarAdjustedMonitorBounds(
+            Int32Rect monitorBounds,
+            ABEdge edge)
+        {
+            var adjustedBounds = monitorBounds;
 
             switch (edge)
             {
                 case ABEdge.ABE_LEFT:
-                    pos.x = 2;
-                    pos.cx -= 2;
+                    adjustedBounds.X += AutoHideRevealThickness;
+                    adjustedBounds.Width -= AutoHideRevealThickness;
                     break;
                 case ABEdge.ABE_TOP:
-                    pos.y = 2;
-                    pos.cy -= 2;
+                    adjustedBounds.Y += AutoHideRevealThickness;
+                    adjustedBounds.Height -= AutoHideRevealThickness;
                     break;
                 case ABEdge.ABE_RIGHT:
-                    pos.cx -= 2;
+                    adjustedBounds.Width -= AutoHideRevealThickness;
                     break;
                 case ABEdge.ABE_BOTTOM:
-                    pos.cy -= 2;
+                    adjustedBounds.Height -= AutoHideRevealThickness;
                     break;
             }
+
+            return adjustedBounds;
         }
 
         #region Win32 Interop
 
+        private const uint AbsAutoHide = 0x00000001;
+        private const int AutoHideRevealThickness = 2;
         private const int MONITOR_DEFAULTTONEAREST = 0x00000002;
         private const int MONITORINFOF_PRIMARY = 0x00000001;
 
@@ -322,7 +359,7 @@ namespace ModernWpf.Controls.Primitives
             WM_WINDOWPOSCHANGED = 0x0047,
         }
 
-        private enum ABEdge
+        internal enum ABEdge
         {
             ABE_LEFT = 0,
             ABE_TOP = 1,
@@ -344,7 +381,7 @@ namespace ModernWpf.Controls.Primitives
             public int uCallbackMessage;
             public int uEdge;
             public RECT rc;
-            public bool lParam;
+            public IntPtr lParam;
         }
 
         [DllImport("shell32", CallingConvention = CallingConvention.StdCall)]

--- a/docs/window-wpf-fluent-source-audit.md
+++ b/docs/window-wpf-fluent-source-audit.md
@@ -58,6 +58,10 @@ ModernWpf now follows the compatible parts of that source shape:
   to `CaptionHeight`. Caption-button bounds use half-open right/bottom edges,
   while title dragging, side/bottom resize borders, and explicit resize grips
   retain their native hit-test codes.
+- A maximized custom-chrome window leaves a two-device-pixel reveal strip on
+  the primary auto-hide taskbar edge, including when Windows proposes bounds
+  that already exactly match the monitor. The shell state check tests the
+  `ABS_AUTOHIDE` flag instead of treating `ABS_ALWAYSONTOP` as auto-hide.
 - `WindowStyle=None` suppresses the ModernWpf title bar, detaches the custom
   `WindowChrome`, and lets content fill the captionless client area.
 
@@ -99,6 +103,9 @@ surface.
   first four content pixels below the title bar and verifies `HTCLIENT`, while
   separately retaining `HTCAPTION` for draggable title space and
   `HTBOTTOMRIGHT` for the explicit resize grip.
+- `WindowVisualStateTests` verifies that full-monitor maximized bounds are
+  reduced once at the auto-hide taskbar edge and that the Win32 state parser
+  distinguishes `ABS_AUTOHIDE` from `ABS_ALWAYSONTOP`.
 - `WindowVisualStateTests` verifies that `WindowStyle=None` collapses the
   ModernWpf title bar, removes custom chrome/maximized-window compensation, and
   places content at the top of the client area.

--- a/test/ModernWpf.WinUI.Tests/CommonStyles/WindowVisualStateTests.cs
+++ b/test/ModernWpf.WinUI.Tests/CommonStyles/WindowVisualStateTests.cs
@@ -98,6 +98,43 @@ public class WindowVisualStateTests
     }
 
     [TestMethod]
+    public void MaximizedWindowLeavesRevealStripForAutoHideTaskbar()
+    {
+        var monitorBounds = new Int32Rect(0, 0, 1920, 1080);
+
+        Assert.IsFalse(
+            MaximizedWindowFixer.IsTaskbarAutoHideState(0x00000000),
+            "No taskbar state flags must not be treated as auto-hide.");
+        Assert.IsFalse(
+            MaximizedWindowFixer.IsTaskbarAutoHideState(0x00000002),
+            "ABS_ALWAYSONTOP alone must not be treated as auto-hide.");
+        Assert.IsTrue(MaximizedWindowFixer.IsTaskbarAutoHideState(0x00000001));
+        Assert.IsTrue(MaximizedWindowFixer.IsTaskbarAutoHideState(0x00000003));
+
+        Assert.IsTrue(
+            MaximizedWindowFixer.TryGetTaskbarAdjustedWindowBounds(
+                monitorBounds,
+                monitorBounds,
+                MaximizedWindowFixer.ABEdge.ABE_BOTTOM,
+                out Int32Rect adjustedBounds));
+        Assert.AreEqual(
+            new Int32Rect(0, 0, 1920, 1078),
+            adjustedBounds,
+            "A monitor-sized maximized window must leave the auto-hide taskbar activation edge uncovered.");
+
+        Assert.IsTrue(
+            MaximizedWindowFixer.TryGetTaskbarAdjustedWindowBounds(
+                adjustedBounds,
+                monitorBounds,
+                MaximizedWindowFixer.ABEdge.ABE_BOTTOM,
+                out Int32Rect readjustedBounds));
+        Assert.AreEqual(
+            adjustedBounds,
+            readjustedBounds,
+            "Repeated window-position messages must not shrink the maximized window more than once.");
+    }
+
+    [TestMethod]
     public void WindowTemplateUsesWpfContentPresenterAndKeepsCustomTitleBar()
     {
         WpfTestHost.Run(() =>


### PR DESCRIPTION
Closes #323.

## What changed

- reserve the existing two-device-pixel reveal strip even when Windows proposes maximized bounds that already exactly match the monitor
- make the bounds adjustment idempotent across repeated `WM_WINDOWPOSCHANGING` messages
- test `ABS_AUTOHIDE` explicitly instead of treating `ABS_ALWAYSONTOP` as auto-hide
- use the taskbar edge reported by `ABM_GETTASKBARPOS`
- correct the pointer-sized `APPBARDATA.lParam` interop field
- document the custom WindowChrome behavior in the WPF Fluent window audit

## Reproduction

The regression test models the native full-monitor proposal (`0,0,1920,1080`) reported by the maximized custom-chrome path. Before the fix it failed because the result stayed `1920x1080`; after the fix it reserves the bottom activation strip as `1920x1078` and remains stable when processed again.

This desktop's taskbar is not configured for auto-hide, so I did not mutate the user's OS setting; native bounds behavior is covered deterministically instead.

## Validation

- pre-fix regression: 1 failed (expected `0,0,1920,1078`; actual `0,0,1920,1080`)
- post-fix regression: 1 passed, 0 failed, 0 skipped
- window/title-bar slice: 17 passed, 0 failed, 0 skipped
- `dotnet restore ModernWpf.sln`: succeeded
- `dotnet build ModernWpf.sln --configuration Release --no-restore`: succeeded, 0 warnings, 0 errors across `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0`
- complete `ModernWpf.WinUI.Tests` (`net8.0-windows7.0`): 1,044 passed, 0 failed, 0 skipped
- scoped `dotnet format --verify-no-changes`: passed
- `git diff --check`: passed