### PR TITLE
Restore custom TextBox validation error bindings

### DIFF
--- a/ModernWpf/Styles/TextBox.xaml
+++ b/ModernWpf/Styles/TextBox.xaml
@@ -66,8 +66,7 @@
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{TemplateBinding Border.CornerRadius}"
-                            primitives:ValidationHelper.IsTemplateValidationAdornerSite="True" />
+                            CornerRadius="{TemplateBinding Border.CornerRadius}" />
 
                         <ScrollViewer
                             x:Name="PART_ContentHost"
@@ -158,8 +157,7 @@
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"
                 MinHeight="{TemplateBinding MinHeight}"
-                CornerRadius="{TemplateBinding Border.CornerRadius}"
-                primitives:ValidationHelper.IsTemplateValidationAdornerSite="True" />
+                CornerRadius="{TemplateBinding Border.CornerRadius}" />
 
             <ScrollViewer
                     x:Name="PART_ContentHost"

--- a/docs/official-fluent-backport-sync.md
+++ b/docs/official-fluent-backport-sync.md
@@ -666,13 +666,13 @@ Source inspected:
 | Text-entry context menu | `DefaultControlContextMenu` for `TextBox` / `TextBoxBase`, `DefaultPasswordBoxContextMenu` for `PasswordBox` | `TextControlContextMenu` plus `TextContextMenu.UsingTextContextMenu=True` | Keeps ModernWpf's existing text-control context-menu integration. |
 | Text-entry corner radius property | `Border.CornerRadius` setters and template bindings | `Border.CornerRadius` | Older ModernWpf targets do not expose the official source property on these controls; this preserves the existing backport radius bridge. |
 | `TextBox` clear-button command | `TemplateButtonCommand` | `TextBoxHelper.IsDeleteButton` | Older target frameworks do not expose the official platform command property; the substitution keeps the official button shape and clear behavior. |
-| `TextBox` validation chrome | Official `DefaultTextBoxInvalidationStyle` | Existing `TextControlValidationErrorTemplate` plus `ValidationHelper.IsTemplateValidationAdornerSite` | Keeps ModernWpf's existing validation adorner routing. |
+| `TextBox` validation chrome | Official `DefaultTextBoxInvalidationStyle` | Existing `TextControlValidationErrorTemplate` on the TextBox itself, without internal-site redirection | Retains the existing public error-template resource while restoring standard WPF `Validation.Errors` data-context behavior; the official template's `ContentBorder` fills the TextBox, so chrome bounds are unchanged. |
 | `DataGridTextBoxStyle` | No official `TextBox.xaml` equivalent | Retained as a support style based on `DefaultTextBoxStyle` | Kept as a compatibility resource for callers that reference it directly; the stock DataGrid template no longer wires it through `DataGridHelper`. |
 | `TextBoxTopHeaderMargin` / `PasswordBoxTopHeaderMargin` | No official stock template use | Retained as unused public aliases | Avoids unnecessary resource-surface churn while the official templates no longer consume header presenter resources. |
 
 ### Test Evidence
 
-- `test\ModernWpf.WinUI.Tests\CommonStyles\TextBoxPasswordBoxVisualStateTests.cs` covers the official WPF Fluent TextBox, TextBoxBase, and PasswordBox setter surfaces, template parts, trigger shapes, clear-button substitution, retained `DataGridTextBoxStyle`, and deletion of ModernWpf-specific template guesses.
+- `test\ModernWpf.WinUI.Tests\CommonStyles\TextBoxPasswordBoxVisualStateTests.cs` covers the official WPF Fluent TextBox, TextBoxBase, and PasswordBox setter surfaces, template parts, trigger shapes, clear-button substitution, retained `DataGridTextBoxStyle`, standard custom validation-template error binding, and deletion of ModernWpf-specific template guesses.
 - `test\ModernWpf.WinUI.Tests\TemplateParityTests.cs` classifies `TextBox.xaml` and `PasswordBox.xaml` as official WPF Fluent stock template files that should not use `VisualStateEx`.
 
 ## 2026-05-18 Batch 23

--- a/docs/textbox-passwordbox-wpf-fluent-source-audit.md
+++ b/docs/textbox-passwordbox-wpf-fluent-source-audit.md
@@ -40,14 +40,16 @@ the stock WPF `TextBox`, `TextBoxBase`, and `PasswordBox` templates.
 - Official WPF Fluent uses `DefaultControlContextMenu`; ModernWpf keeps
   `TextControlContextMenu` plus `TextContextMenu.UsingTextContextMenu` so the
   existing text-control context menu integration remains available.
