### PR TITLE
Cover AutoSuggestBox SuggestionChosen text overrides

### DIFF
--- a/docs/autosuggestbox-winui3-source-audit.md
+++ b/docs/autosuggestbox-winui3-source-audit.md
@@ -96,6 +96,9 @@ The current page retains two examples:
 - Up/Down previews suggestions while retaining/restoring user text; Tab,
   Escape, Enter, query-button Invoke, suggestion choice, and programmatic submit
   preserve source ordering and chosen-suggestion semantics.
+- Suggestion selection applies the default selected-item text before raising
+  `SuggestionChosen`, so an event handler can replace `Text` with an
+  application-specific value without the control overwriting it afterward.
 - Suggestion item input raises ItemClick first and then applies primary or
   secondary selection behavior across WPF Single, Multiple, and Extended
   modes, matching the relevant ListViewBase source ordering.
@@ -143,7 +146,8 @@ The current page retains two examples:
   ItemClick-before-selection ordering, WPF selection modes, query-button state
   setters, popup shadow/insets, and corner filtering.
 - `AutoSuggestBoxInteractionTests` covers choosing a suggestion by keyboard,
-  Escape restoration, and query-button submission behavior.
+  preserving handler-assigned text after `SuggestionChosen`, Escape
+  restoration, and query-button submission behavior.
 - `GalleryAutomationHookTests` pins the two current examples, headers/source,
   names/IDs, cat filtering and chosen output, search suggestions, query/details
   behavior, and current catalog integration.
@@ -175,7 +179,7 @@ state, geometry, layout, resources, and static accessibility match.
 
 ## Verification
 
-- The refreshed AutoSuggestBox product/source slice passes 12/12 on
+- The refreshed AutoSuggestBox product/source slice passes 13/13 on
   `net8.0-windows7.0`.
 - Focused Gallery runtime/source/interaction-shape tests pass 4/4 on both
   `net8.0-windows7.0` and `net10.0-windows7.0`.

--- a/test/ModernWpf.WinUI.Tests/AutoSuggestBox/AutoSuggestBoxInteractionTests.cs
+++ b/test/ModernWpf.WinUI.Tests/AutoSuggestBox/AutoSuggestBoxInteractionTests.cs
@@ -52,6 +52,48 @@ public class AutoSuggestBoxInteractionTests
     }
 
     [TestMethod]
+    public void SuggestionChosenHandlerCanOverrideSelectedItemText()
+    {
+        WpfTestHost.Run(() =>
+        {
+            var suggestion = new SuggestionItem("Friendly description");
+            var autoSuggestBox = new MuxAutoSuggestBox
+            {
+                ItemsSource = new[] { suggestion },
+                Width = 400
+            };
+
+            var suggestionChosenCount = 0;
+            autoSuggestBox.SuggestionChosen += (sender, args) =>
+            {
+                suggestionChosenCount++;
+                Assert.AreSame(suggestion, args.SelectedItem);
+                Assert.AreEqual(suggestion.ToString(), sender.Text);
+                sender.Text = ((SuggestionItem)args.SelectedItem).Description;
+            };
+
+            using var host = new TestWindowHost(autoSuggestBox, width: 520, height: 240);
+
+            var textBox = FindTemplateChild<TextBox>(autoSuggestBox, "TextBox");
+            Assert.IsTrue(textBox.Focus());
+
+            textBox.Text = "test";
+            FlushLayout(host);
+
+            Assert.IsTrue(autoSuggestBox.IsSuggestionListOpen);
+            Assert.AreNotEqual(suggestion.Description, suggestion.ToString());
+
+            var suggestionsList = FindTemplateChild<AutoSuggestBoxListView>(autoSuggestBox, "SuggestionsList");
+            suggestionsList.SelectedItem = suggestion;
+            FlushLayout(host);
+
+            Assert.AreEqual(1, suggestionChosenCount);
+            Assert.AreEqual(suggestion.Description, autoSuggestBox.Text);
+            Assert.AreEqual(suggestion.Description, textBox.Text);
+        });
+    }
+
+    [TestMethod]
     public void SuggestionItemClickSubmitsAndClosesPopup()
     {
         WpfTestHost.Run(() =>
@@ -129,6 +171,16 @@ public class AutoSuggestBoxInteractionTests
             Assert.AreEqual("dolor", submittedSuggestion);
             Assert.IsFalse(autoSuggestBox.IsSuggestionListOpen);
         });
+    }
+
+    private sealed class SuggestionItem
+    {
+        public SuggestionItem(string description)
+        {
+            Description = description;
+        }
+
+        public string Description { get; }
     }
 
     private static void FlushLayout(TestWindowHost host)


### PR DESCRIPTION
Fixes #269.

## Summary

- add the reporter's exact object-suggestion scenario as a live WPF regression
- verify the selected item's default `ToString()` text is applied before `SuggestionChosen`
- verify a handler can replace `Text` with an application-specific description and that the replacement survives dispatcher processing
- record the behavior and refreshed test count in the AutoSuggestBox source audit

## Current 1.x result

The active 1.x implementation already has the correct WinUI ordering from the 1.0 reboot (#688): it applies the default suggestion text and then raises `SuggestionChosen`. The original 2021 bug therefore does not reproduce on current master. This PR adds the missing durable regression rather than rewriting already-correct product code.

## Validation

- focused `SuggestionChosenHandlerCanOverrideSelectedItemText` — 1/1 passed, 0 skipped
- complete AutoSuggestBox product/source slice — 13/13 passed, 0 skipped
- complete `ModernWpf.WinUI.Tests` project on `net8.0-windows7.0` — 1,047/1,047 passed, 0 skipped
- affected test project and product dependencies rebuilt successfully during the focused run
- `git diff --check` — passed

No visual test was rerun because product code, templates, resources, layout, and rendering are unchanged.