### PR TITLE
Configure Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+
+updates:
+  - package-ecosystem: "nuget"
+    directories:
+      - "**/*"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 5
+    groups:
+      nuget-minor-and-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      nuget-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- enable weekly Dependabot version updates for all NuGet manifests and GitHub Actions
- group NuGet minor/patch updates to limit CI noise while keeping major updates individually reviewable
- group security updates per ecosystem and retain a five-PR version-update limit
- stagger the two Monday schedules in the repository's Europe/London timezone

Repository verification found Dependabot vulnerability alerts and automated security fixes already enabled, with no current open alerts. This file supplies the missing version-update policy and customizes security-update grouping.

## Validation

- parsed `.github/dependabot.yml` with PyYAML
- asserted the v2 schema contract, both ecosystems, recursive NuGet coverage, weekly schedules, and update/security groups
- `git diff --cached --check`

No product code or dependencies changed; the PR release gate and CodeQL scans provide repository-level validation.

Fixes #289