### PR TITLE
Fix dark theme text entry carets

### DIFF
--- a/ModernWpf/Styles/AutoSuggestBox.xaml
+++ b/ModernWpf/Styles/AutoSuggestBox.xaml
@@ -23,6 +23,7 @@
         <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
         <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+        <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
         <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrush}" />
         <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />

--- a/ModernWpf/Styles/ToolBar.xaml
+++ b/ModernWpf/Styles/ToolBar.xaml
@@ -118,6 +118,7 @@
     <Style x:Key="{x:Static ToolBar.TextBoxStyleKey}" TargetType="{x:Type TextBox}">
         <Setter Property="KeyboardNavigation.TabNavigation" Value="None" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
         <Setter Property="AllowDrop" Value="True" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />

--- a/docs/autosuggestbox-winui3-source-audit.md
+++ b/docs/autosuggestbox-winui3-source-audit.md
@@ -134,6 +134,10 @@ The current page retains two examples:
 - Input-validation context/command and IME candidate positioning are not
   available on WPF TextBox. The shared inner TextBox also retains WPF triggers
   and `FontIconFallback` in place of native perf setters/AnimatedIcon paths.
+- The dedicated WPF inner-TextBox style explicitly maps `CaretBrush` to
+  `TextControlForeground`. WPF otherwise falls back to its system-background
+  caret calculation, which produces a dark caret over the Gallery title-bar
+  search box in Dark theme.
 - HeaderPlacement is exposed for API parity, while the shared WPF text-control
   header helper remains top-only pending a broader text-control port.
 - WPF mouse buttons/modifiers and `ListView.SelectedItems` represent WinUI
@@ -142,9 +146,10 @@ The current page retains two examples:
 ## Regression Coverage
 
 - `AutoSuggestBoxApiTests` covers source defaults/resources/template parts,
-  delayed counter semantics, automation Invoke and no-chosen-suggestion query,
-  ItemClick-before-selection ordering, WPF selection modes, query-button state
-  setters, popup shadow/insets, and corner filtering.
+  the theme-aware inner-TextBox caret, delayed counter semantics, automation
+  Invoke and no-chosen-suggestion query, ItemClick-before-selection ordering,
+  WPF selection modes, query-button state setters, popup shadow/insets, and
+  corner filtering.
 - `AutoSuggestBoxInteractionTests` covers choosing a suggestion by keyboard,
   preserving handler-assigned text after `SuggestionChosen`, Escape
   restoration, and query-button submission behavior.

--- a/docs/toolbar-family-wpf-fluent-source-audit.md
+++ b/docs/toolbar-family-wpf-fluent-source-audit.md
@@ -43,8 +43,12 @@ This is a stock WPF control-family port, so official WPF Fluent is the primary s
 - Official WPF Fluent's generic `Thumb` uses `Border.CornerRadius`; ModernWpf uses `Border.CornerRadius` for older target compatibility, matching the existing stock-control backport pattern.
 - Official WPF Fluent's generated monolithic dictionary can resolve `ToolBar.xaml` `StaticResource BasedOn` references from sibling style sections. ModernWpf loads style files as split dictionaries, so `ToolBar.xaml` locally merges the stock style dependencies it needs.
 - Official `ToolBar.xaml` references `MenuBorderColorDefaultBrush`, but the local official theme resource files do not define that exact key. ModernWpf exposes it as an alias to the same flyout border concept used by the menu/context menu family.
+- ModernWpf maps the toolbar TextBox `CaretBrush` to
+  `TextControlForeground`. The official style leaves the WPF caret fallback in
+  place, which derives from the system window background and can render a dark
+  caret over a transparent toolbar in Dark theme.
 
 ## Validation
 
-- `test\ModernWpf.WinUI.Tests\CommonStyles\ToolBarFamilyVisualStateTests.cs` verifies the official separator, thumb, toolbar, toolbar item-style keys, theme aliases, and absence of ModernWpf-specific template guesses.
+- `test\ModernWpf.WinUI.Tests\CommonStyles\ToolBarFamilyVisualStateTests.cs` verifies the official separator, thumb, toolbar, toolbar item-style keys, the theme-aware TextBox caret adaptation, theme aliases, and absence of ModernWpf-specific template guesses.
 - `test\ModernWpf.WinUI.Tests\TemplateParityTests.cs` classifies `Separator.xaml`, `Thumb.xaml`, and `ToolBar.xaml` as official WPF Fluent stock templates that should not use `VisualStateEx`.

--- a/test/ModernWpf.Gallery.Tests/GalleryNavigationRuntimeTests.cs
+++ b/test/ModernWpf.Gallery.Tests/GalleryNavigationRuntimeTests.cs
@@ -752,6 +752,52 @@ namespace ModernWpf.Gallery.Tests
         }
 
         [TestMethod]
