### PR TITLE
Fix ItemsRepeater DataTemplate teardown

### DIFF
--- a/ModernWpf.Controls/Repeater/ItemsRepeater/ItemsRepeater.cs
+++ b/ModernWpf.Controls/Repeater/ItemsRepeater/ItemsRepeater.cs
@@ -629,7 +629,7 @@ namespace ModernWpf.Controls
                     {
                         m_itemTemplateWrapper = new ItemTemplateWrapper(selector);
                     }
-                    else
+                    else if (newValue != null)
                     {
                         throw new ArgumentException(nameof(newValue), "ItemTemplate");
                     }

--- a/docs/repeater-winui3-source-audit.md
+++ b/docs/repeater-winui3-source-audit.md
@@ -123,6 +123,13 @@ documented WPF-feasible `UniformGridLayout` adaptations.
 - WinUI lazily initializes the default layout state from `OnLayoutUpdated`.
   ModernWpf installs and initializes its default `StackLayout` in the
   constructor; the WPF layout-updated hook only resets the measure-cycle counter.
+- WPF clears a template-created element's resource-backed dependency properties
+  to their metadata defaults while dismantling the `FrameworkTemplate` tree.
+  `ItemsRepeater` therefore accepts a cleared `ItemTemplate` value after
+  recycling realized elements; non-null values must still be a `DataTemplate`,
+  `DataTemplateSelector`, or `IElementFactory`. The focused regression replaces
+  a `ListView` item whose old template contains a resource-backed repeater,
+  covering issue #257's exact teardown path.
 - The WPF `ScrollViewer.ChangeView` substitute clamps requested offsets, returns
   `true` only for an applied offset change, returns `false` for no-op and valid
   zoom-only requests, and rejects NaN/infinite offset or zoom values.

--- a/test/ModernWpf.WinUI.Tests/Repeater/ItemsRepeaterApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/Repeater/ItemsRepeaterApiTests.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Markup;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ModernWpf.Controls;
+using ModernWpf.WinUI.TestApp;
 using ModernWpf.WinUI.TestInfra;
 
 namespace ModernWpf.WinUI.Tests.Repeater;
@@ -131,6 +133,71 @@ public class ItemsRepeaterApiTests
         });
     }
 
+    [TestMethod]
+    public void ResourceBackedItemTemplateSurvivesOuterListViewItemReplacement()
+    {
+        WpfTestHost.Run(() =>
+        {
+            var repeaterTemplate = (DataTemplate)XamlReader.Parse(
+                @"<DataTemplate
+                      xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                      xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                      xmlns:ui='clr-namespace:ModernWpf.Controls;assembly=ModernWpf.Controls'>
+                      <StackPanel>
+                          <StackPanel.Resources>
+                              <DataTemplate x:Key='ItemsTemplate'>
+                                  <TextBlock Text='{Binding}' />
+                              </DataTemplate>
+                          </StackPanel.Resources>
+                          <ui:ItemsRepeater
+                              ItemTemplate='{StaticResource ItemsTemplate}'
+                              ItemsSource='{Binding Values}' />
+                      </StackPanel>
+                  </DataTemplate>");
+            var plainTemplate = (DataTemplate)XamlReader.Parse(
+                @"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
+                      <TextBlock Text='Equal' />
+                  </DataTemplate>");
+            var items = new ObservableCollection<object>
+            {
+                new object(),
+                new RepeaterValuesItem()
+            };
+            var listView = new System.Windows.Controls.ListView
+            {
+                ItemsSource = items,
+                ItemTemplateSelector = new RepeaterItemTemplateSelector
+                {
+                    PlainTemplate = plainTemplate,
+                    RepeaterTemplate = repeaterTemplate
+                }
+            };
+
+            using var host = new TestWindowHost(listView, width: 400, height: 200);
+            host.UpdateLayout();
+
+            var nestedRepeater = VisualTreeTestHelper
+                .EnumerateDescendants(listView)
+                .OfType<ItemsRepeater>()
+                .Single();
+            Assert.IsInstanceOfType<DataTemplate>(nestedRepeater.ItemTemplate);
+            Assert.IsNotNull(nestedRepeater.ItemTemplateShim);
+
+            items[1] = new object();
+            WpfTestHost.DoEvents();
+            host.UpdateLayout();
+
+            Assert.AreEqual(2, listView.Items.Count);
+            Assert.IsNotNull(listView.ItemContainerGenerator.ContainerFromIndex(1));
+            Assert.IsNull(nestedRepeater.ItemTemplate);
+            Assert.IsNull(nestedRepeater.ItemTemplateShim);
+            Assert.IsFalse(VisualTreeTestHelper
+                .EnumerateDescendants(listView)
+                .OfType<ItemsRepeater>()
+                .Any());
+        });
+    }
+
     private static TestWindowHost CreateScrollHost(ItemsRepeater repeater)
     {
         var scrollViewer = new ScrollViewer
@@ -150,5 +217,22 @@ public class ItemsRepeaterApiTests
             @"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
                   <TextBlock Text='{Binding}' Height='50' />
               </DataTemplate>");
+    }
+
+    private sealed class RepeaterValuesItem
+    {
+        public ObservableCollection<string> Values { get; } = new() { "one", "two" };
+    }
+
+    private sealed class RepeaterItemTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate? PlainTemplate { get; init; }
+
+        public DataTemplate? RepeaterTemplate { get; init; }
+
+        public override DataTemplate SelectTemplate(object item, DependencyObject container)
+        {
+            return item is RepeaterValuesItem ? RepeaterTemplate! : PlainTemplate!;
+        }
     }
 }