-- ModernWpf keeps `Validation.ErrorTemplate` and
-  `ValidationHelper.IsTemplateValidationAdornerSite` for `TextBox` and
-  `TextBoxBase` validation chrome. When validation is already invalid before
-  the template is applied, the helper suppresses the deferred original-site
-  adorner while redirecting validation to the template border, then restores
-  the existing error-template value source at dispatcher `Loaded` priority.
-  This prevents the original-site adorner from remaining after validation
-  succeeds.
+- ModernWpf keeps `Validation.ErrorTemplate` for `TextBox` and `TextBoxBase`
+  validation chrome, but no longer redirects their adorner to the internal
+  `ContentBorder`. WPF initializes an error template's data context from
+  `Validation.Errors` on the adorned element; redirecting to the border made
+  normal custom-template bindings such as `{Binding}` observe an empty
+  collection. The official stock template has no header or description branch
+  and `ContentBorder` fills the `TextBox`, so the standard TextBox-owned adorner
+  retains the same chrome bounds while restoring normal WPF error-template
+  semantics. Initial-error coverage also verifies that the adorner is removed
+  after the value becomes valid.
 - Official WPF Fluent's `TextBox` clear button invokes the newer WPF
   `TemplateButtonCommand`. ModernWpf older targets do not expose that platform
   property, so the clear button uses the existing
@@ -74,9 +76,9 @@ the stock WPF `TextBox`, `TextBoxBase`, and `PasswordBox` templates.
 - `test\ModernWpf.WinUI.Tests\CommonStyles\TextBoxPasswordBoxVisualStateTests.cs`
   covers the official WPF Fluent style setter surfaces, template parts,
   trigger shapes, clear-button substitution and visibility opt-out,
-  `DataGridTextBoxStyle`,
-  initial-error validation-adorners, and deletion of the old WinUI-derived
-  template branches.
+  `DataGridTextBoxStyle`, initial-error validation-adorners, normal
+  `Validation.Errors` binding in a custom error template, and deletion of the
+  old WinUI-derived template branches.
 - `test\ModernWpf.WinUI.Tests\TemplateParityTests.cs` classifies
   `ModernWpf\Styles\TextBox.xaml` and
   `ModernWpf\Styles\PasswordBox.xaml` as official WPF Fluent stock templates

--- a/test/ModernWpf.WinUI.Tests/CommonStyles/TextBoxPasswordBoxVisualStateTests.cs
+++ b/test/ModernWpf.WinUI.Tests/CommonStyles/TextBoxPasswordBoxVisualStateTests.cs
@@ -110,6 +110,69 @@ public class TextBoxPasswordBoxVisualStateTests
     }
 
     [TestMethod]
