### PR TITLE
Fix NavigationView NaN button sizing

### DIFF
--- a/ModernWpf.Controls/NavigationView/NavigationView.cs
+++ b/ModernWpf.Controls/NavigationView/NavigationView.cs
@@ -4753,7 +4753,7 @@ namespace ModernWpf.Controls
 
                 if (useLeftPaddingForBackOrCloseButton && backButtonVisibility == Visibility.Visible)
                 {
-                    leftPaddingForBackOrCloseButton += backButton.Width;
+                    leftPaddingForBackOrCloseButton += GetEffectiveButtonSize(backButton.Width, backButton.ActualWidth);
                 }
             }
 
@@ -4765,11 +4765,13 @@ namespace ModernWpf.Controls
 
                 if (closeButtonVisibility == Visibility.Visible)
                 {
-                    paneHeaderContentBorderRowMinHeight = Math.Max(paneHeaderContentBorderRowMinHeight, closeButton.Height);
+                    paneHeaderContentBorderRowMinHeight = Math.Max(
+                        paneHeaderContentBorderRowMinHeight,
+                        GetEffectiveButtonSize(closeButton.Height, closeButton.ActualHeight));
 
                     if (useLeftPaddingForBackOrCloseButton)
                     {
-                        paneHeaderPaddingForCloseButton = closeButton.Width;
+                        paneHeaderPaddingForCloseButton = GetEffectiveButtonSize(closeButton.Width, closeButton.ActualWidth);
                         leftPaddingForBackOrCloseButton += paneHeaderPaddingForCloseButton;
                     }
                 }
@@ -4834,6 +4836,14 @@ namespace ModernWpf.Controls
                 VisualStateManager.GoToState(this, shouldShowBackButton ? "BackButtonVisible" : "BackButtonCollapsed", false /*useTransitions*/);
             }
             UpdateTitleBarPadding();
+        }
+
+        static double GetEffectiveButtonSize(double specifiedSize, double actualSize)
+        {
+            // WPF represents an Auto Width or Height as NaN. WinUI's template
+            // parts use concrete dimensions, but WPF custom templates and
+            // resource teardown can leave these button dimensions on Auto.
+            return double.IsNaN(specifiedSize) ? actualSize : specifiedSize;
         }
 
         void UpdatePaneTitleMargins()

--- a/docs/navigationview-winui3-source-audit.md
+++ b/docs/navigationview-winui3-source-audit.md
@@ -116,6 +116,7 @@ API controls are covered by the focused Gallery regression.
 | Current `NavigationView` defers `SplitView.DisplayMode` changes made by `OnApplyTemplate` until `Loaded`, using `m_fromOnApplyTemplate` and `m_updateVisualStateForDisplayModeFromOnLoaded`. | ModernWpf now ports both lifecycle guards. WPF can apply an offscreen control's template after it is already loaded, so that path queues the same completion at `DispatcherPriority.Loaded`. `UpdateIsClosedCompact` also synchronizes `PaneStateListSizeGroup` with the authoritative SplitView state when WPF reaches a closed/open value without the WinUI pane lifecycle event. This prevents `ClosedCompact` from coexisting with stale `ListSizeFull`. |
 | The WinUI Gallery default example is `nvSample5`, 745x460, with `Sample Page 1`, four symbol items, a source `BodyTextBlockStyle` paragraph, and selection-driven `Sample Page N` headers. | The generated Gallery sample preserves the exact host size, symbols/tags, source body style and foreground, and selection behavior. A one-physical-pixel WPF text-origin adapter aligns the source paragraph, header, and content offsets without changing tile geometry or hit targets. |
 | The current Gallery exposes eight independently rendered NavigationViews. At the reference viewport the first five are 745x460, footer is 592x460, hierarchy is 565x460, and API is 458x540. Data binding and hierarchy initially show `Sample Page 1`; API starts with an empty Frame and a normal-text `Pane Title`. | All eight controls now have stable `GallerySample_NavigationView_*` artifact IDs and exact reference widths. The option-bearing samples no longer arrange at 745 DIPs and get clipped by narrower columns. Data binding/hierarchy restore their source initial headers, API uses a genuinely empty Frame until selection, and `PaneTitleTextBlock` explicitly uses `ContentControlThemeFontFamily` instead of inheriting the toggle button's symbol font. |
+| `UpdateBackAndCloseButtonsVisibility` reads the back and close template-part dimensions into header padding, and the WinUI template supplies concrete dimensions. | WPF represents an Auto `Width` or `Height` as `NaN`. The port uses the template part's finite `ActualWidth` or `ActualHeight` when a custom template or resource teardown returns a dimension to Auto, preventing `GridLength(NaN)` while preserving measured button spacing. |
 | Source automation exposes the root selection provider and selected container providers. | `NavigationViewAutomationPeer` remains public and source-shaped; product tests cover provider defaults, empty selection, selected providers, item automation, expand/collapse, and pane behavior. |
 | Source applies a depth-16 compositor `ThemeShadow` to `ShadowCaster`. | `ThemeShadowChrome.Depth=16` is the documented software-rendered WPF substitute and retains the source state targets and width binding. |
 
@@ -151,6 +152,10 @@ API controls are covered by the focused Gallery regression.
   keeps an explicitly closed initial pane closed regardless of whether
   `IsPaneOpen` appears before or after `PaneDisplayMode`, while runtime display
   mode changes retain the source automatic open/close behavior.
