### PR TITLE
Fix top navigation overflow layout loop

### DIFF
--- a/ModernWpf.Controls/NavigationView/NavigationView.cs
+++ b/ModernWpf.Controls/NavigationView/NavigationView.cs
@@ -66,6 +66,7 @@ namespace ModernWpf.Controls
 
         // DisplayMode Top specific items
         const string c_topNavMenuItemsHost = "TopNavMenuItemsHost";
+        const string c_topNavMenuItemsScrollHost = "TopNavMenuItemsScrollHost";
         const string c_topNavFooterMenuItemsHost = "TopFooterMenuItemsHost";
         const string c_topNavOverflowButton = "TopNavOverflowButton";
         const string c_topNavMenuItemsOverflowHost = "TopNavMenuItemsOverflowHost";
@@ -183,6 +184,7 @@ namespace ModernWpf.Controls
                 m_topNavRepeaterGettingFocusHelper?.Dispose();
                 m_topNavRepeater = null;
             }
+            m_topNavMenuItemsScrollHost = null;
 
             if (m_leftNavFooterMenuRepeater != null)
             {
@@ -510,6 +512,7 @@ namespace ModernWpf.Controls
             }
 
             m_topNavGrid = GetTemplateChild(c_topNavGrid) as Grid;
+            m_topNavMenuItemsScrollHost = GetTemplateChild(c_topNavMenuItemsScrollHost) as FrameworkElement;
 
             // Change code to NOT do this if we're in top nav mode, to prevent it from being realized:
             if (GetTemplateChild(c_menuItemsHost) is ItemsRepeater leftNavRepeater)
@@ -1452,6 +1455,7 @@ namespace ModernWpf.Controls
                 {
                     // We have infinite space, so move all items to primary list
                     m_topDataProvider.MoveAllItemsToPrimaryList();
+                    UpdateTopNavigationPrimaryItemsHostMaxWidth(availableSize);
                 }
                 else
                 {
@@ -3707,6 +3711,33 @@ namespace ModernWpf.Controls
             {
                 m_topNavigationMode = TopNavigationViewLayoutState.Initialized;
             }
+
+            UpdateTopNavigationPrimaryItemsHostMaxWidth(availableSize);
+        }
+
+        void UpdateTopNavigationPrimaryItemsHostMaxWidth(Size availableSize)
+        {
+            if (m_topNavMenuItemsScrollHost is not { } primaryItemsHost)
+            {
+                return;
+            }
+
+            var maxWidth = double.PositiveInfinity;
+            if (!double.IsInfinity(availableSize.Width) &&
+                HasTopNavigationViewItemNotInPrimaryList())
+            {
+                var desiredWidth = MeasureTopNavigationViewDesiredWidth(c_infSize);
+                var currentPrimaryItemsHostWidth =
+                    LayoutUtils.MeasureAndGetDesiredWidthFor(primaryItemsHost, c_infSize);
+                var widthOutsidePrimaryItemsHost =
+                    Math.Max(0.0, desiredWidth - currentPrimaryItemsHostWidth);
+                maxWidth = Math.Max(0.0, availableSize.Width - widthOutsidePrimaryItemsHost);
+            }
+
+            if (primaryItemsHost.MaxWidth != maxWidth)
+            {
+                primaryItemsHost.SetCurrentValue(MaxWidthProperty, maxWidth);
+            }
         }
 
         void HandleTopNavigationMeasureOverrideNormal(Size availableSize)
@@ -5876,6 +5907,7 @@ namespace ModernWpf.Controls
         Button m_closeButton;
         ItemsRepeater m_leftNavRepeater;
         ItemsRepeater m_topNavRepeater;
+        FrameworkElement m_topNavMenuItemsScrollHost;
         ItemsRepeater m_leftNavFooterMenuRepeater;
         ItemsRepeater m_topNavFooterMenuRepeater;
         Button m_topNavOverflowButton;

--- a/ModernWpf.Controls/NavigationView/NavigationView.xaml
+++ b/ModernWpf.Controls/NavigationView/NavigationView.xaml
@@ -1408,6 +1408,7 @@
 
                                     <!-- Top nav ItemsRepeater -->
                                     <local:ItemsRepeaterScrollHost
