### PR TITLE
Document interactive extended title bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,32 @@ For existing 0.9.x applications, the old resource entry remains supported:
 
 5. See [the wiki](https://github.com/Kinnara/ModernWpf/wiki) for more information.
 
+### Interactive content in an extended title bar
+
+When content extends into the title bar, mark each button or other interactive
+control with WPF's `WindowChrome.IsHitTestVisibleInChrome` attached property:
+
+```xaml
+<Window
+    ...
+    xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
+    xmlns:ui="http://schemas.modernwpf.com/2019"
+    ui:TitleBar.ExtendViewIntoTitleBar="True"
+    ui:WindowHelper.UseModernWindowStyle="True">
+    <Grid>
+        <Button
+            HorizontalAlignment="Left"
+            VerticalAlignment="Top"
+            Content="Title bar action"
+            shell:WindowChrome.IsHitTestVisibleInChrome="True" />
+    </Grid>
+</Window>
+```
+
+Set the property only on controls that need pointer input. Unmarked title-bar
+space remains available for dragging the window, and the normal resize borders
+and `ResizeMode="CanResizeWithGrip"` grip remain active.
+
 ## Build and run the Gallery
 
 The sample application for the active 1.x line is

--- a/docs/window-wpf-fluent-source-audit.md
+++ b/docs/window-wpf-fluent-source-audit.md
@@ -123,6 +123,11 @@ surface.
   first four content pixels below the title bar and verifies `HTCLIENT`, while
   separately retaining `HTCAPTION` for draggable title space and
   `HTBOTTOMRIGHT` for the explicit resize grip.
+- `WindowVisualStateTests` also covers the documented extended-title-bar
+  opt-in: a control marked with
+  `WindowChrome.IsHitTestVisibleInChrome=True` receives `HTCLIENT`, unmarked
+  title-bar space remains `HTCAPTION`, and the explicit resize grip remains
+  `HTBOTTOMRIGHT`.
 - `WindowVisualStateTests` verifies that full-monitor maximized bounds are
   reduced once at the auto-hide taskbar edge and that the Win32 state parser
   distinguishes `ABS_AUTOHIDE` from `ABS_ALWAYSONTOP`.

--- a/test/ModernWpf.WinUI.Tests/CommonStyles/WindowVisualStateTests.cs
+++ b/test/ModernWpf.WinUI.Tests/CommonStyles/WindowVisualStateTests.cs
@@ -291,6 +291,114 @@ public class WindowVisualStateTests
     }
 
     [TestMethod]
