### PR TITLE
Let TitleBarButton text inherit the host font

### DIFF
--- a/ModernWpf/TitleBar/TitleBarButton.xaml
+++ b/ModernWpf/TitleBar/TitleBarButton.xaml
@@ -14,7 +14,6 @@
         <Setter Property="HoverForeground" Value="{DynamicResource SystemControlHighlightAltBaseHighBrush}" />
         <Setter Property="PressedBackground" Value="{DynamicResource SystemControlHighlightListMediumBrush}" />
         <Setter Property="PressedForeground" Value="{DynamicResource SystemControlHighlightAltBaseHighBrush}" />
-        <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}" />
         <Setter Property="FontSize" Value="10" />
         <Setter Property="Height" Value="{DynamicResource {x:Static local:TitleBar.HeightKey}}" />
         <Setter Property="Width" Value="46" />

--- a/docs/titlebar-winui3-gallery-parity.md
+++ b/docs/titlebar-winui3-gallery-parity.md
@@ -118,6 +118,12 @@ customization point. A window-scoped override now drives the rendered
 chrome replacement. Native `WM_NCHITTEST` coverage verifies that the region
 below the former 32-DIP boundary remains draggable at a larger custom height.
 
+`TitleBarButton` also retains normal WPF content-font inheritance. Its built-in
+caption and back icons use `StreamGeometry` through `FontIconFallback`, so the
+old control-wide `SymbolThemeFontFamily` setter is neither needed for those
+icons nor appropriate for arbitrary content. A nested `TextBlock` now inherits
+the host font unless the application explicitly gives it another font.
+
 `ModernWpf.Gallery\Pages\WindowingSampleFactory.cs` now mirrors all three
 current Gallery examples. The configuration code and visible preview use the
 stretch resource, `MaxWidth="580"`, and `Search...`. The new drag-region window

--- a/test/ModernWpf.WinUI.Tests/TitleBar/TitleBarApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/TitleBar/TitleBarApiTests.cs
@@ -206,6 +206,38 @@ public class TitleBarApiTests
     }
 
     [TestMethod]
+    public void TitleBarButtonTextContentInheritsHostFontFamily()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var expectedFontFamily = new FontFamily("Segoe UI");
+            var textBlock = new TextBlock
+            {
+                FontSize = 10,
+                FontWeight = FontWeights.Bold,
+                Text = "aaaaaaaaa"
+            };
+            var titleBarButton = new TitleBarButton
+            {
+                Content = textBlock
+            };
+            var hostContent = new ContentControl
+            {
+                Content = titleBarButton,
+                FontFamily = expectedFontFamily
+            };
+
+            using var host = new TestWindowHost(hostContent, width: 320, height: 160);
+            host.UpdateLayout();
+
+            Assert.AreEqual(expectedFontFamily.Source, titleBarButton.FontFamily.Source);
+            Assert.AreEqual(expectedFontFamily.Source, textBlock.FontFamily.Source);
+        });
+    }
+
+    [TestMethod]
     public void ModernWindowMinimizeButtonHonorsNativeWindowStyle()
     {
         WpfTestHost.Run(() =>

--- a/test/ModernWpf.WinUI.Tests/TitleBar/TitleBarSourceAuditTests.cs
+++ b/test/ModernWpf.WinUI.Tests/TitleBar/TitleBarSourceAuditTests.cs
@@ -13,7 +13,15 @@ public class TitleBarSourceAuditTests
         var repoRoot = FindRepoRoot();
         var audit = Read(repoRoot, "docs", "titlebar-winui3-gallery-parity.md");
         var control = Read(repoRoot, "ModernWpf", "TitleBar", "TitleBarControl.cs");
+        var controlTemplate = Read(repoRoot, "ModernWpf", "TitleBar", "TitleBarControl.xaml");
+        var buttonStyle = Read(repoRoot, "ModernWpf", "TitleBar", "TitleBarButton.xaml");
         var peer = Read(repoRoot, "ModernWpf", "TitleBar", "TitleBarControlAutomationPeer.cs");
+        var titleBarTests = Read(
+            repoRoot,
+            "test",
+            "ModernWpf.WinUI.Tests",
+            "TitleBar",
+            "TitleBarApiTests.cs");
         var windowTests = Read(
             repoRoot,
             "test",
@@ -55,6 +63,7 @@ public class TitleBarSourceAuditTests
         StringAssert.Contains(audit, "TitleBar.HeightKey");
         StringAssert.Contains(audit, "WindowChrome.CaptionHeight");
         StringAssert.Contains(audit, "WM_NCHITTEST");
+        StringAssert.Contains(audit, "normal WPF content-font inheritance");
         Assert.IsFalse(audit.Contains("`src\\controls\\dev\\TitleBar", StringComparison.Ordinal));
 
         StringAssert.Contains(control, "return new TitleBarControlAutomationPeer(this);");
@@ -64,7 +73,15 @@ public class TitleBarSourceAuditTests
         StringAssert.Contains(peer, "return AutomationControlType.TitleBar;");
         StringAssert.Contains(peer, "return \"TitleBar\";");
         StringAssert.Contains(peer, "name = ((TitleBarControl)Owner).Title;");
+        StringAssert.Contains(controlTemplate, "<StreamGeometry x:Key=\"ChromeClose\">");
+        StringAssert.Contains(controlTemplate, "<local:FontIconFallback Data=\"{Binding}\" />");
+        Assert.IsFalse(
+            buttonStyle.Contains(
+                "<Setter Property=\"FontFamily\" Value=\"{DynamicResource SymbolThemeFontFamily}\" />",
+                StringComparison.Ordinal));
 
+        StringAssert.Contains(titleBarTests, "TitleBarButtonTextContentInheritsHostFontFamily");
+        StringAssert.Contains(titleBarTests, "Assert.AreEqual(expectedFontFamily.Source, textBlock.FontFamily.Source);");
         StringAssert.Contains(windowTests, "TitleBarHeightResourceControlsRenderedAndDraggableHeight");
         StringAssert.Contains(windowTests, "WmNcHitTest");
         StringAssert.Contains(windowTests, "Assert.AreSame(replacementChrome, synchronizedReplacement);");


### PR DESCRIPTION
Fixes #250

## Summary

- remove the obsolete control-wide `SymbolThemeFontFamily` setter from the default `TitleBarButton` style
- allow ordinary content, including the reported nested `TextBlock`, to inherit the host application's font like normal WPF button content
- retain built-in caption/back icons through their existing `StreamGeometry` + `FontIconFallback` path
- add an exact runtime regression and pin the WPF-specific behavior in the TitleBar source audit

## Reproduction

The exact reported `TitleBarButton` with a nested bold 10px `TextBlock` was hosted under `Segoe UI`. Before the fix, the regression failed with:

- expected: `Segoe UI`
- actual: `Segoe Fluent Icons, Segoe MDL2 Assets`

The stale symbol-font setter survived the 2020 switch of built-in caption icons from font glyph strings to vector geometry.

## Validation

- exact issue regression: 1 passed, 0 skipped
- TitleBar source-audit test: 1 passed, 0 skipped
- complete TitleBar-related WinUI slice: 17 passed, 0 skipped
- `dotnet restore ModernWpf.sln`: passed
- serialized Release solution build across `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0`: passed with 0 warnings and 0 errors
- complete `ModernWpf.WinUI.Tests` on `net8.0-windows7.0`: 1,053 passed, 0 skipped