### PR TITLE
Keep CommandBarFlyout open during toggle binding sync

### DIFF
--- a/ModernWpf.Controls/CommandBarFlyout/CommandBarFlyout.cs
+++ b/ModernWpf.Controls/CommandBarFlyout/CommandBarFlyout.cs
@@ -44,9 +44,8 @@ namespace ModernWpf.Controls
                     var source = (ObservableCollection<ICommandBarElement>)sender;
                     SharedHelpers.ForwardCollectionChange(source, commandBar.SecondaryCommands, args);
 
-                    // We want to ensure that any interaction with secondary items causes the CommandBarFlyout
-                    // to close, so we'll attach a Click handler to any buttons and Checked/Unchecked handlers
-                    // to any toggle buttons that we get and close the flyout when they're invoked.
+                    // We want to ensure that invoking secondary items causes the CommandBarFlyout
+                    // to close, so we'll attach a Click handler to buttons and toggle buttons.
                     // The only exception is buttons with flyouts - in that case, clicking on the button
                     // will just open the flyout rather than executing an action, so we don't want that to
                     // do anything.
@@ -59,9 +58,7 @@ namespace ModernWpf.Controls
                                 foreach (ICommandBarElement oldElement in args.OldItems)
                                 {
                                     UnhookCommandBarElementDependencyPropertyChanges(oldElement);
-                                    RevokeAndRemove(m_secondaryButtonClickRevokerByElementMap, oldElement);
-                                    RevokeAndRemove(m_secondaryToggleButtonCheckedRevokerByElementMap, oldElement);
-                                    RevokeAndRemove(m_secondaryToggleButtonUncheckedRevokerByElementMap, oldElement);
+                                    RevokeAndRemove(m_secondaryCommandClickRevokerByElementMap, oldElement);
                                 }
 
                                 foreach (ICommandBarElement element in args.NewItems)
@@ -85,9 +82,7 @@ namespace ModernWpf.Controls
                                 foreach (ICommandBarElement element in args.OldItems)
                                 {
                                     UnhookCommandBarElementDependencyPropertyChanges(element);
-                                    RevokeAndRemove(m_secondaryButtonClickRevokerByElementMap, element);
-                                    RevokeAndRemove(m_secondaryToggleButtonCheckedRevokerByElementMap, element);
-                                    RevokeAndRemove(m_secondaryToggleButtonUncheckedRevokerByElementMap, element);
+                                    RevokeAndRemove(m_secondaryCommandClickRevokerByElementMap, element);
                                 }
                                 break;
                             }
@@ -331,9 +326,7 @@ namespace ModernWpf.Controls
 
         private void SetSecondaryCommandsToCloseWhenExecuted()
         {
-            RevokeAndClear(m_secondaryButtonClickRevokerByElementMap);
-            RevokeAndClear(m_secondaryToggleButtonCheckedRevokerByElementMap);
-            RevokeAndClear(m_secondaryToggleButtonUncheckedRevokerByElementMap);
+            RevokeAndClear(m_secondaryCommandClickRevokerByElementMap);
 
             RoutedEventHandler closeFlyoutFunc = delegate { Hide(); };
 
@@ -345,15 +338,13 @@ namespace ModernWpf.Controls
 
                 if (button != null && button.Flyout == null)
                 {
-                    m_secondaryButtonClickRevokerByElementMap[element] = new RoutedEventHandlerRevoker(
+                    m_secondaryCommandClickRevokerByElementMap[element] = new RoutedEventHandlerRevoker(
                         button, ButtonBase.ClickEvent, closeFlyoutFunc);
                 }
                 else if (toggleButton != null)
                 {
-                    m_secondaryToggleButtonCheckedRevokerByElementMap[element] = new RoutedEventHandlerRevoker(
-                        toggleButton, ToggleButton.CheckedEvent, closeFlyoutFunc);
-                    m_secondaryToggleButtonUncheckedRevokerByElementMap[element] = new RoutedEventHandlerRevoker(
-                        toggleButton, ToggleButton.UncheckedEvent, closeFlyoutFunc);
+                    m_secondaryCommandClickRevokerByElementMap[element] = new RoutedEventHandlerRevoker(
+                        toggleButton, ButtonBase.ClickEvent, closeFlyoutFunc);
                 }
             }
         }