+                                        x:Name="TopNavMenuItemsScrollHost"
                                         Grid.Column="3">
                                         <ScrollViewer
                                             HorizontalScrollBarVisibility="Hidden"

--- a/docs/navigationview-winui3-source-audit.md
+++ b/docs/navigationview-winui3-source-audit.md
@@ -112,6 +112,7 @@ API controls are covered by the focused Gallery regression.
 | WinUI Gallery renders the in-app acrylic pane over its default Light/Dark page as solid sampled colors `#F2F2F2` / `#1F1F1F`; its content is `#F9F9F9` / `#272727`. | WPF has no acrylic compositor. `SystemControlPageBackgroundChromeLowBrush` and `SystemControlBackgroundChromeMediumBrush` are deterministic theme-specific solid fallbacks for the rendered pane, while `LayerFillColorDefaultBrush` supplies the exact content surface. |
 | Current item and top-item normal/hover/pressed/selected foregrounds use primary or secondary text aliases, and hover/pressed top backgrounds use subtle secondary/tertiary fills. | ModernWpf replaces the stale WinUI 2 aliases with the current primary/secondary and subtle-fill resource graph in Light, Dark, and High Contrast. |
 | The left presenter places its 3x16 selection indicator at the item background origin. Top primary presenters use the 4,2 item-button margin and arrange the 16x3 horizontal indicator at the bottom of the 48-DIP top strip. | The local-only second 4-DIP left-indicator inset is removed. Current pane-list spacing and top-grid/item margins are ported. Because WPF measures a horizontal repeater inside `ScrollViewer` with an infinite cross-axis, the top presenter has an explicit 48-DIP minimum-height adapter; the resulting Gallery item fills the strip and its indicator renders below, rather than through, the label. |
+| Top navigation measures the primary items against the width remaining after pane header, overflow, custom content, search, pane footer, and footer items, then moves excess items to overflow. | WPF's `ScrollViewer` otherwise retains the initial unconstrained repeater slot after the split collection shrinks. The named primary scroll host now receives an adaptive `MaxWidth` equal to the actual remaining top-pane width while overflow is active, and returns to an unconstrained width once every item fits. |
 | Current `NavigationView` defers `SplitView.DisplayMode` changes made by `OnApplyTemplate` until `Loaded`, using `m_fromOnApplyTemplate` and `m_updateVisualStateForDisplayModeFromOnLoaded`. | ModernWpf now ports both lifecycle guards. WPF can apply an offscreen control's template after it is already loaded, so that path queues the same completion at `DispatcherPriority.Loaded`. `UpdateIsClosedCompact` also synchronizes `PaneStateListSizeGroup` with the authoritative SplitView state when WPF reaches a closed/open value without the WinUI pane lifecycle event. This prevents `ClosedCompact` from coexisting with stale `ListSizeFull`. |
 | The WinUI Gallery default example is `nvSample5`, 745x460, with `Sample Page 1`, four symbol items, a source `BodyTextBlockStyle` paragraph, and selection-driven `Sample Page N` headers. | The generated Gallery sample preserves the exact host size, symbols/tags, source body style and foreground, and selection behavior. A one-physical-pixel WPF text-origin adapter aligns the source paragraph, header, and content offsets without changing tile geometry or hit targets. |
 | The current Gallery exposes eight independently rendered NavigationViews. At the reference viewport the first five are 745x460, footer is 592x460, hierarchy is 565x460, and API is 458x540. Data binding and hierarchy initially show `Sample Page 1`; API starts with an empty Frame and a normal-text `Pane Title`. | All eight controls now have stable `GallerySample_NavigationView_*` artifact IDs and exact reference widths. The option-bearing samples no longer arrange at 745 DIPs and get clipped by narrower columns. Data binding/hierarchy restore their source initial headers, API uses a genuinely empty Frame until selection, and `PaneTitleTextBlock` explicitly uses `ContentControlThemeFontFamily` instead of inheriting the toggle button's symbol font. |
@@ -133,6 +134,12 @@ API controls are covered by the focused Gallery regression.
   coordinates. The horizontal top repeater requires a 48-DIP presenter
   minimum because WPF's `ScrollViewer` otherwise supplies an infinite
   cross-axis and leaves content-only items at their 24-DIP desired height.