--- a/test/ModernWpf.WinUI.Tests/Repeater/RepeaterSourceAuditTests.cs
+++ b/test/ModernWpf.WinUI.Tests/Repeater/RepeaterSourceAuditTests.cs
@@ -16,6 +16,7 @@ public class RepeaterSourceAuditTests
         var repeater = Read(repoRoot, "ModernWpf.Controls", "Repeater", "ItemsRepeater", "ItemsRepeater.cs");
         var peer = Read(repoRoot, "ModernWpf.Controls", "Repeater", "Automation", "RepeaterAutomationPeer.cs");
         var automationTests = Read(repoRoot, "test", "ModernWpf.WinUI.Tests", "Repeater", "RepeaterAutomationPeerTests.cs");
+        var apiTests = Read(repoRoot, "test", "ModernWpf.WinUI.Tests", "Repeater", "ItemsRepeaterApiTests.cs");
         var galleryFactory = Read(repoRoot, "ModernWpf.Gallery", "Pages", "CollectionsSampleFactory.cs");
         var galleryTests = Read(repoRoot, "test", "ModernWpf.Gallery.Tests", "GalleryAutomationHookTests.cs");
         var harness = Read(repoRoot, "tools", "visual-checks", "Run-GalleryVisualChecks.ps1");
@@ -61,6 +62,9 @@ public class RepeaterSourceAuditTests
         StringAssert.Contains(repeater, "KeyboardNavigationMode.Once");
         StringAssert.Contains(repeater, "MaxStackLayoutIterations = 60");
         StringAssert.Contains(repeater, "return new RepeaterAutomationPeer(this);");
+        StringAssert.Contains(repeater, "else if (newValue != null)");
+        StringAssert.Contains(audit, "WPF clears a template-created element's resource-backed dependency properties");
+        StringAssert.Contains(apiTests, "ResourceBackedItemTemplateSurvivesOuterListViewItemReplacement");
         StringAssert.Contains(peer, "return AutomationControlType.Group;");
         StringAssert.Contains(peer, "if (virtInfo.IsRealized)");
         StringAssert.Contains(peer, "realizedPeers.OrderBy(x => x.Item1)");


### PR DESCRIPTION
## Summary

- allow `ItemsRepeater.ItemTemplate` to clear to its dependency-property default during WPF template teardown
- retain the existing rejection of unsupported non-null template values
- add an exact regression for replacing a `ListView` item whose old template contains a resource-backed `ItemsRepeater`
- document and pin the WPF-specific adaptation in the current WinUI 3 source audit

## Root cause

When WPF dismantles a `FrameworkTemplate`, it invalidates resource-backed dependency properties on generated elements back to their metadata defaults. In this case the nested repeater's `ItemTemplate` changes from the resolved `DataTemplate` to `null`. `OnItemTemplateChanged` correctly recycled the realized elements, but then treated that valid cleared value as an unsupported template and threw `ArgumentException`.

The WinUI-shaped validation remains in place for every non-null value; only WPF's valid cleared state is accepted.

## Reproduction

The regression mirrors the linked repro without its unrelated ReactiveUI dependencies: a `ListView` switches an item from a template containing an `ItemsRepeater` and locally scoped `DataTemplate` to a plain template.

Before the fix, the focused test failed with:

```text
System.ArgumentException: newValue (Parameter 'ItemTemplate')
at ModernWpf.Controls.ItemsRepeater.OnItemTemplateChanged(...)
```

After the fix, the template and factory shim clear cleanly and the old repeater leaves the visual tree.

## Validation

- focused issue regression: 1 passed, 0 failed, 0 skipped
- Repeater source-audit test: 1 passed, 0 failed, 0 skipped
- complete Repeater slice: 70 passed, 0 failed, 0 skipped
- `dotnet restore .\ModernWpf.sln`: passed
- `dotnet build .\ModernWpf.sln --configuration Release --no-restore --maxcpucount:1`: passed; 0 warnings, 0 errors; product targets `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0` built
- complete `ModernWpf.WinUI.Tests` on `net8.0-windows7.0`: 1,051 passed, 0 failed, 0 skipped

`ModernWpf.WinUI.Tests` itself targets only `net8.0-windows7.0`; there is no net10 test target. The product's net10 build is covered by the solution build.

Fixes #257