@@ -367,24 +358,18 @@ namespace ModernWpf.Controls
 
             if (button != null && button.Flyout == null)
             {
-                m_secondaryButtonClickRevokerByElementMap[element] = new RoutedEventHandlerRevoker(
+                m_secondaryCommandClickRevokerByElementMap[element] = new RoutedEventHandlerRevoker(
                     button, ButtonBase.ClickEvent, closeFlyoutFunc);
-                RevokeAndRemove(m_secondaryToggleButtonCheckedRevokerByElementMap, element);
-                RevokeAndRemove(m_secondaryToggleButtonUncheckedRevokerByElementMap, element);
             }
             else if (toggleButton != null)
             {
-                RevokeAndRemove(m_secondaryButtonClickRevokerByElementMap, element);
-                m_secondaryToggleButtonCheckedRevokerByElementMap[element] = new RoutedEventHandlerRevoker(
-                    toggleButton, ToggleButton.CheckedEvent, closeFlyoutFunc);
-                m_secondaryToggleButtonUncheckedRevokerByElementMap[element] = new RoutedEventHandlerRevoker(
-                    toggleButton, ToggleButton.UncheckedEvent, closeFlyoutFunc);
+                RevokeAndRemove(m_secondaryCommandClickRevokerByElementMap, element);
+                m_secondaryCommandClickRevokerByElementMap[element] = new RoutedEventHandlerRevoker(
+                    toggleButton, ButtonBase.ClickEvent, closeFlyoutFunc);
             }
             else
             {
-                RevokeAndRemove(m_secondaryButtonClickRevokerByElementMap, element);
-                RevokeAndRemove(m_secondaryToggleButtonCheckedRevokerByElementMap, element);
-                RevokeAndRemove(m_secondaryToggleButtonUncheckedRevokerByElementMap, element);
+                RevokeAndRemove(m_secondaryCommandClickRevokerByElementMap, element);
             }
         }
 
@@ -608,11 +593,7 @@ namespace ModernWpf.Controls
 
         CommandBarFlyoutCommandBar m_commandBar;
 
-        Dictionary<ICommandBarElement, RoutedEventHandlerRevoker> m_secondaryButtonClickRevokerByElementMap =
-            new Dictionary<ICommandBarElement, RoutedEventHandlerRevoker>();
-        Dictionary<ICommandBarElement, RoutedEventHandlerRevoker> m_secondaryToggleButtonCheckedRevokerByElementMap =
-            new Dictionary<ICommandBarElement, RoutedEventHandlerRevoker>();
-        Dictionary<ICommandBarElement, RoutedEventHandlerRevoker> m_secondaryToggleButtonUncheckedRevokerByElementMap =
+        Dictionary<ICommandBarElement, RoutedEventHandlerRevoker> m_secondaryCommandClickRevokerByElementMap =
             new Dictionary<ICommandBarElement, RoutedEventHandlerRevoker>();
         Dictionary<ICommandBarElement, List<DependencyPropertyChangedRevoker>> m_propertyChangedRevokersByElementMap =
             new Dictionary<ICommandBarElement, List<DependencyPropertyChangedRevoker>>();

--- a/docs/commandbarflyout-winui3-source-audit.md
+++ b/docs/commandbarflyout-winui3-source-audit.md
@@ -84,7 +84,7 @@ CommandBarFlyout page/sample change after Gallery conversion commit
 | --- | --- |
 | Constructor sets `ShouldConstrainToRootBounds=false`, disables default open/close animations, and owns primary/secondary command vectors. | Matched with WPF observable collections and FlyoutBase properties. |
 | Primary and secondary command collection changes are mirrored into the internal command bar. | Matched with collection-forwarding tests. |
