### PR TITLE
Start ModernWPF 1.0.0-preview.2 development

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,8 +158,17 @@ jobs:
         if (-not (Test-Path -LiteralPath $releaseNotesPath -PathType Leaf)) {
           throw "Release notes do not exist for version '$env:RELEASE_VERSION': $releaseNotesPath"
         }
+        $releaseNotes = Get-Content -LiteralPath $releaseNotesPath -Raw
+        if ($releaseNotes.Contains('<!-- RELEASE-NOTES: DRAFT -->')) {
+          throw "Release notes for '$env:RELEASE_VERSION' are still marked as a draft."
+        }
 
-        Copy-Item -LiteralPath $releaseNotesPath "$env:RELEASE_ROOT\release-notes.md"
+        .\tools\release\Prepare-GitHubReleaseNotes.ps1 `
+          -SourcePath $releaseNotesPath `
+          -DestinationPath "$env:RELEASE_ROOT\release-notes.md" `
+          -Repository $env:GITHUB_REPOSITORY `
+          -Tag $env:RELEASE_TAG `
+          -RepositoryRoot (Get-Location).Path
         Copy-Item $env:TEST_RESULTS "$env:RELEASE_ROOT\test-results" -Recurse
         Compress-Archive -Path "$env:RELEASE_ROOT\test-results\*" -DestinationPath "$env:RELEASE_ROOT\test-results.zip"
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <Version>1.0.0-preview.1</Version>
+    <Version>1.0.0-preview.2</Version>
     <!-- Immutable after the first 1.x package is published. -->
     <ModernWpfCompatibilityBaselineVersion>1.0.0-preview.1</ModernWpfCompatibilityBaselineVersion>
     <ModernWpfSystemValueTupleVersion>4.6.2</ModernWpfSystemValueTupleVersion>

--- a/docs/release-notes-1.0.0-preview.2.md
+++ b/docs/release-notes-1.0.0-preview.2.md
@@ -1,0 +1,20 @@
+# ModernWPF 1.0.0-preview.2
+
+<!-- RELEASE-NOTES: DRAFT -->
+
+`1.0.0-preview.2` is the active development version following the first
+ModernWPF 1.x preview. This file will accumulate user-facing changes before
+the version is tagged.
+
+## Development baseline
+
+- `1.0.0-preview.1` remains the immutable forward-compatibility and package
+  validation baseline.
+- New public CLR APIs and resource keys must be recorded in the checked-in
+  unshipped inventories.
+- NuGet publication uses Trusted Publishing with a short-lived OIDC credential;
+  the repository does not store a long-lived NuGet API key.
+
+See [Migrating from ModernWPF 0.9.x](migrating-from-0.9.md) and the
+[1.x public API contract](public-api-contract-1x.md) for the compatibility
+boundary.

--- a/docs/release-readiness-1x.md
+++ b/docs/release-readiness-1x.md
@@ -1,6 +1,6 @@
 # ModernWpf 1.x Release Readiness
 
-This document defines the release gate for the `1.0.0-preview.1` maintenance line.
+This document defines the release gate for the active ModernWPF 1.x preview line.
 
 ## Supported package shape
 
@@ -101,7 +101,7 @@ annotated `v<Version>` tag on `master`. The tag version must match
 example:
 
 ```powershell