+- WPF also retains the first unconstrained horizontal repeater arrange slot
+  after top-navigation overflow changes the split collection. The primary
+  `ItemsRepeaterScrollHost` is capped to the width left by the other top-pane
+  columns so viewport cache growth follows the visible pane instead of the
+  discarded multi-item extent. The cap is recomputed during resize and removed
+  when overflow is no longer needed.
 - Unlike WinUI's page realization order, WPF can raise `Loaded` for a collapsed
   or offscreen NavigationView before applying its control template. The port
   therefore completes the source display-mode deferral through the dispatcher
@@ -223,7 +230,11 @@ API controls are covered by the focused Gallery regression.
 - The WPF initial-window-layout substitute defers SplitView's state replay when
   dispatcher processing is suspended; the existing launch-state regression
   now covers the path without a nested-dispatcher exception.
-- NavigationView product/source-audit tests pass 59/59; SplitView product tests
+- `TopNavigationWithHeaderFooterConstrainsOverflowHostAndRemainsResponsive`
+  covers issue #319 with header, footer, 24 top items, overflow, an idle-layout
+  bound, and 768-to-1200-to-640 resize recovery. It also verifies that both the
+  primary scroll host and top grid remain inside the NavigationView width.
+- NavigationView product/source-audit tests pass 60/60; SplitView product tests
   pass 14/14; the focused Gallery sample/source-shape slice passes 7/7 on net8
   and net10. Gallery builds successfully on net462, net8, and net10 with zero
   errors; current target builds retain existing unrelated warnings.