-| Secondary command execution closes the flyout, except `AppBarButton` entries with an associated flyout. | Matched with WPF routed-event revokers. |
+| Secondary command execution closes the flyout, except `AppBarButton` entries with an associated flyout. | Matched with WPF routed `Click` revokers. `AppBarToggleButton` uses `Click` rather than state-change events so late WPF binding synchronization cannot masquerade as command execution. |
 | Secondary `AppBarButton` / `AppBarToggleButton` changes to `Icon`, `Label`, and `KeyboardAcceleratorTextOverride` refresh open flyout sizing. | Matched; all three dependency properties are now tracked, including keyboard accelerator text. |
 | Adding or replacing a primary/secondary command updates that command's localized MenuItem identity without rescanning every existing command. | Behavior matched through the scoped `IsInCommandBarFlyout` flag and peer lookup: inserted commands immediately expose MenuItem / `menu item` without localized-resource rescans. A current-source regression covers live insertion after the flyout is open. |
 | `AlwaysExpanded` forces `ShowMode=Standard`, opens the command bar, and hides the overflow button. | Matched with WPF command-bar state tests. |
@@ -108,6 +108,12 @@ CommandBarFlyout page/sample change after Gallery conversion commit
 - WPF automation does not expose WinRT `AutomationEvents.MenuOpened` / `MenuClosed`. Control types, localized type names, expanded ellipsis name, app-visible behavior, and focus routing are matched and covered; only the WinRT-specific event identifiers remain a platform gap.
 - WPF AutomationProperties has no `FlowsTo` / `FlowsFrom` attached-property API. ModernWpf matches the source primary/secondary focus graph and tab-stop uniqueness, but cannot publish those two WinUI relationship properties through WPF UIA.
 - WPF template binding can lag dependency-property callbacks during measurement, so ModernWpf keeps a narrow deferred size refresh after source-tracked secondary command property changes.
+- WinUI observes secondary `AppBarToggleButton.Checked` / `Unchecked` to close
+  the flyout after invocation. WPF can raise those routed events when a binding
+  first resolves after the popup opens, even though the command was not
+  invoked. ModernWpf observes the toggle's routed `Click` event instead; mouse,
+  keyboard, and automation invocation still close the flyout, while binding
+  initialization and programmatic state synchronization do not.
 - WPF has no WinUI gamepad/remote input-mode service in this control path. ModernWpf wires the source-shaped touch/default subset through WPF key/mouse/touch events and leaves gamepad/remote selection as a platform gap.
 
 ## Current Validation