+        public void MainWindowSearchCaretUsesDarkThemeForeground()
+        {
+            WpfTestHost.Run(() =>
+            {
+                var previousTheme = ThemeManager.Current.ApplicationTheme;
+                MainWindow window = null;
+
+                try
+                {
+                    ThemeManager.Current.ApplicationTheme = ApplicationTheme.Dark;
+                    WpfTestHost.DoEvents();
+
+                    window = new MainWindow
+                    {
+                        Left = -32000,
+                        Top = -32000,
+                        ShowInTaskbar = false,
+                        WindowStartupLocation = WindowStartupLocation.Manual
+                    };
+                    window.Show();
+                    WpfTestHost.DoEvents();
+                    window.UpdateLayout();
+                    WpfTestHost.DoEvents();
+
+                    var searchBox = (AutoSuggestBox)window.FindName("ControlsSearchBox");
+                    var textBox = FindVisualChildren<TextBox>(searchBox)
+                        .Single(element => string.Equals(element.Name, "TextBox", StringComparison.Ordinal));
+                    var expectedCaret = (Brush)textBox.TryFindResource("TextControlForeground");
+
+                    Assert.IsNotNull(expectedCaret);
+                    Assert.AreSame(expectedCaret, textBox.CaretBrush);
+                    Assert.IsInstanceOfType(textBox.CaretBrush, typeof(SolidColorBrush));
+                    Assert.IsTrue(
+                        ((SolidColorBrush)textBox.CaretBrush).Color.R > 0xC0,
+                        "The dark-theme search caret should use a light foreground brush.");
+                }
+                finally
+                {
+                    window?.Close();
+                    ThemeManager.Current.ApplicationTheme = previousTheme;
+                    WpfTestHost.DoEvents();
+                }
+            });
+        }
+
+        [TestMethod]
         public void MainWindowViewModelOfficialCommandHandlersDriveShellActions()
         {
             var backCount = 0;

--- a/test/ModernWpf.WinUI.Tests/AutoSuggestBox/AutoSuggestBoxApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/AutoSuggestBox/AutoSuggestBoxApiTests.cs
@@ -52,6 +52,7 @@ public class AutoSuggestBoxApiTests
             AssertDynamicResourceSetter(textBoxStyle, FrameworkElement.MinWidthProperty, "TextControlThemeMinWidth");
             AssertDynamicResourceSetter(textBoxStyle, FrameworkElement.MinHeightProperty, "TextControlThemeMinHeight");
             AssertDynamicResourceSetter(textBoxStyle, Control.ForegroundProperty, "TextControlForeground");
+            AssertDynamicResourceSetter(textBoxStyle, TextBoxBase.CaretBrushProperty, "TextControlForeground");
             AssertDynamicResourceSetter(textBoxStyle, Control.BackgroundProperty, "TextControlBackground");
             AssertDynamicResourceSetter(textBoxStyle, Control.BorderBrushProperty, "TextControlBorderBrush");
             AssertDynamicResourceSetter(textBoxStyle, TextBoxBase.SelectionBrushProperty, "TextControlSelectionHighlightColor");
@@ -134,6 +135,7 @@ public class AutoSuggestBoxApiTests
             Assert.AreEqual(textBox.TryFindResource("TextControlThemeMinWidth"), textBox.MinWidth);
             Assert.AreEqual(textBox.TryFindResource("TextControlThemeMinHeight"), textBox.MinHeight);
             AssertBrushEquals(autoSuggestBox.Foreground, textBox.Foreground);
+            AssertBrushEquals((Brush)textBox.TryFindResource("TextControlForeground"), textBox.CaretBrush);
             AssertBrushEquals(autoSuggestBox.Background, textBox.Background);
             AssertBrushEquals(autoSuggestBox.BorderBrush, textBox.BorderBrush);
             AssertBrushEquals((Brush)textBox.TryFindResource("TextControlSelectionHighlightColor"), textBox.SelectionBrush);

--- a/test/ModernWpf.WinUI.Tests/CommonStyles/ToolBarFamilyVisualStateTests.cs
+++ b/test/ModernWpf.WinUI.Tests/CommonStyles/ToolBarFamilyVisualStateTests.cs
@@ -138,6 +138,10 @@ public class ToolBarFamilyVisualStateTests
 
             var textBoxStyle = (Style)Application.Current.FindResource(ToolBar.TextBoxStyleKey);
             Assert.AreEqual(typeof(TextBox), textBoxStyle.TargetType);
+            AssertDynamicResourceSetter(
+                textBoxStyle.Setters.OfType<Setter>().ToArray(),
+                TextBoxBase.CaretBrushProperty,
+                "TextControlForeground");
             Assert.IsTrue(textBoxStyle.Setters.OfType<Setter>()
                 .Any(item => item.Property == Control.TemplateProperty));
 


### PR DESCRIPTION
## What changed

- Bind the AutoSuggestBox inner TextBox caret to `TextControlForeground`.
- Apply the same theme-aware caret binding to the toolbar TextBox style found during the related text-control audit.
- Add a Gallery regression test that verifies the title-bar search caret is light in Dark theme.
- Extend AutoSuggestBox and ToolBar style coverage and document both WPF adaptations.

## Why

The AutoSuggestBox inner TextBox overrides the normal TextBox style but did not set `CaretBrush`. WPF therefore used its system-background caret fallback, producing a dark, barely visible caret in the Gallery title-bar search box under Dark theme. The toolbar TextBox style had the same omission.

## Validation

- `dotnet restore ModernWpf.sln`
- `dotnet build ModernWpf.sln --configuration Release --no-restore` — 0 warnings, 0 errors
- Text-entry focused slice — 43 passed, 0 skipped
- Complete ModernWpf.WinUI.Tests (`net8.0-windows7.0`) — 1,061 passed, 0 skipped
- Complete ModernWpf.Gallery.Tests (`net8.0-windows7.0`) — 717 passed, 0 skipped
- Complete ModernWpf.Gallery.Tests (`net10.0-windows7.0`) — 717 passed, 0 skipped
