### PR TITLE
Fix custom title bar caption height

### DIFF
--- a/ModernWpf/TitleBar/TitleBarControl.cs
+++ b/ModernWpf/TitleBar/TitleBarControl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Automation.Peers;
@@ -26,6 +27,9 @@ namespace ModernWpf.Controls.Primitives
         private const string MaximizeRestoreButtonName = "PART_MaximizeRestoreButton";
         private const string LeftSystemOverlayName = "PART_LeftSystemOverlay";
         private const string RightSystemOverlayName = "PART_RightSystemOverlay";
+
+        private static readonly DependencyPropertyDescriptor WindowChromePropertyDescriptor =
+            DependencyPropertyDescriptor.FromProperty(WindowChrome.WindowChromeProperty, typeof(Window));
 
         private Window _parentWindow;
         private HwndSource _parentHwndSource;
@@ -407,6 +411,10 @@ namespace ModernWpf.Controls.Primitives
         {
             if (_parentWindow != null)
             {
+                WindowChromePropertyDescriptor.RemoveValueChanged(
+                    _parentWindow,
+                    OnWindowChromeChanged);
+
                 if (_altLeftBinding != null)
                 {
                     _parentWindow.InputBindings.Remove(_altLeftBinding);
@@ -420,6 +428,8 @@ namespace ModernWpf.Controls.Primitives
 
             if (_parentWindow != null)
             {
+                UpdateWindowChromeCaptionHeight();
+
                 _altLeftBinding = new KeyBinding(new GoBackCommand(this), Key.Left, ModifierKeys.Alt);
                 _parentWindow.InputBindings.Add(_altLeftBinding);
             }
@@ -432,6 +442,40 @@ namespace ModernWpf.Controls.Primitives
             if (TemplatedParent is Window window)
             {
                 TitleBar.SetHeight(window, sizeInfo.NewSize.Height);
+                UpdateWindowChromeCaptionHeight();
+            }
+        }
+
+        private void OnWindowChromeChanged(object sender, EventArgs e)
+        {
+            Dispatcher.BeginInvoke(new Action(UpdateWindowChromeCaptionHeight));
+        }
+
+        private void UpdateWindowChromeCaptionHeight()
+        {
+            if (_parentWindow != null &&
+                WindowChrome.GetWindowChrome(_parentWindow) is { } chrome)
+            {
+                double height = TitleBar.GetHeight(_parentWindow);
+                if (chrome.CaptionHeight != height)
+                {
+                    var valueSource = DependencyPropertyHelper.GetValueSource(
+                        _parentWindow,
+                        WindowChrome.WindowChromeProperty);
+                    if (valueSource.BaseValueSource == BaseValueSource.Local &&
+                        !valueSource.IsExpression)
+                    {
+                        chrome.CaptionHeight = height;
+                    }
+                    else
+                    {
+                        var updatedChrome = (WindowChrome)chrome.CloneCurrentValue();
+                        updatedChrome.CaptionHeight = height;
+                        _parentWindow.SetCurrentValue(
+                            WindowChrome.WindowChromeProperty,
+                            updatedChrome);
+                    }
+                }
             }
         }
 
@@ -441,6 +485,14 @@ namespace ModernWpf.Controls.Primitives
             {
                 return;
             }
+
+            WindowChromePropertyDescriptor.RemoveValueChanged(
+                _parentWindow,
+                OnWindowChromeChanged);
+            WindowChromePropertyDescriptor.AddValueChanged(
+                _parentWindow,
+                OnWindowChromeChanged);
+            UpdateWindowChromeCaptionHeight();
 
             var hwndSource = PresentationSource.FromVisual(this) as HwndSource;
             if (!ReferenceEquals(hwndSource, _parentHwndSource))
@@ -453,6 +505,13 @@ namespace ModernWpf.Controls.Primitives
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
         {
+            if (_parentWindow != null)
+            {
+                WindowChromePropertyDescriptor.RemoveValueChanged(
+                    _parentWindow,
+                    OnWindowChromeChanged);
+            }
+
             RemoveWindowHook();
         }
 

--- a/docs/titlebar-winui3-gallery-parity.md
+++ b/docs/titlebar-winui3-gallery-parity.md
@@ -111,6 +111,13 @@ WinUI API name was added. Its attached window state, icon handling, title
 content, back/pane buttons, and WPF `WindowChrome` integration remain native to
 WPF.
 
+The retained shell's public `TitleBar.HeightKey` is a WPF-specific
+customization point. A window-scoped override now drives the rendered
+`TitleBarControl`, read-only `TitleBar.Height`, and
+`WindowChrome.CaptionHeight` together, including runtime resource changes and
+chrome replacement. Native `WM_NCHITTEST` coverage verifies that the region
+below the former 32-DIP boundary remains draggable at a larger custom height.
+
 `ModernWpf.Gallery\Pages\WindowingSampleFactory.cs` now mirrors all three
 current Gallery examples. The configuration code and visible preview use the
 stretch resource, `MaxWidth="580"`, and `Search...`. The new drag-region window

--- a/docs/window-wpf-fluent-source-audit.md
+++ b/docs/window-wpf-fluent-source-audit.md
@@ -50,6 +50,12 @@ ModernWpf now follows the compatible parts of that source shape:
   bit. Applications can remove that bit during `SourceInitialized` while
   retaining `WindowHelper.UseModernWindowStyle`; the custom command is then
   disabled and cannot minimize the window.
+- A window-scoped `TitleBar.HeightKey` override keeps the rendered
+  `TitleBarControl`, the read-only `TitleBar.Height` value, and
+  `WindowChrome.CaptionHeight` synchronized. The synchronization also follows
+  runtime resource changes and replacement chrome objects, so the entire
+  visible title-bar height remains draggable instead of retaining the default
+  32-DIP caption boundary.
 - Disabled custom caption buttons remain inert when Windows 11 routes their
   input through non-client messages. In particular, `ResizeMode=CanMinimize`
   keeps the disabled maximize button from invoking its command.
@@ -99,6 +105,11 @@ surface.
   `SourceInitialized` disables the ModernWpf minimize button and its routed
   command, and that the non-client click bridge cannot invoke the disabled
   maximize button when `ResizeMode=CanMinimize`.
+- `WindowVisualStateTests` scopes `TitleBar.HeightKey` to one window, verifies
+  rendered/read-only/chrome heights at 56 DIPs, sends `WM_NCHITTEST` through
+  the area below the former 32-DIP boundary, changes the resource to 64 DIPs,
+  and verifies that an explicitly replaced `WindowChrome` is synchronized
+  without replacing the caller-owned instance.
 - `WindowVisualStateTests` sends native `WM_NCHITTEST` messages across the
   first four content pixels below the title bar and verifies `HTCLIENT`, while
   separately retaining `HTCAPTION` for draggable title space and

--- a/test/ModernWpf.WinUI.Tests/CommonStyles/WindowVisualStateTests.cs
+++ b/test/ModernWpf.WinUI.Tests/CommonStyles/WindowVisualStateTests.cs
@@ -19,6 +19,89 @@ namespace ModernWpf.WinUI.Tests.CommonStyles;
 public class WindowVisualStateTests
 {
     [TestMethod]
+    public void TitleBarHeightResourceControlsRenderedAndDraggableHeight()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var window = new Window
+            {
+                Width = 420,
+                Height = 240,
+                Left = -32000,
+                Top = -32000,
+                Content = new Border(),
+                ShowInTaskbar = false,
+                WindowStartupLocation = WindowStartupLocation.Manual
+            };
+            window.Resources[ModernWpf.Controls.TitleBar.HeightKey] = 56d;
+            WindowHelper.SetUseModernWindowStyle(window, true);
+
+            try
+            {
+                window.Show();
+                WpfTestHost.DoEvents();
+                window.UpdateLayout();
+                WpfTestHost.DoEvents();
+
+                var titleBar = VisualTreeTestHelper.FindDescendant<TitleBarControl>(window);
+                var chrome = WindowChrome.GetWindowChrome(window);
+
+                Assert.IsNotNull(titleBar);
+                Assert.IsNotNull(chrome);
+                Assert.AreEqual(56d, titleBar.ActualHeight, 0.1);
+                Assert.AreEqual(56d, ModernWpf.Controls.TitleBar.GetHeight(window), 0.1);
+                Assert.AreEqual(56d, chrome.CaptionHeight, 0.1);
+
+                var handle = new WindowInteropHelper(window).Handle;
+                var captionHitTests = new[] { 8d, 24d, 36d, 44d, 52d }
+                    .Select(offset =>
+                    {
+                        var point = titleBar.PointToScreen(
+                            new Point(titleBar.ActualWidth / 2, offset));
+                        return SendMessage(
+                            handle,
+                            WmNcHitTest,
+                            IntPtr.Zero,
+                            PackScreenPoint(
+                                (int)Math.Floor(point.X),
+                                (int)Math.Floor(point.Y))).ToInt32();
+                    })
+                    .ToArray();
+                CollectionAssert.AreEqual(
+                    new[] { HtCaption, HtCaption, HtCaption, HtCaption, HtCaption },
+                    captionHitTests,
+                    $"Actual hit tests: {string.Join(",", captionHitTests)}.");
+
+                window.Resources[ModernWpf.Controls.TitleBar.HeightKey] = 64d;
+                WpfTestHost.DoEvents();
+                window.UpdateLayout();
+
+                chrome = WindowChrome.GetWindowChrome(window);
+                Assert.IsNotNull(chrome);
+                Assert.AreEqual(64d, titleBar.ActualHeight, 0.1);
+                Assert.AreEqual(64d, ModernWpf.Controls.TitleBar.GetHeight(window), 0.1);
+                Assert.AreEqual(64d, chrome!.CaptionHeight, 0.1);
+
+                var replacementChrome = new ModernWindowChrome { CaptionHeight = 32d };
+                WindowChrome.SetWindowChrome(window, replacementChrome);
+                WpfTestHost.DoEvents();
+
+                var synchronizedReplacement = WindowChrome.GetWindowChrome(window);
+                Assert.IsNotNull(synchronizedReplacement);
+                Assert.AreSame(replacementChrome, synchronizedReplacement);
+                Assert.AreEqual(64d, synchronizedReplacement!.CaptionHeight, 0.1);
+            }
+            finally
+            {
+                window.Close();
+                WpfTestHost.DoEvents();
+            }
+        });
+    }
+
+    [TestMethod]
     public void WindowStyleUsesOfficialWpfFluentResourceSurfaceWithModernWpfChrome()
     {
         WpfTestHost.Run(() =>

--- a/test/ModernWpf.WinUI.Tests/TitleBar/TitleBarSourceAuditTests.cs
+++ b/test/ModernWpf.WinUI.Tests/TitleBar/TitleBarSourceAuditTests.cs
@@ -14,6 +14,12 @@ public class TitleBarSourceAuditTests
         var audit = Read(repoRoot, "docs", "titlebar-winui3-gallery-parity.md");
         var control = Read(repoRoot, "ModernWpf", "TitleBar", "TitleBarControl.cs");
         var peer = Read(repoRoot, "ModernWpf", "TitleBar", "TitleBarControlAutomationPeer.cs");
+        var windowTests = Read(
+            repoRoot,
+            "test",
+            "ModernWpf.WinUI.Tests",
+            "CommonStyles",
+            "WindowVisualStateTests.cs");
         var galleryFactory = Read(repoRoot, "ModernWpf.Gallery", "Pages", "WindowingSampleFactory.cs");
         var harness = Read(repoRoot, "tools", "visual-checks", "Run-GalleryVisualChecks.ps1");
 
@@ -46,12 +52,22 @@ public class TitleBarSourceAuditTests
         StringAssert.Contains(audit, "`6.819` local delta");
         StringAssert.Contains(audit, "`7.897` local delta");
         StringAssert.Contains(audit, "controls\\dev\\TitleBar\\TitleBar.cpp");
+        StringAssert.Contains(audit, "TitleBar.HeightKey");
+        StringAssert.Contains(audit, "WindowChrome.CaptionHeight");
+        StringAssert.Contains(audit, "WM_NCHITTEST");
         Assert.IsFalse(audit.Contains("`src\\controls\\dev\\TitleBar", StringComparison.Ordinal));
 
         StringAssert.Contains(control, "return new TitleBarControlAutomationPeer(this);");
+        StringAssert.Contains(control, "UpdateWindowChromeCaptionHeight");
+        StringAssert.Contains(control, "WindowChrome.WindowChromeProperty");
+        StringAssert.Contains(control, "CloneCurrentValue");
         StringAssert.Contains(peer, "return AutomationControlType.TitleBar;");
         StringAssert.Contains(peer, "return \"TitleBar\";");
         StringAssert.Contains(peer, "name = ((TitleBarControl)Owner).Title;");
+
+        StringAssert.Contains(windowTests, "TitleBarHeightResourceControlsRenderedAndDraggableHeight");
+        StringAssert.Contains(windowTests, "WmNcHitTest");
+        StringAssert.Contains(windowTests, "Assert.AreSame(replacementChrome, synchronizedReplacement);");
 
         StringAssert.Contains(galleryFactory, "TitleBarContentHorizontalAlignment");
         StringAssert.Contains(galleryFactory, "MaxWidth=\"\"580\"\"");


### PR DESCRIPTION
Fixes #251

## Summary

- keep a window-scoped `TitleBar.HeightKey` override synchronized across the rendered title bar, read-only `TitleBar.Height`, and the active `WindowChrome.CaptionHeight`
- replace style/resource-provided chrome when needed so WPF's native chrome worker observes the new caption height, while preserving an explicitly caller-owned `WindowChrome` instance
- add native `WM_NCHITTEST` regression coverage for the full custom height, runtime height changes, and chrome replacement
- pin the WPF-specific behavior in the TitleBar and Window source audits

## Reproduction

Before the fix, a 56-DIP title bar rendered at the requested height but the active native caption boundary stayed at 32 DIPs. The exact regression returned caption/client hit results `2,2,1,1,1` at vertical offsets `8,24,36,44,52`, reproducing the issue below the former 32-DIP boundary.

## Validation

- exact issue regression: 1 passed, 0 skipped
- TitleBar source-audit test: 1 passed, 0 skipped
- complete `WindowVisualStateTests`: 8 passed, 0 skipped
- TitleBar-related WinUI slice: 16 passed, 0 skipped
- `dotnet restore ModernWpf.sln`: passed
- serialized Release solution build across `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0`: passed with 0 warnings and 0 errors
- complete `ModernWpf.WinUI.Tests` on `net8.0-windows7.0`: 1,052 passed, 0 skipped