@@ -125,7 +131,7 @@ dotnet build .\ModernWpf.Controls\ModernWpf.Controls.csproj -f net10.0-windows7.
 git diff --check
 ```
 
-Fresh gate-enforced Light `artifacts/visual-checks/20260719-022802-704-69300/report.md` and Dark `artifacts/visual-checks/20260719-022908-765-38068/report.md` runs both retain static primary delta `4.99` with `454x302` versus `453x302` photo crops. Expanded interaction crops are exact `229x136` matches at delta `7.05` / `8.18`, and both raw UIA command unions remain exact `217x124`. Live UIA reports Menu/MenuItem roles and `Less app bar` in both applications. The harness enforces static delta `<=6.0`, static size delta `<=2`, interaction delta `<=9.0`, and exact interaction size parity. Fresh Light/Dark OpenRepeat recordings `artifacts/gallery-recordings/20260719-023035-553/report.md` and `artifacts/gallery-recordings/20260719-023154-586/report.md` pass, detect both opens, and provide dense transition review. The refreshed focused API suite passes 29/29; focused current-source/sample/interaction/gate Gallery coverage passes 5/5 on net8 and net10; Controls and Gallery build on net462, net8, and net10 with zero errors. Controls retains the repository's 18 unrelated net462 warnings, while Gallery is warning-free.
+Fresh gate-enforced Light `artifacts/visual-checks/20260719-022802-704-69300/report.md` and Dark `artifacts/visual-checks/20260719-022908-765-38068/report.md` runs both retain static primary delta `4.99` with `454x302` versus `453x302` photo crops. Expanded interaction crops are exact `229x136` matches at delta `7.05` / `8.18`, and both raw UIA command unions remain exact `217x124`. Live UIA reports Menu/MenuItem roles and `Less app bar` in both applications. The harness enforces static delta `<=6.0`, static size delta `<=2`, interaction delta `<=9.0`, and exact interaction size parity. Fresh Light/Dark OpenRepeat recordings `artifacts/gallery-recordings/20260719-023035-553/report.md` and `artifacts/gallery-recordings/20260719-023154-586/report.md` pass, detect both opens, and provide dense transition review. The refreshed focused API suite passes 39/39, including late secondary-toggle binding initialization followed by real invocation; focused current-source/sample/interaction/gate Gallery coverage passes 5/5 on net8 and net10; Controls and Gallery build on net462, net8, and net10 with zero errors. Controls retains the repository's 18 unrelated net462 warnings, while Gallery is warning-free.
 
 ## 2026-07-21 Transition-State Follow-up
 

--- a/test/ModernWpf.WinUI.Tests/CommandBarFlyout/CommandBarFlyoutApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/CommandBarFlyout/CommandBarFlyoutApiTests.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -93,6 +94,55 @@ public class CommandBarFlyoutApiTests
             Assert.IsTrue(commandBar.IsOpen, "AlwaysExpanded must reject an overflow-collapse request while the flyout is open.");
 
             HideAndWait(commandBarFlyout);
+        });
+    }
+
+    [TestMethod]
+    public void SecondaryToggleBindingInitializationDoesNotDismissFlyout()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var toggleButton = new TestAppBarToggleButton { Label = "Auto run" };
+            toggleButton.SetBinding(
+                ToggleButton.IsCheckedProperty,
+                new Binding("IsChecked") { Mode = BindingMode.OneWay });
+
+            var commandBarFlyout = new CommandBarFlyout
+            {
+                Placement = FlyoutPlacementMode.BottomEdgeAlignedLeft
+            };
+            commandBarFlyout.SecondaryCommands.Add(toggleButton);
+
+            var closingCount = 0;
+            commandBarFlyout.Closing += delegate { closingCount++; };
+            commandBarFlyout.Opened += delegate
+            {
+                toggleButton.DataContext = new { IsChecked = true };
+            };
+
+            var target = new System.Windows.Controls.Button
+            {
+                Content = "Show CommandBarFlyout",
+                Width = 180,
+                Height = 36
+            };
+
+            using var host = new TestWindowHost(target, width: 420, height: 260);
+
+            commandBarFlyout.ShowAt(target);
+            WpfTestHost.DoEvents();
+
+            Assert.AreEqual(true, toggleButton.IsChecked);
+            Assert.AreEqual(0, closingCount, "Binding initialization must not invoke a secondary command.");
+            Assert.IsTrue(commandBarFlyout.IsOpen, "Binding initialization must not dismiss the CommandBarFlyout.");
+
+            toggleButton.InvokeClick();
+            WaitFor(() => !commandBarFlyout.IsOpen, "Invoking the secondary toggle did not dismiss the CommandBarFlyout.");
+
+            Assert.AreEqual(false, toggleButton.IsChecked);
+            Assert.AreEqual(1, closingCount);
         });
     }
 
@@ -1845,6 +1895,14 @@ public class CommandBarFlyoutApiTests
         for (var type = value.GetType(); type != null; type = type.BaseType)
         {
             Assert.AreNotEqual(typeName, type.Name);
+        }
+    }
+
+    private sealed class TestAppBarToggleButton : AppBarToggleButton
+    {
+        public void InvokeClick()
+        {
+            OnClick();
         }
     }
 


### PR DESCRIPTION
Fixes #274

## Summary

- close secondary `AppBarToggleButton` commands on routed `Click`, not `Checked` / `Unchecked`
- preserve dismissal for real mouse, keyboard, and automation invocation
- add a regression that resolves a bound `IsChecked` value after the flyout opens, verifies the flyout stays open, then verifies a real invocation closes it
- document the WPF-specific adaptation in the CommandBarFlyout source audit

## Reproduction

Before the product fix, the new focused regression failed with `closingCount == 2` immediately after the late binding resolved; expected `0`.

## Validation

- `dotnet restore ModernWpf.sln` — succeeded
- `dotnet build ModernWpf.sln --configuration Release --no-restore --maxcpucount:1` — succeeded, 0 warnings, 0 errors
- focused new regression — 1/1 passed, 0 skipped
- `CommandBarFlyoutApiTests` — 39/39 passed, 0 skipped
- CommandBarFlyout / CommandBar / template parity / sync matrix slice — 108/108 passed, 0 skipped
- complete `ModernWpf.WinUI.Tests` project on `net8.0-windows7.0` — 1,046/1,046 passed, 0 skipped
- `git diff --check` — passed

Visual tests were not rerun because this changes only dismissal event routing; no template, resource, layout, or rendering path changed.