+- WPF uses `NaN` to represent Auto template-part dimensions. Back and close
+  button padding therefore falls back to the measured dimension when the
+  specified dimension is Auto, including while dynamic resources are being
+  torn down.
 - WinUI `ItemsRepeater`, `SplitView`, `Flyout`, popup/XamlRoot services, focus
   movement, top overflow measurement, gamepad/access-key paths, composition
   animations, x:Bind phases, and recycle metadata use the existing documented
@@ -234,7 +239,7 @@ API controls are covered by the focused Gallery regression.
   covers issue #319 with header, footer, 24 top items, overflow, an idle-layout
   bound, and 768-to-1200-to-640 resize recovery. It also verifies that both the
   primary scroll host and top grid remain inside the NavigationView width.
-- NavigationView product/source-audit tests pass 60/60; SplitView product tests
+- NavigationView product/source-audit tests pass 61/61; SplitView product tests
   pass 14/14; the focused Gallery sample/source-shape slice passes 7/7 on net8
   and net10. Gallery builds successfully on net462, net8, and net10 with zero
   errors; current target builds retain existing unrelated warnings.

--- a/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewApiTests.cs
@@ -1986,6 +1986,69 @@ public class NavigationViewApiTests
     }
 
     [TestMethod]
+    public void NavigationViewAutoSizedBackAndCloseButtonsUseActualDimensions()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var navView = new ModernWpf.Controls.NavigationView
+            {
+                IsBackButtonVisible = ModernWpf.Controls.NavigationViewBackButtonVisible.Visible,
+                IsPaneOpen = true,
+                IsPaneToggleButtonVisible = false,
+                PaneDisplayMode = ModernWpf.Controls.NavigationViewPaneDisplayMode.LeftMinimal,
+                MenuItems =
+                {
+                    new ModernWpf.Controls.NavigationViewItem
+                    {
+                        Content = "Home"
+                    }
+                }
+            };
+
+            using var host = new TestWindowHost(navView);
+            navView.IsPaneOpen = true;
+            host.UpdateLayout();
+
+            var backButton = FindNamedDescendant<Button>(navView, "NavigationViewBackButton");
+            var closeButton = FindNamedDescendant<Button>(navView, "NavigationViewCloseButton");
+            var contentLeftPadding = FindNamedDescendant<FrameworkElement>(navView, "ContentLeftPadding");
+            var closeButtonColumn = navView.Template.FindName("PaneHeaderCloseButtonColumn", navView) as ColumnDefinition;
+            var paneHeaderRow = navView.Template.FindName("PaneHeaderContentBorderRow", navView) as RowDefinition;
+
+            Assert.IsNotNull(closeButtonColumn);
+            Assert.IsNotNull(paneHeaderRow);
+
+            closeButton.Width = double.NaN;
+            closeButton.Height = double.NaN;
+            host.UpdateLayout();
+            navView.IsBackButtonVisible = ModernWpf.Controls.NavigationViewBackButtonVisible.Collapsed;
+            navView.IsBackButtonVisible = ModernWpf.Controls.NavigationViewBackButtonVisible.Visible;
+            host.UpdateLayout();
+
+            Assert.AreEqual(Visibility.Visible, closeButton.Visibility);
+            Assert.AreEqual(closeButton.ActualWidth, contentLeftPadding.Width, 0.001);
+            Assert.AreEqual(closeButton.ActualWidth, closeButtonColumn!.Width.Value, 0.001);
+            Assert.AreEqual(closeButton.ActualHeight, paneHeaderRow!.MinHeight, 0.001);
+
+            navView.IsPaneOpen = false;
+            host.UpdateLayout();
+
+            Assert.AreEqual(Visibility.Visible, backButton.Visibility);
+            backButton.Width = double.NaN;
+            host.UpdateLayout();
+
+            var expectedBackButtonWidth = backButton.ActualWidth;
+            navView.IsPaneToggleButtonVisible = true;
+            navView.IsPaneToggleButtonVisible = false;
+
+            Assert.AreEqual(expectedBackButtonWidth, contentLeftPadding.Width, 0.001);
+            Assert.AreEqual(new GridLength(0), closeButtonColumn.Width);
+        });
+    }
+
+    [TestMethod]
     public void NavigationViewPaneCollapsedStateUsesWinUIVisualStateSetters()
     {
         WpfTestHost.Run(() =>


### PR DESCRIPTION
## Summary

- treat WPF Auto back/close button dimensions as measured dimensions when NavigationView computes header padding
- prevent `GridLength(NaN)` during custom-template and dynamic-resource teardown paths
- add a focused runtime regression for Auto-sized back and close template parts
- document the WPF adaptation in the NavigationView source audit

## Validation

- `dotnet restore .\ModernWpf.sln` — passed
- `dotnet build .\ModernWpf.sln --configuration Release --no-restore --maxcpucount:1` — passed with 0 warnings and 0 errors
- focused regression — 1 passed, 0 skipped
- `FullyQualifiedName~NavigationView` — 61 passed, 0 skipped
- complete `ModernWpf.WinUI.Tests` on `net8.0-windows7.0` — 1,048 passed, 0 skipped
- `git diff --check` — passed

Fixes #268