### PR TITLE
Update compatible GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,11 @@ updates:
       time: "06:30"
       timezone: "Europe/London"
     open-pull-requests-limit: 5
+    ignore:
+      # v2.5 treats the 19041 web installer as an ISO and fails before restore (#719).
+      - dependency-name: "GuillaumeFalourd/setup-windows10-sdk-action"
+        update-types:
+          - "version-update:semver-major"
     groups:
       github-actions:
         applies-to: "version-updates"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
 
@@ -117,7 +117,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: release-gate-test-results
         path: ${{ env.TEST_RESULTS }}
@@ -125,7 +125,7 @@ jobs:
         retention-days: 30
 
     - name: Upload validated packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: release-gate-packages
         path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,11 +40,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup .NET
         if: matrix.language == 'csharp'
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       version: ${{ steps.validate.outputs.version }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         ref: ${{ inputs.tag }}
         fetch-depth: 0
@@ -70,7 +70,7 @@ jobs:
         "artifact-name=modernwpf-$projectVersion" >> $env:GITHUB_OUTPUT
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
 
@@ -163,7 +163,7 @@ jobs:
         $hashLines | Set-Content "$releaseRoot\SHA256SUMS" -Encoding ascii
 
     - name: Upload retained release artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.validate.outputs.artifact-name }}
         path: ${{ env.RELEASE_ROOT }}
@@ -181,7 +181,7 @@ jobs:
 
     steps:
     - name: Download exact build artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ needs.build.outputs.artifact-name }}
         path: release


### PR DESCRIPTION
Supersedes #719.

## Summary

- update `actions/checkout` to v7
- update `actions/setup-dotnet` to v6
- update `actions/upload-artifact` to v7 and `actions/download-artifact` to v8
- retain `GuillaumeFalourd/setup-windows10-sdk-action@v1.5`
- tell Dependabot to ignore only major-version updates for that SDK installer

## Why #719 cannot be merged

PR #719's CodeQL jobs passed, but its release gate failed before restore. `setup-windows10-sdk-action@v2.5` maps SDK 19041 to a Microsoft link that currently resolves to `winsdksetup.exe`, while the action saves the payload as `winsdk_19041.iso` and calls `Mount-DiskImage`. The deterministic result is `HRESULT 0x80070570` ("file or directory is corrupted and unreadable").

The existing v1.5 action uses the actual 19041 ISO URL and is green on master. This replacement takes the other compatible updates without recreating the broken installer bump.

## Validation

- fetched and compared the official v1.5/v2.5 installer scripts
- inspected the full failed GitHub Actions log for #719
- parsed `.github/dependabot.yml` and all three changed workflow YAML files successfully
- confirmed no legacy checkout/setup/artifact versions remain
- `git diff --check` passed

Product source, packages, templates, and public contracts are unchanged. The PR Build and CodeQL workflows provide the relevant end-to-end validation.