-gh workflow run release.yml --ref v1.0.0-preview.1 -f tag=v1.0.0-preview.1
+gh workflow run release.yml --ref v1.0.0-preview.2 -f tag=v1.0.0-preview.2
 ```
 
 The workflow builds and tests the tag once, retains the packages, symbols, TRX
@@ -109,6 +109,14 @@ results, release notes, and `SHA256SUMS`, then pauses at the protected
 `nuget-production` environment. The publication job verifies the downloaded
 artifact, prepares a draft GitHub prerelease, publishes the exact `.nupkg` to
 NuGet, and only then publishes the GitHub prerelease.
+
+Active-development notes carry a `RELEASE-NOTES: DRAFT` marker. The release
+workflow refuses to create an artifact until that marker is removed.
+
+When preparing the retained artifact, the workflow converts documentation links
+that are relative to the checked-in release-notes file into immutable,
+tag-pinned GitHub URLs. Keep those links relative in source so they also work
+when the notes are read under `docs/`.
 
 NuGet publication uses Trusted Publishing rather than a stored API key. The
 nuget.org policy is owned by the `kinnara` account and accepts OIDC identities

--- a/test/ModernWpf.Tools.Tests/ReleaseVersioningTests.cs
+++ b/test/ModernWpf.Tools.Tests/ReleaseVersioningTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -184,7 +185,19 @@ namespace ModernWpf.Tools.Tests
                 "Test-Path -LiteralPath $releaseNotesPath -PathType Leaf");
             StringAssert.Contains(
                 workflow,
-                "Copy-Item -LiteralPath $releaseNotesPath");
+                "<!-- RELEASE-NOTES: DRAFT -->");
+            StringAssert.Contains(
+                workflow,
+                "are still marked as a draft");
+            StringAssert.Contains(
+                workflow,
+                @".\tools\release\Prepare-GitHubReleaseNotes.ps1");
+            StringAssert.Contains(
+                workflow,
+                "-Repository $env:GITHUB_REPOSITORY");
+            StringAssert.Contains(
+                workflow,
+                "-Tag $env:RELEASE_TAG");
             StringAssert.Contains(
                 workflow,
                 "--title \"ModernWPF ${{ needs.build.outputs.version }}\"");
@@ -204,6 +217,92 @@ namespace ModernWpf.Tools.Tests
                 CountOccurrences(
                     workflow,
                     "Expected exactly one ModernWpfUI package, found $($packages.Count)."));
+        }
+
+        [TestMethod]
+        public void GitHubReleaseNotesUseTagPinnedDocumentationLinks()
+        {
+            var repoRoot = FindRepoRoot();
+            var props = XDocument.Load(Path.Combine(repoRoot, "Directory.Build.props"));
+            var version = GetPropertyValue(props, "Version");
+            var releaseNotesPath = Path.Combine(
+                repoRoot,
+                "docs",
+                $"release-notes-{version}.md");
+            var scriptPath = Path.Combine(
+                repoRoot,
+                "tools",
+                "release",
+                "Prepare-GitHubReleaseNotes.ps1");
+            var outputPath = Path.Combine(
+                Path.GetTempPath(),
+                $"modernwpf-release-notes-{Guid.NewGuid():N}.md");
+
+            try
+            {
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = "pwsh",
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    WorkingDirectory = repoRoot
+                };
+                foreach (var argument in new[]
+                {
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-File",
+                    scriptPath,
+                    "-SourcePath",
+                    releaseNotesPath,
+                    "-DestinationPath",
+                    outputPath,
+                    "-Repository",
+                    "Kinnara/ModernWpf",
+                    "-Tag",
+                    $"v{version}",
+                    "-RepositoryRoot",
+                    repoRoot
+                })
+                {
+                    startInfo.ArgumentList.Add(argument);
+                }
+
+                using var process = Process.Start(startInfo);
+                Assert.IsNotNull(process);
+                var standardOutput = process.StandardOutput.ReadToEnd();
+                var standardError = process.StandardError.ReadToEnd();
+                process.WaitForExit();
+
+                Assert.AreEqual(
+                    0,
+                    process.ExitCode,
+                    $"Release-note preparation failed.{Environment.NewLine}" +
+                    $"{standardOutput}{Environment.NewLine}{standardError}");
+
+                var preparedReleaseNotes = File.ReadAllText(outputPath);
+                var tagUrlPrefix =
+                    $"https://github.com/Kinnara/ModernWpf/blob/v{version}/docs/";
+                StringAssert.Contains(
+                    preparedReleaseNotes,
+                    $"{tagUrlPrefix}migrating-from-0.9.md");
+                StringAssert.Contains(
+                    preparedReleaseNotes,
+                    $"{tagUrlPrefix}public-api-contract-1x.md");
+                Assert.IsFalse(
+                    preparedReleaseNotes.Contains(
+                        "](migrating-from-0.9.md)",
+                        StringComparison.Ordinal));
+                Assert.IsFalse(
+                    preparedReleaseNotes.Contains(
+                        "](public-api-contract-1x.md)",
+                        StringComparison.Ordinal));
+            }
+            finally
+            {
+                File.Delete(outputPath);
+            }
         }
 
         [TestMethod]

--- a/tools/release/Prepare-GitHubReleaseNotes.ps1
+++ b/tools/release/Prepare-GitHubReleaseNotes.ps1
@@ -1,0 +1,86 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$SourcePath,
+
+    [Parameter(Mandatory)]
+    [string]$DestinationPath,
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
+    [string]$Repository,
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$')]
+    [string]$Tag,
+
+    [Parameter(Mandatory)]
+    [string]$RepositoryRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRootPath = [IO.Path]::GetFullPath($RepositoryRoot).TrimEnd(
+    [char[]]@([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar))
+$repositoryPrefix = "$repositoryRootPath$([IO.Path]::DirectorySeparatorChar)"
+$sourceFullPath = (Resolve-Path -LiteralPath $SourcePath).Path
+
+if (-not $sourceFullPath.StartsWith(
+    $repositoryPrefix,
+    [StringComparison]::OrdinalIgnoreCase)) {
+    throw "Release notes must be inside the repository: $sourceFullPath"
+}
+
+$sourceDirectory = Split-Path -Parent $sourceFullPath
+$releaseNotes = Get-Content -LiteralPath $sourceFullPath -Raw
+$relativeMarkdownLinkPattern =
+    '(?<prefix>\]\()(?<target>(?![A-Za-z][A-Za-z0-9+.-]*:|/|#)[^)]+\.md(?:#[^)]+)?)(?<suffix>\))'
+
+[Text.RegularExpressions.MatchEvaluator]$replaceRelativeMarkdownLink = {
+    param([Text.RegularExpressions.Match]$match)
+
+    $target = $match.Groups['target'].Value
+    $fragmentIndex = $target.IndexOf('#')
+    if ($fragmentIndex -ge 0) {
+        $targetPath = $target.Substring(0, $fragmentIndex)
+        $fragment = $target.Substring($fragmentIndex)
+    }
+    else {
+        $targetPath = $target
+        $fragment = ''
+    }
+
+    $targetFullPath = [IO.Path]::GetFullPath((Join-Path $sourceDirectory $targetPath))
+    if (-not $targetFullPath.StartsWith(
+        $repositoryPrefix,
+        [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Release-note link leaves the repository: $target"
+    }
+    if (-not (Test-Path -LiteralPath $targetFullPath -PathType Leaf)) {
+        throw "Release-note link target does not exist: $target"
+    }
+
+    $targetRelativePath = [IO.Path]::GetRelativePath(
+        $repositoryRootPath,
+        $targetFullPath).Replace('\', '/')
+    $targetUrl = "https://github.com/$Repository/blob/$Tag/$targetRelativePath$fragment"
+
+    return "$($match.Groups['prefix'].Value)$targetUrl$($match.Groups['suffix'].Value)"
+}
+
+$preparedReleaseNotes = [Text.RegularExpressions.Regex]::Replace(
+    $releaseNotes,
+    $relativeMarkdownLinkPattern,
+    $replaceRelativeMarkdownLink)
+$destinationFullPath = [IO.Path]::GetFullPath($DestinationPath)
+$destinationDirectory = Split-Path -Parent $destinationFullPath
+
+if (-not (Test-Path -LiteralPath $destinationDirectory -PathType Container)) {
+    New-Item -ItemType Directory -Path $destinationDirectory -Force | Out-Null
+}
+
+[IO.File]::WriteAllText(
+    $destinationFullPath,
+    $preparedReleaseNotes,
+    [Text.UTF8Encoding]::new($false))


### PR DESCRIPTION
## Summary

- bump the active development version to `1.0.0-preview.2`
- keep published `1.0.0-preview.1` as the immutable compatibility and NuGet package-validation baseline
- add draft preview.2 release notes and make publication reject the draft marker
- convert documentation-relative release-note links to immutable, tag-pinned GitHub URLs
- add focused tooling coverage for the release-note conversion

## Why

Preview 1 is now published and must become the forward package baseline for subsequent builds. The preview 1 GitHub release also exposed that links which are correct inside `docs/` are resolved from the repository root when used as a GitHub release body; the release workflow now prepares the correct tag-specific form automatically.

## Impact

There are no product API or runtime changes. Development packages now validate against the public preview 1 package, and preview 2 cannot be published while its notes are marked as a draft.

## Validation

- `dotnet restore ModernWpf.sln --force-evaluate --source https://api.nuget.org/v3/index.json`
- `dotnet build ModernWpf.sln --configuration Release --no-restore --maxcpucount:1` — 0 warnings, 0 errors
- `dotnet build test/ModernWpf.Tools.Tests/ModernWpf.Tools.Tests.csproj --configuration Release --framework net10.0 --no-restore` — 0 warnings, 0 errors
- `dotnet test test/ModernWpf.Tools.Tests/ModernWpf.Tools.Tests.csproj --configuration Release --framework net10.0 --no-build --no-restore` — 14 passed
- `dotnet pack ModernWpf.Controls/ModernWpf.Controls.csproj --configuration Release --no-build --no-restore --output artifacts/preview2-validation` — package validation passed against public `1.0.0-preview.1`
- `tools/release/Verify-ModernWpfPackage.ps1` — passed
- `tools/release/Test-ModernWpfPackageSmoke.ps1` — passed for both resource entries on `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0`
- `git diff --cached --check` — passed