### PR TITLE
Harden preview release versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,14 +140,26 @@ jobs:
     - name: Verify package and execute consumers
       shell: pwsh
       run: |
-        $package = Get-ChildItem "$env:RELEASE_ROOT\packages\ModernWpfUI.*.nupkg" | Select-Object -Single
+        $packages = @(Get-ChildItem "$env:RELEASE_ROOT\packages\ModernWpfUI.*.nupkg")
+        if ($packages.Count -ne 1) {
+          throw "Expected exactly one ModernWpfUI package, found $($packages.Count)."
+        }
+
+        $package = $packages[0]
         .\tools\release\Verify-ModernWpfPackage.ps1 -PackagePath $package.FullName
         .\tools\release\Test-ModernWpfPackageSmoke.ps1 -PackagePath $package.FullName
 
     - name: Prepare immutable release artifact
       shell: pwsh
+      env:
+        RELEASE_VERSION: ${{ steps.validate.outputs.version }}
       run: |
-        Copy-Item docs\release-notes-1.0.0-preview.1.md "$env:RELEASE_ROOT\release-notes.md"
+        $releaseNotesPath = "docs\release-notes-$env:RELEASE_VERSION.md"
+        if (-not (Test-Path -LiteralPath $releaseNotesPath -PathType Leaf)) {
+          throw "Release notes do not exist for version '$env:RELEASE_VERSION': $releaseNotesPath"
+        }
+
+        Copy-Item -LiteralPath $releaseNotesPath "$env:RELEASE_ROOT\release-notes.md"
         Copy-Item $env:TEST_RESULTS "$env:RELEASE_ROOT\test-results" -Recurse
         Compress-Archive -Path "$env:RELEASE_ROOT\test-results\*" -DestinationPath "$env:RELEASE_ROOT\test-results.zip"
 
@@ -238,7 +250,7 @@ jobs:
             --verify-tag `
             --draft `
             --prerelease `
-            --title "ModernWpf ${{ needs.build.outputs.version }}" `
+            --title "ModernWPF ${{ needs.build.outputs.version }}" `
             --notes-file release\release-notes.md
           if ($LASTEXITCODE -ne 0) {
             throw "Could not create draft GitHub prerelease."
@@ -261,7 +273,12 @@ jobs:
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       run: |
-        $package = Get-ChildItem release\packages\ModernWpfUI.*.nupkg | Select-Object -Single
+        $packages = @(Get-ChildItem release\packages\ModernWpfUI.*.nupkg)
+        if ($packages.Count -ne 1) {
+          throw "Expected exactly one ModernWpfUI package, found $($packages.Count)."
+        }
+
+        $package = $packages[0]
         dotnet nuget push $package.FullName `
           --api-key $env:NUGET_API_KEY `
           --source https://api.nuget.org/v3/index.json `

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,8 @@
 ﻿<Project>
   <PropertyGroup>
     <Version>1.0.0-preview.1</Version>
+    <!-- Immutable after the first 1.x package is published. -->
+    <ModernWpfCompatibilityBaselineVersion>1.0.0-preview.1</ModernWpfCompatibilityBaselineVersion>
     <Authors>Yimeng Wu</Authors>
     <Copyright>Copyright © 2019–2026 Yimeng Wu</Copyright>
     <Product>ModernWPF UI Library</Product>

--- a/ModernWpf.Controls/ModernWpf.Controls.csproj
+++ b/ModernWpf.Controls/ModernWpf.Controls.csproj
@@ -18,7 +18,7 @@
     <EnableStrictModeForCompatibleFrameworksInPackage>true</EnableStrictModeForCompatibleFrameworksInPackage>
     <EnableStrictModeForBaselineValidation>true</EnableStrictModeForBaselineValidation>
     <PackageValidationBaselineVersion
