### PR TITLE
Fix NumberBox float display precision

### DIFF
--- a/ModernWpf.Controls/NumberBox/DefaultNumberRounder.cs
+++ b/ModernWpf.Controls/NumberBox/DefaultNumberRounder.cs
@@ -8,6 +8,17 @@ namespace ModernWpf.Controls
 
         public double RoundDouble(double value)
         {
+            // WPF bindings promote Single values to NumberBox.Value's double
+            // type. Preserve the Single's shortest round-trip representation
+            // instead of displaying digits introduced by that conversion.
+            var singleValue = (float)value;
+            if ((double)singleValue == value)
+            {
+                return double.Parse(
+                    singleValue.ToString("R", CultureInfo.InvariantCulture),
+                    CultureInfo.InvariantCulture);
+            }
+
             return double.Parse(
                 value.ToString("G" + SignificantDigits, CultureInfo.InvariantCulture),
                 CultureInfo.InvariantCulture);

--- a/docs/numberbox-winui3-source-audit.md
+++ b/docs/numberbox-winui3-source-audit.md
@@ -104,7 +104,9 @@ options, formatter behavior, accessible name, automation IDs, and source text.
 - Input validation trims the current source whitespace set through WPF
   `String.Trim`, supports the source parser when expressions are enabled,
   handles invalid-input overwrite/disabled modes, coerces min/max/value, and
-  uses ten significant digits to suppress floating-point display artifacts.
+  uses ten significant digits for double values. Exact Single-to-Double
+  promotions use the Single's shortest round-trip representation so WPF
+  binding conversion does not expose binary precision artifacts.
 - Up/Down and PageUp/PageDown step on key down, Enter validates, Escape restores
   formatted text, mouse wheel steps only while the inner text box is focused,
   wrapping crosses between Minimum/Maximum, and the caret returns to the end.
@@ -144,6 +146,11 @@ options, formatter behavior, accessible name, automation IDs, and source text.
   account for WPF resource scope and non-FrameworkElement setter limitations.
 - The WPF formatter/parser interfaces and `DefaultNumberRounder` replace WinRT
   globalization formatter interfaces while preserving source behavior.
+- WPF bindings can promote a `Single` source into the `Value` dependency
+  property's `double` type. The display rounder recognizes values that
+  round-trip exactly through `Single` and normalizes only those values through
+  the Single `R` representation; genuine doubles retain the current WinUI 3
+  ten-significant-digit path.
 - Dark inline/popup glyph foreground derives from the resolved NumberBox
   foreground; High Contrast keeps the source system resource authoritative.
 
@@ -155,8 +162,9 @@ options, formatter behavior, accessible name, automation IDs, and source text.
   UIA Name/LabeledBy/range text, and source control defaults.
 - `NumberBoxInteractionTests` covers stepping, enabled boundaries, whitespace
   trimming, significant-digit preservation, validation modes, focus-only wheel
-  input, custom formatting, NaN event suppression, keyboard behavior,
-  expressions, automation RangeValue, and header/description lifecycle.
+  input, custom formatting, Single promotion without display artifacts, NaN
+  event suppression, keyboard behavior, expressions, automation RangeValue,
+  and header/description lifecycle.
 - `GalleryAutomationHookTests` pins all three current examples, current live
   values/names/options, formatter behavior, accessible name, sample source,
   and Inline/Compact option reaction.
@@ -164,6 +172,24 @@ options, formatter behavior, accessible name, automation IDs, and source text.
   resting and `2.0` interaction gates, and zero size tolerance for both crops.
 - `NumberBoxSourceAuditTests` pins current commits/blobs, product/template/peer/
   Gallery implementation shape, strict report values, and this audit.
+
+## 2026-07-26 Single-Precision Binding Follow-up
+
+Issue #267 supplies `10.4f` to NumberBox. WPF promotes that value to the
+dependency property's `double` type as `10.399999618530273`; the current
+ten-significant-digit rounder consequently displayed `10.39999962`.
+
+WinUI 2 commit `b4e5f2cafeae04f3a799123d48dca9516832becb` (`#7851`) addressed
+the same double/float conversion family by changing the default rounder
+globally to a `1e-6` increment. The current WinUI 3 snapshot instead uses ten
+significant digits. ModernWpf keeps that current behavior for genuine doubles
+and applies a narrower WPF binding adaptation: a value that round-trips exactly
+through `Single` is normalized through Single's shortest round-trip text before
+the configured NumberFormatter runs. `Value` itself remains unchanged.
+
+`FloatValueDisplaySuppressesBinaryPrecisionArtifacts` pins the reported
+`10.4f` display as `10.4`, verifies the inner TextBox and public `Text` agree,
+and confirms a genuine high-precision double still follows the ten-digit path.
 
 ## Live Installed-Gallery Evidence
 
@@ -184,7 +210,7 @@ accessibility match.
 
 ## Verification
 
-- The refreshed NumberBox product/source slice passes 18/18 on
+- The refreshed NumberBox product/source slice passes 19/19 on
   `net8.0-windows7.0`.
 - Focused Gallery runtime/source tests pass 2/2 on both
   `net8.0-windows7.0` and `net10.0-windows7.0`.

--- a/test/ModernWpf.WinUI.Tests/NumberBox/NumberBoxInteractionTests.cs
+++ b/test/ModernWpf.WinUI.Tests/NumberBox/NumberBoxInteractionTests.cs
@@ -143,6 +143,38 @@ public class NumberBoxInteractionTests
     }
 
     [TestMethod]
