### PR TITLE
Use NuGet Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,7 @@ jobs:
       url: https://github.com/Kinnara/ModernWpf/releases/tag/${{ inputs.tag }}
     permissions:
       contents: write
+      id-token: write
 
     steps:
     - name: Download exact build artifact
@@ -270,10 +271,16 @@ jobs:
           throw "Could not attach the retained release artifacts."
         }
 
+    - name: Request short-lived NuGet API key
+      id: nuget-login
+      uses: NuGet/login@v1
+      with:
+        user: kinnara
+
     - name: Publish exact NuGet package
       shell: pwsh
       env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
       run: |
         $packages = @(Get-ChildItem release\packages\ModernWpfUI.*.nupkg)
         if ($packages.Count -ne 1) {

--- a/docs/release-readiness-1x.md
+++ b/docs/release-readiness-1x.md
@@ -110,6 +110,19 @@ results, release notes, and `SHA256SUMS`, then pauses at the protected
 artifact, prepares a draft GitHub prerelease, publishes the exact `.nupkg` to
 NuGet, and only then publishes the GitHub prerelease.
 
+NuGet publication uses Trusted Publishing rather than a stored API key. The
+nuget.org policy is owned by the `kinnara` account and accepts OIDC identities
+only from:
+
+- repository owner `Kinnara`
+- repository `ModernWpf`
+- workflow `release.yml`
+- environment `nuget-production`
+
+The publication job requests its short-lived key immediately before the NuGet
+push. Keep `id-token: write` scoped to that job, and do not add a long-lived
+`NUGET_API_KEY` secret.
+
 When adding an explicitly supported resource key, run:
 
 ```powershell

--- a/test/ModernWpf.Tools.Tests/ReleaseVersioningTests.cs
+++ b/test/ModernWpf.Tools.Tests/ReleaseVersioningTests.cs
@@ -206,6 +206,25 @@ namespace ModernWpf.Tools.Tests
                     "Expected exactly one ModernWpfUI package, found $($packages.Count)."));
         }
 
+        [TestMethod]
+        public void ReleaseWorkflowUsesNuGetTrustedPublishing()
+        {
+            var repoRoot = FindRepoRoot();
+            var workflow = File.ReadAllText(
+                Path.Combine(repoRoot, ".github", "workflows", "release.yml"));
+
+            StringAssert.Contains(workflow, "id-token: write");
+            StringAssert.Contains(workflow, "uses: NuGet/login@v1");
+            StringAssert.Contains(workflow, "user: kinnara");
+            StringAssert.Contains(
+                workflow,
+                "NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}");
+            Assert.IsFalse(
+                workflow.Contains(
+                    "secrets.NUGET_API_KEY",
+                    StringComparison.Ordinal));
+        }
+
         private static string GetPropertyValue(XDocument props, string name)
         {
             return props


### PR DESCRIPTION
## Summary

- grant OIDC token issuance only to the protected `publish` job
- exchange the GitHub Actions identity for a short-lived NuGet key with `NuGet/login@v1`
- remove the workflow dependency on the long-lived `NUGET_API_KEY` secret
- document the exact NuGet trusted-publishing identity and guard it with a tooling test

## Why

The stored repository key was last updated in June 2022 and NuGet rejected the preview.1 push with HTTP 403. The GitHub prerelease remains a draft and `ModernWpfUI` 1.0.0-preview.1 is not present on NuGet.

Trusted Publishing binds publication to `Kinnara/ModernWpf`, workflow `release.yml`, and protected environment `nuget-production`, issuing a short-lived credential immediately before push.

## Validation

- focused `ReleaseWorkflowUsesNuGetTrustedPublishing` test: 1 passed
- complete `ModernWpf.Tools.Tests`: 13 passed, 0 skipped, 0 failed
- `git diff --check`

## External setup

The matching policy under the NuGet user `kinnara` must be created before this PR is marked ready and merged.