-      Condition="'$(Version)' != '1.0.0-preview.1' and '$(PackageValidationBaselineVersion)' == ''">1.0.0-preview.1</PackageValidationBaselineVersion>
+      Condition="'$(Version)' != '$(ModernWpfCompatibilityBaselineVersion)' and '$(PackageValidationBaselineVersion)' == ''">$(ModernWpfCompatibilityBaselineVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/release-notes-1.0.0-preview.1.md
+++ b/docs/release-notes-1.0.0-preview.1.md
@@ -1,6 +1,6 @@
-# ModernWpf 1.0.0-preview.1
+# ModernWPF 1.0.0-preview.1
 
-`1.0.0-preview.1` starts the actively maintained ModernWpf 1.x line. It is the
+`1.0.0-preview.1` starts the actively maintained ModernWPF 1.x line. It is the
 first forward-compatibility baseline for the CLR APIs and public resource keys
 shipped by `ModernWpfUI`.
 
@@ -9,7 +9,7 @@ shipped by `ModernWpfUI`.
 - Targets `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0`.
 - Adds `FluentControlsResources` as the recommended resource entry.
   `net10.0-windows7.0` uses the platform WPF Fluent theme for stock controls;
-  the other targets use ModernWpf's Fluent backport.
+  the other targets use ModernWPF's Fluent backport.
 - Retains `ThemeResources` plus `XamlControlsResources` as the legacy resource
   entry for applications migrating from 0.9.x.
 - Aligns the WinUI-derived controls, layouts, templates, automation peers, and
@@ -40,7 +40,7 @@ Source and binary compatibility with 0.9.x is not promised. In particular:
 - WinRT projection and ABI implementation types are no longer public package
   API.
 
-See [Migrating from ModernWpf 0.9.x](migrating-from-0.9.md) and the
+See [Migrating from ModernWPF 0.9.x](migrating-from-0.9.md) and the
 [1.x public API contract](public-api-contract-1x.md) for the complete boundary.
 
 ## Recommended application resources

--- a/test/ModernWpf.Tools.Tests/ReleaseVersioningTests.cs
+++ b/test/ModernWpf.Tools.Tests/ReleaseVersioningTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ModernWpf.Tools.Tests
+{
+    [TestClass]
+    public class ReleaseVersioningTests
+    {
+        [TestMethod]
+        public void PackageValidationUsesCentralCompatibilityBaseline()
+        {
+            var repoRoot = FindRepoRoot();
+            var props = XDocument.Load(Path.Combine(repoRoot, "Directory.Build.props"));
+            var baseline = props
+                .Descendants("ModernWpfCompatibilityBaselineVersion")
+                .Select(element => element.Value)
+                .SingleOrDefault() ?? string.Empty;
+            var packageProject = File.ReadAllText(
+                Path.Combine(repoRoot, "ModernWpf.Controls", "ModernWpf.Controls.csproj"));
+
+            Assert.IsFalse(string.IsNullOrWhiteSpace(baseline));
+            StringAssert.Contains(
+                packageProject,
+                "'$(Version)' != '$(ModernWpfCompatibilityBaselineVersion)'");
+            StringAssert.Contains(
+                packageProject,
+                ">$(ModernWpfCompatibilityBaselineVersion)</PackageValidationBaselineVersion>");
+            Assert.IsFalse(packageProject.Contains(baseline, StringComparison.Ordinal));
+        }
+
+        [TestMethod]
+        public void ReleaseWorkflowDerivesNotesAndUsesDisplayBrand()
+        {
+            var repoRoot = FindRepoRoot();
+            var props = XDocument.Load(Path.Combine(repoRoot, "Directory.Build.props"));
+            var version = props
+                .Descendants("Version")
+                .Select(element => element.Value)
+                .Single();
+            var releaseNotesPath = Path.Combine(
+                repoRoot,
+                "docs",
+                $"release-notes-{version}.md");
+            var workflow = File.ReadAllText(
+                Path.Combine(repoRoot, ".github", "workflows", "release.yml"));
+
+            Assert.IsTrue(
+                File.Exists(releaseNotesPath),
+                $"Release notes are missing for version '{version}'.");
+            var releaseNotes = File.ReadAllText(releaseNotesPath);
+            StringAssert.StartsWith(releaseNotes, $"# ModernWPF {version}");
+            StringAssert.Contains(
+                workflow,
+                "RELEASE_VERSION: ${{ steps.validate.outputs.version }}");
+            StringAssert.Contains(
+                workflow,
+                "$releaseNotesPath = \"docs\\release-notes-$env:RELEASE_VERSION.md\"");
+            StringAssert.Contains(
+                workflow,
+                "Test-Path -LiteralPath $releaseNotesPath -PathType Leaf");
+            StringAssert.Contains(
+                workflow,
+                "Copy-Item -LiteralPath $releaseNotesPath");
+            StringAssert.Contains(
+                workflow,
+                "--title \"ModernWPF ${{ needs.build.outputs.version }}\"");
+            Assert.IsFalse(
+                workflow.Contains(
+                    "Copy-Item docs\\release-notes-1.0.0-preview.1.md",
+                    StringComparison.Ordinal));
+            Assert.IsFalse(
+                workflow.Contains("--title \"ModernWpf ", StringComparison.Ordinal));
+            Assert.IsFalse(
+                workflow.Contains("Select-Object -Single", StringComparison.Ordinal));
+            Assert.AreEqual(
+                2,
+                CountOccurrences(
+                    workflow,
+                    "Expected exactly one ModernWpfUI package, found $($packages.Count)."));
+        }
+
+        private static int CountOccurrences(string text, string value)
+        {
+            var count = 0;
+            var index = 0;
+
+            while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
+        }
+
+        private static string FindRepoRoot()
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (directory != null)
+            {
+                if (File.Exists(Path.Combine(directory.FullName, "ModernWpf.sln")))
+                {
+                    return directory.FullName;
+                }
+
+                directory = directory.Parent;
+            }
+
+            Assert.Fail("Could not locate ModernWpf.sln from the test output directory.");
+            return string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- keep the public package version at `1.0.0-preview.1`
- centralize the immutable first-1.x compatibility baseline
- derive the release-notes file from the validated release version
- use the `ModernWPF` display name for the GitHub release and release notes
- replace unsupported `Select-Object -Single` calls with explicit one-package validation
- add tooling tests that protect the release-versioning contract

## Why

The manual release workflow still hard-coded preview-1 notes and used a
PowerShell parameter that does not exist. The former could attach stale notes
to preview 2; the latter would stop preview 1 before package verification or
publication.

## Validation

- tooling tests: 9 passed, 0 failed, 0 skipped
- current-version MSBuild evaluation leaves package baselining disabled
- simulated `1.0.0-preview.2` evaluation selects `1.0.0-preview.1`
- serialized Release solution build: 0 errors
- release workflow YAML parsed successfully
- package and symbol-package verification passed
- packaged consumers passed on `net462`, `net8.0-windows7.0`, and
  `net10.0-windows7.0` with both resource entries

The existing `PInvoke009` recommendation for `System.Memory` on `net462`
remains unchanged.