+    public void CustomTextBoxValidationErrorTemplateReceivesTextBoxErrors()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var errorTemplate = CreateValidationErrorsTemplate();
+            var model = new RequiredTextModel();
+            var textBox = new TextBox
+            {
+                DataContext = model,
+                Width = 240
+            };
+            textBox.Resources["TextControlValidationErrorTemplate"] = errorTemplate;
+            textBox.SetBinding(
+                TextBox.TextProperty,
+                new Binding(nameof(RequiredTextModel.Value))
+                {
+                    Mode = BindingMode.TwoWay,
+                    UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
+                    ValidatesOnDataErrors = true
+                });
+            WpfTestHost.DoEvents();
+
+            Assert.IsTrue(
+                Validation.GetHasError(textBox),
+                "The binding must be invalid before the TextBox template is applied.");
+
+            using var host = new TestWindowHost(textBox, width: 320, height: 160);
+            host.UpdateLayout();
+            WpfTestHost.DoEvents();
+
+            var contentBorder = GetTemplateChild<Border>(textBox, "ContentBorder");
+            var adornerLayer = AdornerLayer.GetAdornerLayer(textBox)
+                ?? throw new AssertFailedException("Expected the hosted TextBox to have an AdornerLayer.");
+            var adorners = (adornerLayer.GetAdorners(textBox) ?? System.Array.Empty<Adorner>())
+                .Concat(adornerLayer.GetAdorners(contentBorder) ?? System.Array.Empty<Adorner>())
+                .ToArray();
+            var errorAdorner = adorners
+                .SingleOrDefault(
+                    adorner => VisualTreeTestHelper.FindDescendant<ItemsControl>(adorner) != null)
+                ?? throw new AssertFailedException("Expected the custom validation error template to be displayed.");
+            var validationErrors = VisualTreeTestHelper.FindDescendant<ItemsControl>(errorAdorner)
+                ?? throw new AssertFailedException("Expected the custom validation error template to contain its ItemsControl.");
+
+            Assert.AreSame(errorTemplate, Validation.GetErrorTemplate(textBox));
+            Assert.AreSame(
+                textBox,
+                errorAdorner.AdornedElement,
+                "The standard WPF validation adorner must read errors from the TextBox that owns them.");
+            Assert.AreEqual(
+                textBox.RenderSize,
+                contentBorder.RenderSize,
+                "Adorning the TextBox must retain the same validation-chrome bounds as its full-size ContentBorder.");
+            Assert.AreEqual(1, validationErrors.Items.Count);
+            Assert.IsInstanceOfType(validationErrors.Items[0], typeof(ValidationError));
+            Assert.AreEqual(
+                "Value is required.",
+                ((ValidationError)validationErrors.Items[0]).ErrorContent);
+        });
+    }
+
+    [TestMethod]
     public void DefaultTextBoxBaseStyleUsesOfficialWpfFluentTemplateShape()
     {
         WpfTestHost.Run(() =>
@@ -235,6 +298,7 @@ public class TextBoxPasswordBoxVisualStateTests
         Assert.IsFalse(text.Contains("TemplateButtonCommand", System.StringComparison.Ordinal));
         Assert.IsFalse(text.Contains("ControlHelper.CornerRadius", System.StringComparison.Ordinal));
         Assert.IsFalse(text.Contains("DefaultControlContextMenu", System.StringComparison.Ordinal));
+        Assert.IsFalse(text.Contains("ValidationHelper.IsTemplateValidationAdornerSite", System.StringComparison.Ordinal));
     }
 
     [TestMethod]
@@ -436,7 +500,7 @@ public class TextBoxPasswordBoxVisualStateTests
         Assert.AreEqual(textBox.BorderThickness, contentBorder.BorderThickness);
         Assert.AreEqual(textBox.MinHeight, contentBorder.MinHeight);
         Assert.AreEqual(((CornerRadius)textBox.GetValue(System.Windows.Controls.Border.CornerRadiusProperty)), contentBorder.CornerRadius);
-        Assert.IsTrue(ValidationHelper.GetIsTemplateValidationAdornerSite(contentBorder));
+        Assert.IsFalse(ValidationHelper.GetIsTemplateValidationAdornerSite(contentBorder));
 
         Assert.AreEqual(textBox.BorderThickness, contentHost.Margin);
         Assert.AreEqual(textBox.Padding, contentHost.Padding);
@@ -726,6 +790,28 @@ public class TextBoxPasswordBoxVisualStateTests
     {
         return (adornerLayer.GetAdorners(textBox)?.Length ?? 0)
             + (adornerLayer.GetAdorners(contentBorder)?.Length ?? 0);
+    }
+
+    private static ControlTemplate CreateValidationErrorsTemplate()
+    {
+        const string xaml = """
+            <ControlTemplate
+                xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                <StackPanel>
+                    <AdornedElementPlaceholder />
+                    <ItemsControl ItemsSource="{Binding}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding ErrorContent}" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </ControlTemplate>
+            """;
+
+        return (ControlTemplate)XamlReader.Parse(xaml);
     }
 
     private static string FindRepoRoot()


### PR DESCRIPTION
Fixes #188

## Summary

- stop redirecting stock `TextBox` / `TextBoxBase` validation adorners to the internal `ContentBorder`
- restore standard WPF `Validation.Errors` data-context behavior for custom error templates using `{Binding}`
- retain identical validation-chrome bounds because the audited official WPF Fluent `ContentBorder` fills the TextBox
- add the exact custom-template regression and update the WPF Fluent source-audit records

## Reproduction

The regression uses the issue's custom `ControlTemplate` shape: an `AdornedElementPlaceholder` followed by an `ItemsControl ItemsSource="{Binding}"`. Before the fix, the error template displayed but failed with:

- expected validation items: `1`
- actual validation items: `0`

WPF initializes an error template's data context from `Validation.Errors` on the adorned element. The old redirection adorned an internal border that owned no validation errors.

## Validation

- exact regression plus initial-error cleanup and TextBox template/source checks: 5 passed, 0 skipped
- complete `TextBoxPasswordBoxVisualStateTests`: 9 passed, 0 skipped
- `TemplateParityTests`: 24 passed, 0 skipped
- `dotnet restore ModernWpf.sln`: passed, including dependency audit
- serialized `dotnet build ModernWpf.sln --configuration Release --no-restore`: passed across `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0` with 0 warnings and 0 errors
- complete `ModernWpf.WinUI.Tests` on its configured `net8.0-windows7.0` target: 1,054 passed, 0 skipped
- complete `ModernWpf.Theme.Tests` on `net8.0-windows7.0`: 17 passed, 0 skipped
- complete `ModernWpf.Theme.Tests` on `net10.0-windows7.0`: 20 passed, 0 skipped

`ModernWpf.WinUI.Tests` itself targets only net8; net10 product compilation is covered by the full solution build.