+    public void ExtendedTitleBarInteractiveControlPreservesCaptionAndResizeGrip()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var button = new Button
+            {
+                Content = "Title bar action",
+                Width = 120,
+                Height = 32,
+                Margin = new Thickness(16, 0, 0, 0),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Top
+            };
+            WindowChrome.SetIsHitTestVisibleInChrome(button, true);
+
+            var content = new Grid
+            {
+                Children = { button }
+            };
+            var window = new Window
+            {
+                Width = 420,
+                Height = 240,
+                Left = -30000,
+                Top = -30000,
+                Content = content,
+                ResizeMode = ResizeMode.CanResizeWithGrip,
+                ShowInTaskbar = false,
+                WindowStartupLocation = WindowStartupLocation.Manual
+            };
+            ModernWpf.Controls.TitleBar.SetExtendViewIntoTitleBar(window, true);
+            WindowHelper.SetUseModernWindowStyle(window, true);
+
+            try
+            {
+                window.Show();
+                WpfTestHost.DoEvents();
+                window.UpdateLayout();
+                WpfTestHost.DoEvents();
+
+                var titleBar = VisualTreeTestHelper.FindDescendant<TitleBarControl>(window)
+                    ?? throw new AssertFailedException("Expected the modern window title bar.");
+                var handle = new WindowInteropHelper(window).Handle;
+                var buttonCenter = button.PointToScreen(
+                    new Point(button.ActualWidth / 2, button.ActualHeight / 2));
+                var titleBarBottom = titleBar.PointToScreen(
+                    new Point(0, titleBar.ActualHeight)).Y;
+
+                Assert.IsTrue(
+                    buttonCenter.Y < titleBarBottom,
+                    "The test control must overlap the extended title-bar region.");
+                Assert.IsTrue(WindowChrome.GetIsHitTestVisibleInChrome(button));
+
+                var inputHit = window.InputHitTest(window.PointFromScreen(buttonCenter)) as DependencyObject;
+                Assert.IsNotNull(inputHit);
+                Assert.IsTrue(
+                    ReferenceEquals(button, inputHit) || button.IsAncestorOf(inputHit),
+                    $"Expected the extended title-bar button to own the WPF hit target, but found {inputHit!.GetType().Name}.");
+                Assert.AreEqual(
+                    HtClient,
+                    SendMessage(
+                        handle,
+                        WmNcHitTest,
+                        IntPtr.Zero,
+                        PackScreenPoint(
+                            (int)Math.Floor(buttonCenter.X),
+                            (int)Math.Floor(buttonCenter.Y))).ToInt32(),
+                    "An opted-in control in the extended title bar must receive client input.");
+
+                var emptyTitleBarPoint = titleBar.PointToScreen(
+                    new Point(titleBar.ActualWidth / 2, titleBar.ActualHeight / 2));
+                Assert.AreEqual(
+                    HtCaption,
+                    SendMessage(
+                        handle,
+                        WmNcHitTest,
+                        IntPtr.Zero,
+                        PackScreenPoint(
+                            (int)Math.Floor(emptyTitleBarPoint.X),
+                            (int)Math.Floor(emptyTitleBarPoint.Y))).ToInt32(),
+                    "Unmarked title-bar space must remain draggable.");
+
+                var resizeGrip = VisualTreeTestHelper.FindDescendant<ResizeGrip>(window)
+                    ?? throw new AssertFailedException("Expected the modern window resize grip.");
+                var resizeGripPoint = resizeGrip.PointToScreen(
+                    new Point(resizeGrip.ActualWidth / 2, resizeGrip.ActualHeight / 2));
+                Assert.AreEqual(
+                    HtBottomRight,
+                    SendMessage(
+                        handle,
+                        WmNcHitTest,
+                        IntPtr.Zero,
+                        PackScreenPoint(
+                            (int)Math.Floor(resizeGripPoint.X),
+                            (int)Math.Floor(resizeGripPoint.Y))).ToInt32(),
+                    "Opting in one interactive control must not disable the window resize grip.");
+            }
+            finally
+            {
+                window.Close();
+                WpfTestHost.DoEvents();
+            }
+        });
+    }
+
+    [TestMethod]
     public void ContentImmediatelyBelowTitleBarUsesClientHitTesting()
     {
         WpfTestHost.Run(() =>


### PR DESCRIPTION
## Summary

- document how to opt individual controls into client hit testing when `TitleBar.ExtendViewIntoTitleBar` is enabled
- add a native `WM_NCHITTEST` regression proving an opted-in button remains interactive
- prove unmarked title-bar space stays draggable and the explicit resize grip stays active
- record the new guard in the Window source audit

## Why

Issue #16 has long had the correct WPF workaround in a comment, but it was not present in the repository documentation and the resize-grip follow-up had no exact regression. The guidance now makes the important scope explicit: set `WindowChrome.IsHitTestVisibleInChrome` on each interactive control, not the whole title-bar container.

No product runtime behavior changes; this locks and documents the current 1.x shell contract.

## Validation

```powershell
dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-restore --filter "FullyQualifiedName~WindowVisualStateTests.ExtendedTitleBarInteractiveControlPreservesCaptionAndResizeGrip"
dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --configuration Release --framework net8.0-windows7.0 --no-build --no-restore
```

- focused: 1 passed, 0 failed, 0 skipped
- complete affected project: 1,059 passed, 0 failed, 0 skipped

Closes #16