--- a/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewIssue319Tests.cs
+++ b/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewIssue319Tests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModernWpf.WinUI.TestApp;
+using ModernWpf.WinUI.TestInfra;
+
+namespace ModernWpf.WinUI.Tests.NavigationView;
+
+[TestClass]
+public class NavigationViewIssue319Tests
+{
+    [TestMethod]
+    [Timeout(15000)]
+    public void TopNavigationWithHeaderFooterConstrainsOverflowHostAndRemainsResponsive()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var navView = new ModernWpf.Controls.NavigationView
+            {
+                Width = 768,
+                Height = 480,
+                PaneDisplayMode = ModernWpf.Controls.NavigationViewPaneDisplayMode.Top,
+                PaneHeader = new Border
+                {
+                    Width = 160,
+                    Child = new TextBlock { Text = "Pane header" }
+                },
+                PaneFooter = new Border
+                {
+                    Width = 160,
+                    Child = new TextBlock { Text = "Pane footer" }
+                },
+                IsSettingsVisible = false,
+                IsTitleBarAutoPaddingEnabled = false
+            };
+            for (var index = 0; index < 24; index++)
+            {
+                navView.MenuItems.Add(new ModernWpf.Controls.NavigationViewItem
+                {
+                    Content = $"Navigation item {index:00}"
+                });
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            using var host = new TestWindowHost(navView, width: 768, height: 480);
+            host.UpdateLayout();
+            WpfTestHost.DoEvents();
+            stopwatch.Stop();
+
+            var primaryRepeater = VisualTreeTestHelper.EnumerateDescendants(navView)
+                .OfType<ModernWpf.Controls.ItemsRepeater>()
+                .Single(element => element.Name == "TopNavMenuItemsHost");
+            var primaryScrollHost = VisualTreeTestHelper.EnumerateDescendants(navView)
+                .OfType<ModernWpf.Controls.ItemsRepeaterScrollHost>()
+                .Single(element => element.Name == "TopNavMenuItemsScrollHost");
+            var topNavGrid = VisualTreeTestHelper.EnumerateDescendants(navView)
+                .OfType<Grid>()
+                .Single(element => element.Name == "TopNavGrid");
+            var overflowButton = VisualTreeTestHelper.EnumerateDescendants(navView)
+                .OfType<Button>()
+                .Single(element => element.Name == "TopNavOverflowButton");
+            var topDataProvider = navView.GetTopDataProvider();
+
+            Assert.AreEqual(Visibility.Visible, overflowButton.Visibility);
+            Assert.IsTrue(topDataProvider.GetPrimaryListSize() > 0);
+            Assert.IsTrue(topDataProvider.GetOverflowItems().Count > 0);
+            Assert.AreEqual(
+                topDataProvider.GetPrimaryListSize(),
+                primaryRepeater.ItemsSourceView.Count);
+            Assert.IsTrue(stopwatch.Elapsed < TimeSpan.FromSeconds(5));
+            AssertTopNavigationIsConstrained(navView, primaryScrollHost, topNavGrid);
+
+            var idleLayoutUpdates = CountLayoutUpdates(navView, TimeSpan.FromSeconds(1));
+            Assert.IsTrue(
+                idleLayoutUpdates < 20,
+                $"The overflow layout must settle promptly. Count={idleLayoutUpdates}.");
+
+            var initialPrimaryCount = topDataProvider.GetPrimaryListSize();
+            Resize(host, navView, 1200);
+            var expandedPrimaryCount = topDataProvider.GetPrimaryListSize();
+
+            Assert.IsTrue(expandedPrimaryCount > initialPrimaryCount);
+            AssertTopNavigationIsConstrained(navView, primaryScrollHost, topNavGrid);
+
+            Resize(host, navView, 640);
+
+            Assert.IsTrue(topDataProvider.GetPrimaryListSize() < expandedPrimaryCount);
+            Assert.IsTrue(topDataProvider.GetOverflowItems().Count > 0);
+            AssertTopNavigationIsConstrained(navView, primaryScrollHost, topNavGrid);
+        });
+    }
+
+    private static void AssertTopNavigationIsConstrained(
+        ModernWpf.Controls.NavigationView navView,
+        FrameworkElement primaryScrollHost,
+        FrameworkElement topNavGrid)
+    {
+        Assert.IsTrue(double.IsFinite(primaryScrollHost.MaxWidth));
+        Assert.IsTrue(primaryScrollHost.MaxWidth <= navView.ActualWidth);
+        Assert.IsTrue(primaryScrollHost.ActualWidth <= navView.ActualWidth + 1.0);
+        Assert.IsTrue(topNavGrid.ActualWidth <= navView.ActualWidth + 1.0);
+    }
+
+    private static int CountLayoutUpdates(FrameworkElement element, TimeSpan duration)
+    {
+        var count = 0;
+        element.LayoutUpdated += OnLayoutUpdated;
+        PumpFor(duration);
+        element.LayoutUpdated -= OnLayoutUpdated;
+        return count;
+
+        void OnLayoutUpdated(object? sender, EventArgs args)
+        {
+            count++;
+        }
+    }
+
+    private static void Resize(
+        TestWindowHost host,
+        ModernWpf.Controls.NavigationView navView,
+        double width)
+    {
+        host.Window.Width = width;
+        navView.Width = width;
+        host.UpdateLayout();
+        PumpFor(TimeSpan.FromMilliseconds(250));
+    }
+
+    private static void PumpFor(TimeSpan duration)
+    {
+        var frame = new DispatcherFrame();
+        var timer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = duration
+        };
+        timer.Tick += (_, _) =>
+        {
+            timer.Stop();
+            frame.Continue = false;
+        };
+        timer.Start();
+        Dispatcher.PushFrame(frame);
+    }
+}


### PR DESCRIPTION
Closes #319

## Summary
- constrain the WPF top-navigation primary scroll host to the width left by the other top-pane columns while overflow is active
- recompute the constraint across resize and remove it once all items fit
- document the WPF-specific overflow adapter and add a regression covering header, footer, overflow, idle layout, and 768 → 1200 → 640 recovery

## Reproduction
With a 768-DIP top NavigationView, 160-DIP pane header and footer, and 24 items, the split provider correctly reached 1 primary / 23 overflow items, but the primary repeater retained a 3574-DIP arrange slot and the top grid retained 4022 DIPs. The viewport cache then drove about 90 layout passes in one second. The adaptive host cap keeps the top grid within the NavigationView and reduced the same idle interval to single-digit layout updates.

## Validation
- `dotnet restore ModernWpf.sln`
- `dotnet build ModernWpf.sln --configuration Release --no-restore` — 0 warnings, 0 errors
- focused issue regression — 1/1 passed
- NavigationView slice — 60/60 passed
- complete `ModernWpf.WinUI.Tests` net8 suite — 1045/1045 passed
- `git diff --check`

The WinUI test project targets net8 only; product assemblies were built successfully for net462, net8.0-windows7.0, and net10.0-windows7.0.