+    public void FloatValueDisplaySuppressesBinaryPrecisionArtifacts()
+    {
+        WpfTestHost.Run(() =>
+        {
+            var floatValue = (double)10.4f;
+            Assert.AreNotEqual(10.4d, floatValue);
+
+            var numberBox = CreateNumberBox();
+            numberBox.Value = floatValue;
+
+            using var host = new TestWindowHost(numberBox, width: 320, height: 180);
+
+            var inputBox = FindTemplatePart<TextBox>(numberBox, "InputBox");
+            var expectedText = 10.4d.ToString(CultureInfo.CurrentCulture);
+
+            Assert.AreEqual(floatValue, numberBox.Value);
+            Assert.AreEqual(expectedText, numberBox.Text);
+            Assert.AreEqual(expectedText, inputBox.Text);
+
+            var doubleValue = 10.1234567890123d;
+
+            numberBox.Value = doubleValue;
+            host.UpdateLayout();
+
+            var expectedDoubleText = 10.12345679d.ToString(CultureInfo.CurrentCulture);
+            Assert.AreEqual(doubleValue, numberBox.Value);
+            Assert.AreEqual(expectedDoubleText, numberBox.Text);
+            Assert.AreEqual(expectedDoubleText, inputBox.Text);
+        });
+    }
+
+    [TestMethod]
     public void MinMaxTest()
     {
         WpfTestHost.Run(() =>

--- a/test/ModernWpf.WinUI.Tests/NumberBox/NumberBoxSourceAuditTests.cs
+++ b/test/ModernWpf.WinUI.Tests/NumberBox/NumberBoxSourceAuditTests.cs
@@ -25,6 +25,7 @@ public class NumberBoxSourceAuditTests
         StringAssert.Contains(audit, "c7e2f98d978c81c2b7b0054eb042a6f8f816ec9c");
         StringAssert.Contains(audit, "beabd047460bf5d43a41fcf8bddf7730188bd5a7");
         StringAssert.Contains(audit, "49b4d5326b4deba8c036e63a7e676715a5de4f3a");
+        StringAssert.Contains(audit, "b4e5f2cafeae04f3a799123d48dca9516832becb");
         StringAssert.Contains(audit, "29f62479d5c046a0b854a5868e5a7cd484572d87");
         StringAssert.Contains(audit, "14a4a1a2b8ddc527dc4a7d5f7e743d7c2bc97db7");
         StringAssert.Contains(audit, "4bf79c2f673991f328230e60b218df60b3cabddb");
@@ -55,6 +56,8 @@ public class NumberBoxSourceAuditTests
         StringAssert.Contains(numberBox, "ReevaluateForwardedUIAProperties();");
         StringAssert.Contains(numberBox, "spinButtonsColumn.Width = spinButtonMode == NumberBoxSpinButtonPlacementMode.Inline");
         StringAssert.Contains(generatedProperties, "if (!double.IsNaN(value) || !double.IsNaN(Value))");
+        StringAssert.Contains(rounder, "var singleValue = (float)value;");
+        StringAssert.Contains(rounder, "singleValue.ToString(\"R\", CultureInfo.InvariantCulture)");
         StringAssert.Contains(rounder, "value.ToString(\"G\" + SignificantDigits, CultureInfo.InvariantCulture)");
 
         StringAssert.Contains(template, "x:Name=\"InputEater\"");


### PR DESCRIPTION
## Summary

- normalize exact `Single`-to-`Double` promotions through the Single's shortest round-trip representation before NumberBox formatting
- keep the underlying `Value` unchanged and preserve the current ten-significant-digit path for genuine doubles
- add the exact `10.4f` regression from the report plus a high-precision double guard
- document the WPF binding adaptation and related upstream WinUI #7851 precedent

## Validation

- `dotnet restore .\ModernWpf.sln` — passed
- `dotnet build .\ModernWpf.sln --configuration Release --no-restore --maxcpucount:1` — passed with 0 warnings and 0 errors
- focused `FloatValueDisplaySuppressesBinaryPrecisionArtifacts` regression — 1 passed, 0 skipped
- `FullyQualifiedName~NumberBox` — 19 passed, 0 skipped
- complete `ModernWpf.WinUI.Tests` on `net8.0-windows7.0` — 1,049 passed, 0 skipped
- `git diff --check` — passed

Fixes #267