### PR TITLE
Fix release publisher repository context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,8 @@ jobs:
   publish:
     needs: build
     runs-on: windows-2022
+    env:
+      GH_REPO: ${{ github.repository }}
     environment:
       name: nuget-production
       url: https://github.com/Kinnara/ModernWpf/releases/tag/${{ inputs.tag }}

--- a/docs/release-readiness-1x.md
+++ b/docs/release-readiness-1x.md
@@ -97,7 +97,12 @@ targets. It treats assembly-conflict warning `MSB3277` as an error.
 `.github/workflows/build.yml` performs validation only. Publication uses the
 manually dispatched `.github/workflows/release.yml`, which accepts an existing
 annotated `v<Version>` tag on `master`. The tag version must match
-`Directory.Build.props`.
+`Directory.Build.props`. Dispatch the workflow from that same tag ref; for
+example:
+
+```powershell
+gh workflow run release.yml --ref v1.0.0-preview.1 -f tag=v1.0.0-preview.1
+```
 
 The workflow builds and tests the tag once, retains the packages, symbols, TRX
 results, release notes, and `SHA256SUMS`, then pauses at the protected

--- a/test/ModernWpf.Tools.Tests/ReleaseVersioningTests.cs
+++ b/test/ModernWpf.Tools.Tests/ReleaseVersioningTests.cs
@@ -188,6 +188,9 @@ namespace ModernWpf.Tools.Tests
             StringAssert.Contains(
                 workflow,
                 "--title \"ModernWPF ${{ needs.build.outputs.version }}\"");
+            StringAssert.Contains(
+                workflow,
+                "GH_REPO: ${{ github.repository }}");
             Assert.IsFalse(
                 workflow.Contains(
                     "Copy-Item docs\\release-notes-1.0.0-preview.1.md",


### PR DESCRIPTION
## Summary
- give the checkout-free publish job explicit repository context through `GH_REPO`
- document dispatching release workflows from the immutable version-tag ref
- guard the repository context in the tooling tests

## Failure addressed
Release run 30265553121 completed the tagged build and artifact verification, then failed before creating a draft release because `gh release` could not infer a repository in the checkout-free publish job. NuGet was not touched and no GitHub release exists.

## Validation
- `dotnet test .\test\ModernWpf.Tools.Tests\ModernWpf.Tools.Tests.csproj --configuration Release --framework net10.0 --filter "FullyQualifiedName~ReleaseWorkflowDerivesNotesAndUsesDisplayBrand"` (1 passed)
- `dotnet test .\test\ModernWpf.Tools.Tests\ModernWpf.Tools.Tests.csproj --configuration Release --framework net10.0 --no-build --no-restore` (12 passed)
- `git diff --check`