### PR TITLE
Fix horizontal GridView mouse-wheel scrolling

### DIFF
--- a/ModernWpf/Controls/ScrollViewerEx.cs
+++ b/ModernWpf/Controls/ScrollViewerEx.cs
@@ -25,6 +25,19 @@ namespace ModernWpf.Controls
             {
                 base.OnMouseWheel(e);
             }
+            else if (ScrollableWidth > 0 && ScrollInfo != null)
+            {
+                if (e.Delta < 0)
+                {
+                    ScrollInfo.MouseWheelRight();
+                }
+                else
+                {
+                    ScrollInfo.MouseWheelLeft();
+                }
+
+                e.Handled = true;
+            }
         }
 
         /*private bool CanScrollVerticallyInDirection(bool inPositiveDirection)

--- a/docs/listview-winui3-source-audit.md
+++ b/docs/listview-winui3-source-audit.md
@@ -86,6 +86,13 @@ ModernWpf's generated page resolves the same current content through `Collection
   templated `ScrollViewerEx` instances bind that attached property from the
   collection control, enabling WPF's native touch-manipulation scrolling while
   the configured scrollbar visibility still determines the scrollable axes.
+- WPF's stock `ScrollViewer` maps mouse-wheel input only to its vertical
+  `IScrollInfo` path. The retained `ScrollViewerEx` gives vertical overflow
+  priority and, when no vertical extent exists, routes the wheel to
+  `IScrollInfo.MouseWheelLeft` / `MouseWheelRight`. This preserves WPF's
+  platform scroll units and virtualizing-panel behavior for horizontal-only
+  custom `GridView` layouts without introducing a separate smooth-scrolling
+  animation model.
 - WinUI SemanticZoom, gamepad focus engagement, connected animations, native item presenters, data virtualization, and native drag/reorder providers are not available as direct WPF services. The source audit does not claim those unsupported platform paths.
 - The current native dragged-item `Reserve` call is an allocation optimization and has no observable WPF port requirement.
 - The current perf2026 dictionary's discrete setter conversion maps to the already-retained `VisualStateEx.Setters`; unsupported drag/reorder/presenter-only state machinery is not fabricated.

--- a/docs/scrollviewer-wpf-fluent-source-audit.md
+++ b/docs/scrollviewer-wpf-fluent-source-audit.md
@@ -34,12 +34,22 @@ source for the stock `System.Windows.Controls.ScrollViewer` default style.
   `ComboBox`, `AutoSuggestBox`, `DatePicker`, and `NumberBox`.
 - `TextControlContentHostStyle` remains based on `DefaultScrollViewerStyle` but
   keeps its WPF text-host presenter-margin and corner-radius support.
+- The separate public `ScrollViewerEx` used by ModernWpf's custom
+  `ListView` / `GridView` family keeps vertical wheel scrolling as the first
+  choice. When there is no vertical extent but horizontal overflow exists, it
+  delegates to WPF `IScrollInfo.MouseWheelLeft` / `MouseWheelRight` so the
+  platform scroll unit and virtualizing-panel behavior remain authoritative.
+  This is a control behavior adaptation and does not alter the stock WPF
+  `ScrollViewer` template.
 
 ## Validation
 
 - `test\ModernWpf.WinUI.Tests\CommonStyles\ScrollViewerVisualStateTests.cs`
   covers the official WPF Fluent stock setter surface, template parts, removed
   default-style guesses, and retained ModernWpf text-control host support.
+- `test\ModernWpf.WinUI.Tests\ListView\ListViewApiTests.cs` covers
+  horizontal-only `GridView` overflow responding to mouse-wheel input through
+  its templated `ScrollViewerEx`.
 - `test\ModernWpf.WinUI.Tests\TemplateParityTests.cs` classifies
   `ModernWpf\Styles\ScrollViewer.xaml` as an official WPF Fluent stock template
   file that should not use `VisualStateEx`.

--- a/docs/winui3-source-parity.md
+++ b/docs/winui3-source-parity.md
@@ -146,6 +146,13 @@ post-May-2026 root layout (`controls/...` rather than `src/controls/...`).
   `Both`; each templated `ScrollViewerEx` binds the mode from its parent and
   enters WPF's native touch-manipulation scrolling path while scrollbar
   visibility continues to constrain the available axes.
+- 2026-07-26 GridView horizontal-wheel completion: issue #162 reproduced with
+  horizontal overflow and no vertical extent because WPF maps mouse-wheel
+  input only to its vertical scrolling path. `ScrollViewerEx` now preserves
+  vertical priority and otherwise delegates to WPF
+  `IScrollInfo.MouseWheelLeft` / `MouseWheelRight`, retaining platform scroll
+  units and virtualizing-panel behavior. The exact custom `GridView`
+  regression is locked in `ListViewApiTests`.
 - 2026-07-19 VariableSizedWrapGrid / WrapGrid / ItemsWrapGrid current-source refresh: `docs\variablesizedwrapgrid-winui3-source-audit.md` pins 17 official product blobs at commit `de3e767333c2f0717a6a70cb22bd192ced5ad885`; every blob is byte-identical across the old/current roots. Source-derived geometry tests retain first-item sizing, wrapping, spans, alignment, and finite occupancy; current Gallery has no standalone family page, while its GridView customization still consumes a live MaxItemsWrapGrid. Native recycling/cache/group/keyboard services remain explicit WPF boundaries.
 - 2026-05-18 Expander official Fluent replacement: `docs\expander-wpf-fluent-source-audit.md` maps stock WPF `Expander` to `PresentationFramework.Fluent\Styles\Expander.xaml`. The prior WinUI-shaped `VisualStateEx` / `ToggleButtonHelper` / `ContentPresenterEx` template guesses were deleted because official WPF Fluent is the primary source for stock WPF controls.
 - 2026-05-17 Repeater / ItemsRepeater layouts whole-family source audit: `docs\repeater-winui3-source-audit.md` maps `ItemsRepeater`, `ViewportManager`, layouts, item-template/recycle/source-view helpers, selection model, and upstream API tests against local WinUI 3 source. The files were already source-derived rather than guessed WPF wrappers; this slice closes the stale WinUI 2-era classification and ports the missing source `StackLayout` measure-cycle guard plus viewport `GetLayoutExtent` hook.

--- a/test/ModernWpf.WinUI.Tests/ListView/ListViewApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/ListView/ListViewApiTests.cs
@@ -5,6 +5,7 @@ using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Markup;
 using System.Windows.Media;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ModernWpf;
@@ -85,6 +86,52 @@ public class ListViewApiTests
                 Assert.AreEqual(PanningMode.Both, scrollViewer.PanningMode);
                 Assert.IsTrue(scrollViewer.IsManipulationEnabled);
             }
+        });
+    }
+
+    [TestMethod]
+    public void GridViewMouseWheelScrollsHorizontalOverflow()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var gridView = new MuxGridView
+            {
+                ItemsPanel = (ItemsPanelTemplate)XamlReader.Parse(
+                    """
+                    <ItemsPanelTemplate xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                    """)
+            };
+            ScrollViewer.SetHorizontalScrollBarVisibility(gridView, ScrollBarVisibility.Visible);
+            ScrollViewer.SetVerticalScrollBarVisibility(gridView, ScrollBarVisibility.Disabled);
+
+            for (int index = 0; index < 4; index++)
+            {
+                gridView.Items.Add(new Border { Width = 120, Height = 60 });
+            }
+
+            using var host = new TestWindowHost(gridView, width: 180, height: 120);
+            host.UpdateLayout();
+
+            var scrollViewer = FindTemplateChild<ModernWpf.Controls.ScrollViewerEx>(gridView, "ScrollViewer");
+            Assert.IsTrue(scrollViewer.ScrollableWidth > 0, "The GridView must have horizontal overflow.");
+            Assert.AreEqual(0, scrollViewer.ScrollableHeight, 0.01, "The regression requires no vertical extent.");
+
+            var args = new MouseWheelEventArgs(Mouse.PrimaryDevice, Environment.TickCount, -120)
+            {
+                RoutedEvent = UIElement.MouseWheelEvent,
+                Source = scrollViewer
+            };
+
+            scrollViewer.RaiseEvent(args);
+            host.UpdateLayout();
+
+            Assert.IsTrue(args.Handled, "The horizontal-only ScrollViewerEx should consume the wheel event.");
+            Assert.IsTrue(scrollViewer.HorizontalOffset > 0, "The mouse wheel should move horizontal overflow.");
+            Assert.AreEqual(0, scrollViewer.VerticalOffset, 0.01);
         });
     }
 


### PR DESCRIPTION
Fixes #162

## Summary

- keep existing vertical mouse-wheel scrolling as the first choice in `ScrollViewerEx`
- when no vertical extent exists but horizontal overflow does, delegate to WPF `IScrollInfo.MouseWheelLeft` / `MouseWheelRight`
- retain WPF's platform scroll units and virtualizing-panel behavior instead of adding a separate pixel or animation model
- add an exact custom `GridView` regression and update the ScrollViewer/ListView source audits

## Reproduction

The regression creates a custom ModernWpf `GridView` with a horizontal items panel, a visible horizontal scrollbar, disabled vertical scrolling, and confirmed horizontal overflow. It then raises a mouse-wheel event against the templated `ScrollViewerEx`.

Before the fix:

- wheel event handled: expected `true`, actual `false`
- horizontal offset: remained `0`
- result: 1 failed, 0 passed, 0 skipped

## Validation

- exact post-fix regression: 1 passed, 0 skipped
- focused ListView/GridView + ScrollViewer slice: 23 passed, 0 skipped
- `dotnet restore ModernWpf.sln`: passed, including dependency audit
- serialized `dotnet build ModernWpf.sln --configuration Release --no-restore`: passed across `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0` with 0 warnings and 0 errors
- complete `ModernWpf.WinUI.Tests` net8: 1,055 passed, 0 skipped
- public API inventories: unchanged