### PR TITLE
Add NavigationView template-selector regression

### DIFF
--- a/docs/navigationview-winui3-source-audit.md
+++ b/docs/navigationview-winui3-source-audit.md
@@ -239,7 +239,14 @@ API controls are covered by the focused Gallery regression.
   covers issue #319 with header, footer, 24 top items, overflow, an idle-layout
   bound, and 768-to-1200-to-640 resize recovery. It also verifies that both the
   primary scroll host and top grid remain inside the NavigationView width.
-- NavigationView product/source-audit tests pass 61/61; SplitView product tests
+- `MenuItemTemplateSelectorWithMoreThanFourItemsRemainsBounded` covers issue
+  #111 with eight source items and a selector whose template root is a
+  `NavigationViewItem`. Left and Top navigation both realize and map every
+  item, stay within a bounded initial selector-call budget, and make no further
+  selector calls across five dispatcher and layout passes. This confirms that
+  the selector loop reported against 0.9 is resolved on the active 1.x
+  repeater implementation.
+- NavigationView product/source-audit tests pass 62/62; SplitView product tests
   pass 14/14; the focused Gallery sample/source-shape slice passes 7/7 on net8
   and net10. Gallery builds successfully on net462, net8, and net10 with zero
   errors; current target builds retain existing unrelated warnings.

--- a/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewApiTests.cs
@@ -414,6 +414,79 @@ public class NavigationViewApiTests
     }
 
     [TestMethod]
+    public void MenuItemTemplateSelectorWithMoreThanFourItemsRemainsBounded()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            foreach (var paneDisplayMode in new[]
+            {
+                ModernWpf.Controls.NavigationViewPaneDisplayMode.Left,
+                ModernWpf.Controls.NavigationViewPaneDisplayMode.Top
+            })
+            {
+                var defaultTemplate = (DataTemplate)XamlReader.Parse(
+                    @"<DataTemplate
+                          xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                          xmlns:ui='http://schemas.modernwpf.com/2019'>
+                          <ui:NavigationViewItem Content='{Binding}' Tag='Default' />
+                      </DataTemplate>");
+                var alternateTemplate = (DataTemplate)XamlReader.Parse(
+                    @"<DataTemplate
+                          xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                          xmlns:ui='http://schemas.modernwpf.com/2019'>
+                          <ui:NavigationViewItem Content='{Binding}' Tag='Alternate' />
+                      </DataTemplate>");
+                var items = new ObservableCollection<string>(
+                    Enumerable.Range(1, 8).Select(index => $"Item {index}"));
+                var maximumCallCount = items.Count * 8;
+                var selector = new CountingNavigationItemTemplateSelector(
+                    defaultTemplate,
+                    alternateTemplate,
+                    items[^1],
+                    maximumCallCount);
+                var navView = new ModernWpf.Controls.NavigationView
+                {
+                    IsSettingsVisible = false,
+                    MenuItemsSource = items,
+                    MenuItemTemplateSelector = selector,
+                    PaneDisplayMode = paneDisplayMode,
+                    Width = 1200,
+                    Height = 500
+                };
+
+                using var host = new TestWindowHost(navView, width: 1200, height: 500);
+                var initialCallCount = selector.CallCount;
+                Assert.IsTrue(
+                    initialCallCount > 0,
+                    $"{paneDisplayMode} did not invoke the item template selector.");
+                Assert.IsTrue(
+                    initialCallCount <= maximumCallCount,
+                    $"{paneDisplayMode} invoked the selector too often during initial realization.");
+
+                for (var pass = 0; pass < 5; pass++)
+                {
+                    WpfTestHost.DoEvents();
+                    host.UpdateLayout();
+                    Assert.AreEqual(
+                        initialCallCount,
+                        selector.CallCount,
+                        $"{paneDisplayMode} re-entered the selector after layout pass {pass + 1}.");
+                }
+
+                foreach (var item in items)
+                {
+                    var container = navView.ContainerFromMenuItem(item) as ModernWpf.Controls.NavigationViewItem;
+                    Assert.IsNotNull(container, $"{paneDisplayMode} did not realize '{item}'.");
+                    Assert.AreEqual(item, container!.Content);
+                    Assert.AreEqual(item == items[^1] ? "Alternate" : "Default", container.Tag);
+                }
+            }
+        });
+    }
+
+    [TestMethod]
     public void VerifyMenuItemAndContainerMappingMenuItems()
     {
         WpfTestHost.Run(() =>
@@ -2940,6 +3013,43 @@ public class NavigationViewApiTests
         return VisualStateManager.GetVisualStateGroups(stateGroupsRoot)
             .OfType<VisualStateGroup>()
             .Single(item => item.Name == groupName);
+    }
+
+    private sealed class CountingNavigationItemTemplateSelector : DataTemplateSelector
+    {
+        private readonly int _maximumCallCount;
+
+        public CountingNavigationItemTemplateSelector(
+            DataTemplate defaultTemplate,
+            DataTemplate alternateTemplate,
+            object alternateItem,
+            int maximumCallCount)
+        {
+            DefaultTemplate = defaultTemplate;
+            AlternateTemplate = alternateTemplate;
+            AlternateItem = alternateItem;
+            _maximumCallCount = maximumCallCount;
+        }
+
+        public int CallCount { get; private set; }
+
+        public DataTemplate DefaultTemplate { get; }
+
+        public DataTemplate AlternateTemplate { get; }
+
+        public object AlternateItem { get; }
+
+        public override DataTemplate SelectTemplate(object item, DependencyObject container)
+        {
+            CallCount++;
+            if (CallCount > _maximumCallCount)
+            {
+                throw new InvalidOperationException(
+                    $"The NavigationView item template selector exceeded {_maximumCallCount} calls.");
+            }
+
+            return Equals(item, AlternateItem) ? AlternateTemplate : DefaultTemplate;
+        }
     }
 
     private static TestWindowHost CreateNavigationViewHost(


### PR DESCRIPTION
## Summary

- cover the issue #111 scenario with eight bound menu items and two distinct `DataTemplateSelector` templates rooted in `NavigationViewItem`
- verify both Left and Top navigation stay within a bounded initial selector-call budget and make no additional calls across repeated dispatcher/layout passes
- verify every source item maps to the expected realized container/template
- record the active 1.x resolution in the NavigationView WinUI 3 source audit

The selector loop reported against 0.9 is not reproducible on the current 1.x repeater implementation. This regression locks in that behavior for both navigation orientations.

Closes #111.

## Validation

- `dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-restore --filter "FullyQualifiedName~MenuItemTemplateSelectorWithMoreThanFourItemsRemainsBounded"` — 1 passed, 0 failed, 0 skipped
- `dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-build --no-restore --filter "FullyQualifiedName~NavigationView"` — 62 passed, 0 failed, 0 skipped
- `dotnet restore .\ModernWpf.sln` — succeeded
- `dotnet build .\ModernWpf.sln --configuration Release --no-restore` — succeeded, 0 warnings, 0 errors
- `dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-build --no-restore` — 1,057 passed, 0 failed, 0 skipped
- `git diff --check` — clean