### PR TITLE
Forward NavigationView content templates

### DIFF
--- a/ModernWpf.Controls/NavigationView/NavigationView.xaml
+++ b/ModernWpf.Controls/NavigationView/NavigationView.xaml
@@ -1688,7 +1688,7 @@
                                             <ui:ContentPresenterEx
                                                 Grid.Row="2"
                                                 Grid.ColumnSpan="2"
-                                                Content="{TemplateBinding Content}"/>
+                                                ContentSource="Content"/>
                                         </Grid>
                                     </Border>
                                 </local:SplitView.Content>

--- a/docs/navigationview-winui3-source-audit.md
+++ b/docs/navigationview-winui3-source-audit.md
@@ -156,6 +156,11 @@ API controls are covered by the focused Gallery regression.
   button padding therefore falls back to the measured dimension when the
   specified dimension is Auto, including while dynamic resources are being
   torn down.
+- WinUI's main content presenter explicitly template-binds only `Content`.
+  WPF does not infer the remaining inherited content aliases from that binding,
+  so the WPF presenter uses `ContentSource="Content"` to forward `Content`,
+  `ContentTemplate`, `ContentTemplateSelector`, and `ContentStringFormat`
+  together while retaining the source presenter shape.
 - WinUI `ItemsRepeater`, `SplitView`, `Flyout`, popup/XamlRoot services, focus
   movement, top overflow measurement, gamepad/access-key paths, composition
   animations, x:Bind phases, and recycle metadata use the existing documented
@@ -246,8 +251,12 @@ API controls are covered by the focused Gallery regression.
   selector calls across five dispatcher and layout passes. This confirms that
   the selector loop reported against 0.9 is resolved on the active 1.x
   repeater implementation.
-- NavigationView product/source-audit tests pass 62/62; SplitView product tests
-  pass 14/14; the focused Gallery sample/source-shape slice passes 7/7 on net8
+- `NavigationViewContentTemplateIsAppliedToMainContent` covers issue #96 by
+  applying a custom `DataTemplate` to the inherited `ContentTemplate`
+  property, verifying that the main presenter receives that exact template,
+  and verifying the template's bound visual content.
+- NavigationView product/source-audit tests pass 63/63; SplitView product tests
+  pass 14/14; the focused Gallery sample/source-shape slice passes 8/8 on net8
   and net10. Gallery builds successfully on net462, net8, and net10 with zero
   errors; current target builds retain existing unrelated warnings.
 

--- a/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewApiTests.cs
@@ -104,6 +104,50 @@ public class NavigationViewApiTests
     }
 
     [TestMethod]
+    public void NavigationViewContentTemplateIsAppliedToMainContent()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var contentTemplate = (DataTemplate)XamlReader.Parse(
+                @"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
+                      <Border Tag='NavigationContentTemplate'>
+                          <TextBlock Text='{Binding}' />
+                      </Border>
+                  </DataTemplate>");
+            var navView = new ModernWpf.Controls.NavigationView
+            {
+                Content = "Templated content",
+                ContentTemplate = contentTemplate,
+                Width = 800,
+                Height = 500
+            };
+
+            using var host = new TestWindowHost(navView, width: 800, height: 500);
+            host.UpdateLayout();
+
+            var contentPresenter = VisualTreeTestHelper
+                .EnumerateDescendants(navView)
+                .OfType<ModernWpf.Controls.ContentPresenterEx>()
+                .Single(presenter =>
+                    ReferenceEquals(presenter.TemplatedParent, navView) &&
+                    Equals(presenter.Content, navView.Content));
+            Assert.AreSame(contentTemplate, contentPresenter.ContentTemplate);
+
+            var templatedContent = VisualTreeTestHelper
+                .EnumerateDescendants(contentPresenter)
+                .OfType<Border>()
+                .Single(border => Equals(border.Tag, "NavigationContentTemplate"));
+            var text = VisualTreeTestHelper
+                .EnumerateDescendants(templatedContent)
+                .OfType<TextBlock>()
+                .Single();
+            Assert.AreEqual(navView.Content, text.Text);
+        });
+    }
+
+    [TestMethod]
     public void VerifyValuesCoercion()
     {
         WpfTestHost.Run(() =>


### PR DESCRIPTION
## Summary

- make the existing NavigationView main `ContentPresenterEx` use WPF's `ContentSource="Content"` alias
- forward the inherited `Content`, `ContentTemplate`, `ContentTemplateSelector`, and `ContentStringFormat` contract together
- add a regression that verifies the exact custom template reaches the presenter and renders its bound visual content
- document the WPF-specific adaptation in the current NavigationView source audit

Before the change, the focused regression failed because the presenter received `Content` but its `ContentTemplate` was `null`. The existing presenter remains the correct host: current WinUI also uses a `ContentPresenter` here; replacing it with a nested `ContentControl` would diverge from the source shape.

The routed-event request in #96 is intentionally not part of this fix. ModernWpf 1.x has shipped `ItemInvoked` as `TypedEventHandler<NavigationView, NavigationViewItemInvokedEventArgs>`, and current WinUI's event shape is the contract authority. Converting it into a WPF routed event would change the frozen public event/event-args semantics.

Fixes #96.

## Validation

- pre-fix: `NavigationViewContentTemplateIsAppliedToMainContent` failed with expected template / actual `null`
- `dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-restore --filter "FullyQualifiedName~NavigationViewContentTemplateIsAppliedToMainContent"` — 1 passed, 0 failed, 0 skipped
- `dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-build --no-restore --filter "FullyQualifiedName~NavigationView"` — 63 passed, 0 failed, 0 skipped
- `dotnet test .\test\ModernWpf.Gallery.Tests\ModernWpf.Gallery.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-build --no-restore --filter "FullyQualifiedName~NavigationView"` — 8 passed, 0 failed, 0 skipped
- `dotnet test .\test\ModernWpf.Gallery.Tests\ModernWpf.Gallery.Tests.csproj --configuration Release --framework net10.0-windows7.0 --no-build --no-restore --filter "FullyQualifiedName~NavigationView"` — 8 passed, 0 failed, 0 skipped
- `dotnet restore .\ModernWpf.sln` — succeeded
- `dotnet build .\ModernWpf.sln --configuration Release --no-restore` — succeeded, 0 warnings, 0 errors
- `dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-build --no-restore` — 1,058 passed, 0 failed, 0 skipped
- `git diff --check` — clean