### PR TITLE
Sync WinUI 3 controls and add continuous drift monitoring

### DIFF
--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -1,0 +1,74 @@
+name: Monitor WinUI upstream drift
+
+on:
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upstream-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  report:
+    name: Classify upstream source drift
+    runs-on: windows-2022
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Generate drift report
+        id: drift
+        continue-on-error: true
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          $reportDirectory = Join-Path $env:RUNNER_TEMP 'modernwpf-upstream-drift'
+          New-Item -ItemType Directory -Path $reportDirectory -Force | Out-Null
+          .\tools\upstream\Get-UpstreamDriftReport.ps1 `
+            -OutputPath (Join-Path $reportDirectory 'upstream-drift.md') `
+            -JsonOutputPath (Join-Path $reportDirectory 'upstream-drift.json') `
+            -FailOnObservedDrift `
+            -FailOnIncompleteComparison
+
+      - name: Publish job summary
+        if: always()
+        shell: pwsh
+        run: |
+          $reportPath = Join-Path $env:RUNNER_TEMP 'modernwpf-upstream-drift\upstream-drift.md'
+          if (Test-Path -LiteralPath $reportPath -PathType Leaf) {
+            Get-Content -LiteralPath $reportPath -Raw |
+              Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+          }
+          else {
+            'The upstream drift report could not be generated.' |
+              Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+          }
+
+      - name: Upload drift report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: upstream-drift
+          path: ${{ runner.temp }}/modernwpf-upstream-drift
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Enforce monitoring result
+        if: always()
+        shell: pwsh
+        env:
+          DRIFT_STEP_OUTCOME: ${{ steps.drift.outcome }}
+        run: |
+          if ($env:DRIFT_STEP_OUTCOME -ne 'success') {
+            throw 'Upstream drift monitoring failed. Review the job summary and report artifact.'
+          }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,20 @@ exists below the directory being changed.
 
 ## Compatibility contract
 
-- `1.0.0-preview.1` is the forward-compatibility baseline. Do not remove or
-  change shipped public CLR APIs or explicitly shipped public resource keys.
+- `1.0.0-preview.1` is the first audit and migration baseline, not an
+  immutable API freeze across later previews.
+- During the 1.0 preview series, current applicable WinUI API shape remains
+  authoritative for WinUI-derived controls. A source-audited parity change may
+  deliberately add, change, or remove a Preview 1 CLR API or public resource
+  key when the same change updates the checked-in inventories, documents any
+  WPF adaptation, adds migration guidance, and includes focused tests.
+- Treat the checked-in inventories and NuGet package baseline as drift gates.
+  Unexpected changes fail; an intentional preview-era break must explicitly
+  rebaseline them in the reviewed change.
+- Stable `1.0.0` establishes the SemVer compatibility baseline. After that
+  release, preserve public CLR APIs and explicitly shipped public resource keys
+  throughout 1.x; adopt an upstream breaking change through a compatible
+  adaptation or in the next ModernWpf major version.
 - Public API inventories live in:
   - `ModernWpf/PublicAPI.Shipped.txt`
   - `ModernWpf/PublicAPI.Unshipped.txt`
@@ -34,15 +46,17 @@ exists below the directory being changed.
   files.
 - Prefer internal implementation types. Do not expose template helpers,
   converters, automation details, or WinRT projection types as package API.
-- Do not add members to an already shipped public interface. Add a new
-  capability interface or an extensible base-class member instead.
+- For ModernWpf-originated additions, do not add members to an already shipped
+  public interface; add a capability interface or extensible base-class member.
+  During previews, mirror a source-audited WinUI interface change when parity
+  requires it and record the resulting migration.
 - When adding a deliberate public resource key, run:
 
   ```powershell
   .\tools\api-contracts\Update-PublicResourceKeyContract.ps1
   ```
 
-- Consult `docs/public-api-contract-1x.md` for the complete boundary and
+- Consult `docs/public-api-contract-1x.md` for the complete governance policy and
   `docs/migrating-from-0.9.md` for intentional legacy breaks.
 
 ## Implementation rules

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,14 @@
 ﻿<Project>
   <PropertyGroup>
     <Version>1.0.0-preview.2</Version>
-    <!-- Immutable after the first 1.x package is published. -->
-    <ModernWpfCompatibilityBaselineVersion>1.0.0-preview.1</ModernWpfCompatibilityBaselineVersion>
+    <!-- Immutable identifier for the published historical audit/migration
+         package. It is informational and is not the active NuGet gate. -->
+    <ModernWpfPreviewAuditBaselineVersion>1.0.0-preview.1</ModernWpfPreviewAuditBaselineVersion>
+    <!-- Review-controlled NuGet comparison baseline. During previews, advance
+         this only in the same change as an accepted breaking-change audit,
+         inventory rebaseline, focused tests, and release-note migration entry.
+         Once stable 1.0.0 ships, this becomes the SemVer baseline for 1.x. -->
+    <ModernWpfPackageValidationBaselineVersion>1.0.0-preview.1</ModernWpfPackageValidationBaselineVersion>
     <ModernWpfPublicApiAnalyzersVersion>5.6.0</ModernWpfPublicApiAnalyzersVersion>
     <ModernWpfSystemValueTupleVersion>4.6.2</ModernWpfSystemValueTupleVersion>
     <ModernWpfWindowsSdkContractsVersion>10.0.28000.2526</ModernWpfWindowsSdkContractsVersion>

--- a/ModernWpf.Controls/CommandBar/CommandBar.cs
+++ b/ModernWpf.Controls/CommandBar/CommandBar.cs
@@ -738,7 +738,8 @@ namespace ModernWpf.Controls
             settings.OverflowContentMaxHeight = CalculateOverflowContentMaxHeight();
             settings.OverflowContentMinWidth = GetDoubleResource("CommandBarOverflowMinWidth", 160);
             settings.OverflowContentMaxWidth = GetDoubleResource("CommandBarOverflowMaxWidth", 480);
-            settings.EffectiveOverflowButtonVisibility = CalculateEffectiveOverflowButtonVisibility();
+            settings.EffectiveOverflowButtonVisibility =
+                CalculateEffectiveOverflowButtonVisibility(contentHeight);
             settings.OverflowContentHorizontalOffset = 0;
 
             Size overflowContentSize = new();
@@ -756,14 +757,17 @@ namespace ModernWpf.Controls
             settings.OverflowContentHiddenYTranslation = -contentHeight;
         }
 
-        private Visibility CalculateEffectiveOverflowButtonVisibility()
+        private Visibility CalculateEffectiveOverflowButtonVisibility(double contentHeight)
         {
             bool visible = true;
 
             switch (OverflowButtonVisibility)
             {
                 case CommandBarOverflowButtonVisibility.Auto:
-                    visible = m_dynamicSecondaryCommands.Count > 0 || HasVisiblePrimaryCommandWithBottomLabel();
+                    visible =
+                        m_dynamicSecondaryCommands.Count > 0 ||
+                        HasVisiblePrimaryCommandWithBottomLabel() ||
+                        ContentDiffersFromCompactHeight(contentHeight);
                     break;
                 case CommandBarOverflowButtonVisibility.Collapsed:
                     visible = false;
@@ -771,6 +775,26 @@ namespace ModernWpf.Controls
             }
 
             return visible ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private bool ContentDiffersFromCompactHeight(double contentHeight)
+        {
+            double compactHeight = GetDoubleResource("AppBarThemeCompactHeight", 48);
+            double compactVerticalDelta = contentHeight - compactHeight;
+            double rasterizationScale = VisualTreeHelper.GetDpi(this).DpiScaleY;
+
+            return IsCompactHeightDifferenceSignificant(
+                compactVerticalDelta,
+                rasterizationScale);
+        }
+
+        internal static bool IsCompactHeightDifferenceSignificant(
+            double compactVerticalDelta,
+            double rasterizationScale)
+        {
+            return rasterizationScale > 0 && !double.IsNaN(rasterizationScale)
+                ? Math.Abs(compactVerticalDelta) >= 0.5 / rasterizationScale
+                : compactVerticalDelta != 0;
         }
 
         private double GetDoubleResource(string key, double fallback)

--- a/ModernWpf.Controls/ModernWpf.Controls.csproj
+++ b/ModernWpf.Controls/ModernWpf.Controls.csproj
@@ -14,12 +14,14 @@
          public glue. Analyze the final, shipped compilation instead. -->
     <RunAnalyzers Condition="'$(_TargetAssemblyProjectName)' != ''">false</RunAnalyzers>
     <NoWarn>$(NoWarn);RS0036;RS0041</NoWarn>
+    <!-- These diagnostics guard the checked-in accepted API snapshot. A
+         deliberate preview-era WinUI break updates that snapshot explicitly. -->
     <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017;RS0024;RS0025</WarningsAsErrors>
     <EnablePackageValidation>true</EnablePackageValidation>
     <EnableStrictModeForCompatibleFrameworksInPackage>true</EnableStrictModeForCompatibleFrameworksInPackage>
     <EnableStrictModeForBaselineValidation>true</EnableStrictModeForBaselineValidation>
     <PackageValidationBaselineVersion
-      Condition="'$(Version)' != '$(ModernWpfCompatibilityBaselineVersion)' and '$(PackageValidationBaselineVersion)' == ''">$(ModernWpfCompatibilityBaselineVersion)</PackageValidationBaselineVersion>
+      Condition="'$(Version)' != '$(ModernWpfPackageValidationBaselineVersion)' and '$(PackageValidationBaselineVersion)' == ''">$(ModernWpfPackageValidationBaselineVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ModernWpf.Controls/Repeater/ItemsRepeater/ItemTemplate/RecyclePool.cs
+++ b/ModernWpf.Controls/Repeater/ItemsRepeater/ItemTemplate/RecyclePool.cs
@@ -23,7 +23,16 @@ namespace ModernWpf.Controls
             string key,
             UIElement owner)
         {
-            PutElementCore(element, key, owner);
+            bool oldSuppressParentInference = m_suppressParentInference;
+            m_suppressParentInference = owner == null;
+            try
+            {
+                PutElementCore(element, key, owner);
+            }
+            finally
+            {
+                m_suppressParentInference = oldSuppressParentInference;
+            }
         }
 
         public UIElement TryGetElement(
@@ -47,7 +56,7 @@ namespace ModernWpf.Controls
             var winrtKey = key;
             var winrtOwner = owner;
             var winrtOwnerAsPanel = EnsureOwnerIsPanelOrNull(winrtOwner);
-            if (winrtOwnerAsPanel == null)
+            if (winrtOwnerAsPanel == null && !m_suppressParentInference)
             {
                 winrtOwnerAsPanel = (element as FrameworkElement)?.Parent as Panel;
             }
@@ -175,5 +184,6 @@ namespace ModernWpf.Controls
         }
 
         private readonly Dictionary<string, List<ElementInfo>> m_elements = new Dictionary<string, List<ElementInfo>>();
+        private bool m_suppressParentInference;
     }
 }

--- a/ModernWpf.Controls/Repeater/ItemsRepeater/ItemsRepeater.cs
+++ b/ModernWpf.Controls/Repeater/ItemsRepeater/ItemsRepeater.cs
@@ -538,12 +538,20 @@ namespace ModernWpf.Controls
                     {
                         // Walk through all the elements and make sure they are cleared for
                         // non-virtualizing layouts.
-                        foreach (UIElement element in Children)
+                        ViewManager.RecycleWithoutOwner(true);
+                        try
                         {
-                            if (GetVirtualizationInfo(element).IsRealized)
+                            foreach (UIElement element in Children)
                             {
-                                ClearElementImpl(element);
+                                if (GetVirtualizationInfo(element).IsRealized)
+                                {
+                                    ClearElementImpl(element);
+                                }
                             }
+                        }
+                        finally
+                        {
+                            ViewManager.RecycleWithoutOwner(false);
                         }
 
                         Children.Clear();

--- a/ModernWpf.Controls/Repeater/ItemsRepeater/ViewManager.cs
+++ b/ModernWpf.Controls/Repeater/ItemsRepeater/ViewManager.cs
@@ -98,6 +98,11 @@ namespace ModernWpf.Controls
             }
         }
 
+        public void RecycleWithoutOwner(bool recycleWithoutOwner)
+        {
+            m_recycleWithoutOwner = recycleWithoutOwner;
+        }
+
         // We need to clear the datacontext to prevent crashes from happening,
         //  however we only do that if we were the ones setting it.
         // That is when one of the following is the case (numbering taken from line ~642):
@@ -133,7 +138,7 @@ namespace ModernWpf.Controls
 
                 var context = m_ElementFactoryRecycleArgs;
                 context.Element = element;
-                context.Parent = m_owner;
+                context.Parent = m_recycleWithoutOwner ? null : m_owner;
 
                 m_owner.ItemTemplateShim.RecycleElement(context);
 
@@ -913,6 +918,7 @@ namespace ModernWpf.Controls
         // It has to be an element we own (i.e. a direct child).
         private UIElement m_lastFocusedElement;
         private bool m_isDataSourceStableResetPending;
+        private bool m_recycleWithoutOwner;
 
         // Event tokens
         private bool m_gotFocus;

--- a/ModernWpf/Controls/Primitives/WindowedPopup.cs
+++ b/ModernWpf/Controls/Primitives/WindowedPopup.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
@@ -9,7 +10,7 @@ using System.Windows.Media;
 namespace ModernWpf.Controls.Primitives
 {
     [ContentProperty(nameof(Child))]
-    public class WindowedPopup : FrameworkElement, IAddChild
+    public class WindowedPopup : FrameworkElement, IAddChild, ISupportInitialize
     {
         public static readonly DependencyProperty ChildProperty =
             DependencyProperty.Register(
@@ -145,6 +146,19 @@ namespace ModernWpf.Controls.Primitives
             }
         }
 
+        void ISupportInitialize.BeginInit()
+        {
+            base.BeginInit();
+            _isInitializing = true;
+        }
+
+        void ISupportInitialize.EndInit()
+        {
+            base.EndInit();
+            _isInitializing = false;
+            RetryPendingOpen();
+        }
+
         protected override Size MeasureOverride(Size availableSize)
         {
             return new Size();
@@ -180,7 +194,14 @@ namespace ModernWpf.Controls.Primitives
                 newChild.AddHandler(SizeChangedEvent, _childSizeChangedHandler);
             }
 
-            Reposition();
+            if (_isOpenPending)
+            {
+                RetryPendingOpen();
+            }
+            else
+            {
+                Reposition();
+            }
         }
 
         private static void OnIsOpenChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -208,32 +229,48 @@ namespace ModernWpf.Controls.Primitives
                 UpdatePlacementTargetHandlers();
             }
 
-            Reposition();
+            if (_isOpenPending)
+            {
+                RetryPendingOpen();
+            }
+            else
+            {
+                Reposition();
+            }
         }
 
         private void Open()
         {
             if (_source != null)
             {
+                ClearPendingOpen();
                 Reposition();
                 return;
             }
 
             if (Child == null)
             {
-                SetCurrentValue(IsOpenProperty, false);
+                DeferOpen(untilLoaded: _isInitializing);
                 return;
             }
 
-            if (PlacementTarget != null &&
-                DesiredPlacement != PopupPlacementMode.Auto &&
-                !IsConnectedToPresentationSource(PlacementTarget))
+            if (_isInitializing ||
+                (_deferOpenUntilLoaded && !IsConnectedToPresentationSource(this)))
             {
-                SetCurrentValue(IsOpenProperty, false);
+                DeferOpen(untilLoaded: true);
                 return;
             }
 
             UpdatePlacementTargetHandlers();
+            if (PlacementTarget != null &&
+                DesiredPlacement != PopupPlacementMode.Auto &&
+                !IsConnectedToPresentationSource(PlacementTarget))
+            {
+                DeferOpen(untilLoaded: false);
+                return;
+            }
+
+            ClearPendingOpen();
             var placement = CalculatePlacement();
 
             _root = new WindowedPopupRoot { Child = Child };
@@ -247,6 +284,7 @@ namespace ModernWpf.Controls.Primitives
 
         private void Close()
         {
+            ClearPendingOpen();
             ClearPlacementTargetHandlers();
 
             if (_root != null)
@@ -267,6 +305,27 @@ namespace ModernWpf.Controls.Primitives
                 }
 
                 Closed?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        private void DeferOpen(bool untilLoaded)
+        {
+            _isOpenPending = true;
+            _deferOpenUntilLoaded |= untilLoaded;
+            UpdatePlacementTargetHandlers();
+        }
+
+        private void ClearPendingOpen()
+        {
+            _isOpenPending = false;
+            _deferOpenUntilLoaded = false;
+        }
+
+        private void RetryPendingOpen()
+        {
+            if (_isOpenPending && IsOpen && _source == null)
+            {
+                Open();
             }
         }
 
@@ -450,6 +509,7 @@ namespace ModernWpf.Controls.Primitives
             _trackedPlacementTarget = placementTarget;
             if (_trackedPlacementTarget != null)
             {
+                _trackedPlacementTarget.Loaded += OnPlacementTargetLoaded;
                 _trackedPlacementTarget.LayoutUpdated += OnPlacementTargetLayoutUpdated;
                 _trackedPlacementTarget.Unloaded += OnPlacementTargetUnloaded;
             }
@@ -459,15 +519,33 @@ namespace ModernWpf.Controls.Primitives
         {
             if (_trackedPlacementTarget != null)
             {
+                _trackedPlacementTarget.Loaded -= OnPlacementTargetLoaded;
                 _trackedPlacementTarget.LayoutUpdated -= OnPlacementTargetLayoutUpdated;
                 _trackedPlacementTarget.Unloaded -= OnPlacementTargetUnloaded;
                 _trackedPlacementTarget = null;
             }
         }
 
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            RetryPendingOpen();
+        }
+
+        private void OnPlacementTargetLoaded(object sender, RoutedEventArgs e)
+        {
+            RetryPendingOpen();
+        }
+
         private void OnPlacementTargetLayoutUpdated(object sender, EventArgs e)
         {
-            Reposition();
+            if (_isOpenPending)
+            {
+                RetryPendingOpen();
+            }
+            else
+            {
+                Reposition();
+            }
         }
 
         private void OnPlacementTargetUnloaded(object sender, RoutedEventArgs e)
@@ -999,6 +1077,9 @@ namespace ModernWpf.Controls.Primitives
         private HwndSource _source;
         private WindowedPopupRoot _root;
         private FrameworkElement _trackedPlacementTarget;
+        private bool _isInitializing;
+        private bool _isOpenPending;
+        private bool _deferOpenUntilLoaded;
         private const int WS_POPUP = unchecked((int)0x80000000);
         private const int WS_CLIPSIBLINGS = 0x04000000;
         private const int WS_EX_TOOLWINDOW = 0x00000080;
@@ -1014,6 +1095,7 @@ namespace ModernWpf.Controls.Primitives
         public WindowedPopup()
         {
             _childSizeChangedHandler = OnChildSizeChanged;
+            Loaded += OnLoaded;
         }
 
         [DllImport("user32.dll", SetLastError = true)]

--- a/ModernWpf/ModernWpf.csproj
+++ b/ModernWpf/ModernWpf.csproj
@@ -11,6 +11,8 @@
          but this project's generated P/Invoke surface contains none; package
          smoke tests execute every supported target instead. -->
     <NoWarn>1701;1702;1573;1591;RS0041;SYSLIB0021;SYSLIB0051;CA2256;CS9191;PInvoke009</NoWarn>
+    <!-- These diagnostics guard the checked-in accepted API snapshot. A
+         deliberate preview-era WinUI break updates that snapshot explicitly. -->
     <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017;RS0024;RS0025</WarningsAsErrors>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ ModernWPF is not affiliated with or endorsed by Microsoft.
 
 | Line | Status | Policy |
 | --- | --- | --- |
-| 1.x | Active preview | Current development line. `1.0.0-preview.1` establishes the forward-compatible CLR API and public resource-key baseline. |
+| 1.x | Active preview | Current development line. `1.0.0-preview.1` records the first API/resource audit and migration baseline; later previews follow current applicable WinUI API shape, with deliberate breaks documented before stable `1.0.0` establishes the SemVer boundary. |
 | 0.9.x | Frozen and unsupported | Historical packages remain available, but no updates or security fixes are planned. |
 
 Source and binary compatibility with 0.9.x is not promised. Existing
@@ -181,7 +181,8 @@ also requires the .NET Framework 4.6.2 Developer Pack. In Visual Studio, open
 | --- | --- |
 | [1.0.0-preview.1 release notes](docs/release-notes-1.0.0-preview.1.md) | Package changes, intentional 0.9 breaks, recommended resources, and preview limitations. |
 | [Migrating from 0.9.x](docs/migrating-from-0.9.md) | Step-by-step application migration guidance. |
-| [1.x public API contract](docs/public-api-contract-1x.md) | Forward compatibility policy for CLR APIs and public resource keys. |
+| [1.x public API contract](docs/public-api-contract-1x.md) | Preview governance and stable compatibility policy for CLR APIs and public resource keys. |
+| [WinUI 3 synchronization epoch](docs/winui3-sync-2026-07-29.md) | Stable/main/Gallery pins, complete upstream dispositions, WPF adaptations, and continuous drift-monitoring policy. |
 
 ## Build from source
 

--- a/docs/commandbar-winui3-source-audit.md
+++ b/docs/commandbar-winui3-source-audit.md
@@ -1,12 +1,20 @@
 # CommandBar WinUI 3 Source Audit
 
 Date: 2026-07-19
+Updated: 2026-07-30
 
 This audit pins the ModernWpf `CommandBar` product, Gallery sample, automation,
 and installed-Gallery pixel gates to current official sources. The authoritative
 Microsoft UI XAML commit is
 `de3e767333c2f0717a6a70cb22bd192ced5ad885`; the authoritative WinUI Gallery
 commit is `29f62479d5c046a0b854a5868e5a7cd484572d87`.
+
+The central synchronization epoch in `docs/winui3-sync-2026-07-29.md`
+reconciles this detailed baseline through product `winui3/main`
+`eb75504a1978df0d37a3ad4574d6f72bf4d21583`, stable
+`winui3/release/2.3.1` at
+`a97562621a1d1ea397a38a3f512c9eef99db52d8`, and Gallery
+`f4dc3eb367f4bcecac1793829d9a221e924e5bfb`.
 
 ## Current source inputs
 
@@ -46,6 +54,7 @@ no later CommandBar change.
 | The current source template hard-codes the More button's `FontIcon` glyph to `E712` and exposes no CLR icon property. | The default geometry remains source-equivalent, while the WPF resource system exposes it as the public `CommandBarMoreButtonIconData` key. A `StreamGeometry` with that key in an individual CommandBar's resources replaces the glyph without retemplating the control or changing its CLR API. |
 | Source overflow item exposes label, icon, and keyboard accelerator in a 32-DIP row. | `AppBarButton` overflow states expose Settings and `Ctrl+I`; UIA reports Button / Invoke and exact `167x32` current-Gallery geometry. |
 | `ICommandBarElement.DynamicOverflowOrder` and `CommandBar::FindMovablePrimaryCommandsFromOrderSet` move complete positive order groups lowest-first with adjacent separators, then use right-to-left order-zero fallback. `DynamicOverflowItemsChanging` fires before the transition with Adding/Removing action. | Matched. All four AppBar element types own the shared public dependency property; order changes immediately reflow from the original collections. The pre-transition event compares the previous/current moved-primary sets exactly like source, so new members report Adding and pure restoration reports Removing. |
+| In Auto mode, current `CommandBar_Partial.cpp` treats the content height as different from `AppBarThemeCompactHeight` only when the absolute delta reaches half a physical pixel: `0.5 / rasterizationScale` (`8dca4cd76468ac49cd2aa31cafa2e320835cb17b`). | `CommandBar` measures its content height, reads the same compact-height resource, and uses WPF's `VisualTreeHelper.GetDpi(this).DpiScaleY` as the rasterization-scale equivalent. Below-threshold subpixel drift leaves an otherwise empty More button collapsed; at or above the threshold it becomes visible. |
 | Source shadow wrapper surrounds the overflow presenter. | `OverflowContentRoot` owns `SecondaryItemsControlShadowWrapper`; `ThemeShadowChrome` uses depth 32 and medium windowed-popup inset mode. |
 | Command execution closes overflow and source input mode propagates to overflow commands. | Parent ownership callbacks close the bar; WPF default/touch input tracking updates secondary AppBar visual states. |
 | The inherited AppBar lifecycle raises Opening, Opened, Closing, and Closed in order and exposes protected virtual hooks. | Matched on the WPF control. `Closed` is completed from the authoritative `IsOpen=false` transition because collapsing the WPF popup content can suppress `Popup.Closed`; external popup closure still synchronizes `IsOpen`. |
@@ -129,11 +138,17 @@ recordings pass. Both detect the expected Settings surface on two opens and
 produce dense-transition review sheets; maximum frame/local deltas are
 `0.524` / `54.178` and `0.098` / `10.513`.
 
-Product coverage passes 44/44. The current Gallery sample/source/visual-gate
-slice passes 3/3 on net8 and net10, the visual-check PowerShell parses, and
-Controls/Gallery build on net462, net8, and net10 with zero errors.
+The prior detailed-baseline product coverage passed 44/44. The synchronization
+epoch adds
+`CommandBarAutoOverflowButtonUsesPhysicalPixelCompactHeightThreshold`; the
+final serialized epoch gate reruns the complete project after that focused
+regression. The current Gallery sample/source/visual-gate slice previously
+passed 3/3 on net8 and net10, the visual-check PowerShell parses, and
+Controls/Gallery built on net462, net8, and net10 with zero errors.
 
 `CommandBarMoreButtonIconDataCanBeOverriddenPerInstance` verifies both the
 default resource identity and a live per-CommandBar geometry replacement. The
-resource is listed in `PublicResourceKeys.Shipped.txt` and is part of the
-preview-1 forward-compatibility contract.
+resource is listed in `PublicResourceKeys.Shipped.txt`; Preview 1 records its
+audit and migration baseline. Any preview-era change to that public key must be
+deliberate, justified by the source audit or a documented WPF adaptation,
+rebaselined, and documented for consumers.

--- a/docs/custom-popup-source-findings.md
+++ b/docs/custom-popup-source-findings.md
@@ -1,6 +1,7 @@
 # Custom Popup Source Findings
 
 Date: 2026-06-07
+Updated: 2026-07-30
 
 This note captures the source pass for replacing WPF `Popup` usage in ModernWpf flyout surfaces that need WinUI-like placement. The immediate motivator is CommandBarFlyout, but the primitive should be reusable.
 
@@ -15,6 +16,12 @@ This note captures the source pass for replacing WPF `Popup` usage in ModernWpf 
   - `D:\repos\microsoft-ui-xaml\src\dxaml\xcp\dxaml\idl\winrt\core\microsoft.ui.xaml.coretypes.idl`
   - `D:\repos\microsoft-ui-xaml\specs\Popup-AdditionalLayoutProperties-Spec.md`
   - `D:\repos\microsoft-ui-xaml\src\controls\dev\CommandBarFlyout\CommandBarFlyoutCommandBar.cpp`
+- Current WinUI pending-open fix:
+  - `microsoft-ui-xaml` commit
+    `ce96a1586e0fc7826f4e1ed0a39f33e01ab59768`
+  - `dxaml\xcp\core\core\elements\Popup.cpp`
+  - `dxaml\xcp\core\inc\Popup.h`
+  - `dxaml\test\native\external\controls\primitives\popup\PopupIntegrationTests.cpp`
 
 ## WPF Popup Behavior To Avoid
 
@@ -44,6 +51,10 @@ Important source points:
 - If the desired placement is out of bounds, WinUI flips the major placement or justification, recalculates, and reports the final `ActualPlacement`.
 - `ActualPlacementChanged` is raised when the calculated placement changes, before the screen refresh path completes.
 - CommandBarFlyout uses `PlacementTarget = PrimaryItemsRoot`, `DesiredPlacement = BottomEdgeAlignedLeft`, and `ActualPlacement` to choose expanded-up versus expanded-down visual states.
+- Current WinUI keeps `IsOpen=true` when XAML parsing applies it before a
+  popup root is available. `CPopup` records a pending open from both
+  `SetValue(IsOpen)` and `SetChild`, completes it after the element enters the
+  live tree, and clears the pending request when the popup closes.
 
 ## Design Consequences
 
@@ -60,6 +71,20 @@ Required first version:
 - Raise `ActualPlacementChanged` before showing/moving the HWND for the frame.
 - For `ThemeShadowChrome`, distinguish host bounds from content-placement bounds so reserved shadow space expands the HWND but does not move the visible content edge.
 - Reposition on placement target layout changes, child size changes, DPI/source changes, offsets, and desired placement changes.
+- Preserve an `IsOpen=true` request made during XAML initialization when the
+  child or live anchor is not ready. Retry after `Child`, popup `Loaded`, or
+  placement-target `Loaded` becomes available, and cancel the request on
+  `IsOpen=false`.
+
+WPF adaptation for the pending-open path:
+
+- Loose and compiled WPF XAML drive `ISupportInitialize.BeginInit` /
+  `EndInit`; `WindowedPopup` uses that public lifecycle to distinguish parser
+  initialization from an intentionally parentless programmatic `Auto` popup.
+- WPF `Loaded` is the equivalent point at which the popup's presentation
+  source is available. The deferred HWND is created there, while a
+  programmatic `Auto` popup with an existing child retains its immediate,
+  parentless open behavior.
 
 Explicit non-goals for the first version:
 
@@ -88,6 +113,10 @@ Added coverage in `test\ModernWpf.WinUI.Tests\Popup\WindowedPopupApiTests.cs`:
 - Placement target unload cleanup.
 - Child resize while open, including HWND size tracking.
 - Child replacement while open.
+- XAML initialization with `IsOpen=True` before `Child`.
+- XAML property-element initialization with `Child` before `IsOpen=True`.
+- Cancellation of a pending XAML open before `Loaded`.
+- Immediate parentless programmatic `Auto` opening.
 - ThemeShadowChrome reserved placement bounds.
 - Out-of-bounds placement flip before show.
 - `WM_MOUSEACTIVATE` returns `MA_NOACTIVATE`.

--- a/docs/migrating-from-0.9.md
+++ b/docs/migrating-from-0.9.md
@@ -1,8 +1,10 @@
 # Migrating from ModernWpf 0.9.x
 
-ModernWpf 1.x is a new forward-compatible line, not a binary-compatible update
-to 0.9.x. Migrate in a branch and compile every application target before
-replacing a production package reference.
+ModernWpf 1.x is a new product line, not a binary-compatible update to 0.9.x.
+The 1.0 previews may deliberately change to follow current applicable WinUI API
+shape; stable `1.0.0` establishes the SemVer compatibility boundary. Migrate in
+a branch and compile every application target before replacing a production
+package reference.
 
 ## 1. Retarget the application
 
@@ -59,8 +61,11 @@ Do not merge both control-resource entries into the same application scope.
 | Template-only public primitive types | Remove direct references and customize through supported control APIs, templates, and documented resource keys. |
 | Public `ABI.*` or WinRT projection types | Remove references; these are implementation details. |
 
-The checked-in shipped API and resource inventories define the preview-1
-forward baseline. They do not assert compatibility with 0.9.x.
+The checked-in shipped API and resource inventories record the Preview 1 audit
+and migration baseline. During the 1.0 preview series they remain drift gates,
+but an accepted WinUI parity change may deliberately rebaseline them with
+focused tests and migration guidance. They do not assert compatibility with
+0.9.x.
 
 ## 4. Migrate MahApps integration
 

--- a/docs/navigationview-winui3-source-audit.md
+++ b/docs/navigationview-winui3-source-audit.md
@@ -1,6 +1,7 @@
 # NavigationView WinUI 3 Source Audit
 
 Date: 2026-07-19
+Updated: 2026-07-30
 
 This audit refreshes ModernWpf's existing source-shaped `NavigationView` port
 against official `winui3/main` commit
@@ -18,6 +19,28 @@ allocation/performance cleanups plus two substantive current fixes. Commit
 footer subtraction. Commit `834625ee535b767ca8ab3e381468e52ebed6aeb5`
 revalidates expansion, flyout mode, template root, and attached flyout before a
 deferred child-flyout show. Both fixes are now ported and regression-tested.
+
+### 2026-07-29 epoch reconciliation
+
+The repository-wide current-source epoch advances `winui3/main` through
+`eb75504a1978df0d37a3ad4574d6f72bf4d21583` and content-reconciles the latest
+stable `winui3/release/2.3.1` snapshot
+`a97562621a1d1ea397a38a3f512c9eef99db52d8`. Stable commit
+`e5d2c481b35a62e3a2a7b3818f896e6470a25514` first changed
+NavigationView-item Space handling so Alt+Space remains available to the
+window system menu. That change was reverted by
+`72e7be771aea8288ff8d2ae7916ea4257da4cbbc` and then restored in the final
+stable lineage by `a4d23ee1161d5dacd221f8b8dfb730fcc2f27e73`.
+
+ModernWpf is already behaviorally equivalent through WPF's key projection.
+An Alt+Space key-down is represented as `Key.System` with
+`SystemKey=Key.Space`; the item invocation path switches on `KeyEventArgs.Key`
+and handles only a plain `Key.Space`. It therefore neither invokes the item nor
+marks Alt+Space handled, while ordinary Space remains handled and invokes the
+item. No product-code delta is required.
+`NavigationViewItemAltSpaceRemainsUnhandledForSystemMenuLikeCurrentWinUI`
+constructs that exact system-marked WPF event and guards both halves of the
+contract.
 
 ## Current WinUI 3 Source Inputs
 
@@ -108,6 +131,7 @@ API controls are covered by the focused Gallery regression.
 | `NavigationView` owns pane/display-mode state, menu/footer collections, selection, top-navigation data, template parts, and item hierarchy. | The existing WPF control family retains that source-shaped ownership, including the root split view, pane/header/footer hosts, repeaters, overflow host, selection model, item factory, and display-mode updates. |
 | Current `UpdatePaneLayout` compares `menuItemsActualHeight` with half the available height and only subtracts an otherwise-unresolved footer repeater when the subtraction cannot be negative. | ModernWpf ports both conditions directly. `PaneLayoutNeverAssignsNegativeScrollViewerMaxHeight` supplies stale desired/actual menu geometry and an oversized footer to prove both menu and footer `ScrollViewer.MaxHeight` values remain non-negative. |
 | Current `NavigationViewItem::ShowHideChildren` revalidates expansion, flyout mode, root-grid lifetime, and the attached flyout inside its queued render callback. | The WPF composition-render callback applies the same four gates before `ShowAttachedFlyout`. `DeferredChildFlyoutShowSkipsCollapsedItem` proves an expand-then-collapse race stays closed and that a still-expanded item continues to open normally. |
+| Current stable NavigationView item handling leaves Alt+Space unhandled so the system window menu can open, while plain Space invokes the item. | WPF projects Alt+Space as `Key.System` with `SystemKey=Key.Space`. ModernWpf's source-shaped item handler switches on `KeyEventArgs.Key`, so only plain `Key.Space` enters the invoke-and-handle branch. |
 | The current Light/Dark theme dictionaries use `AcrylicInAppFillColorDefaultBrush` for the default pane, transparent expanded/top pane colors, `LayerFillColorDefaultBrush` for content, primary/secondary text aliases for item states, transparent icon background, secondary header foreground, and `CardStrokeColorDefaultBrush` for the content border. | Light/Dark dictionaries now carry the current aliases and the previously missing icon, header, and content-border keys. High Contrast uses the current system brush mappings. The template consumes all three missing keys. |
 | WinUI Gallery renders the in-app acrylic pane over its default Light/Dark page as solid sampled colors `#F2F2F2` / `#1F1F1F`; its content is `#F9F9F9` / `#272727`. | WPF has no acrylic compositor. `SystemControlPageBackgroundChromeLowBrush` and `SystemControlBackgroundChromeMediumBrush` are deterministic theme-specific solid fallbacks for the rendered pane, while `LayerFillColorDefaultBrush` supplies the exact content surface. |
 | Current item and top-item normal/hover/pressed/selected foregrounds use primary or secondary text aliases, and hover/pressed top backgrounds use subtle secondary/tertiary fills. | ModernWpf replaces the stale WinUI 2 aliases with the current primary/secondary and subtle-fill resource graph in Light, Dark, and High Contrast. |
@@ -255,10 +279,15 @@ API controls are covered by the focused Gallery regression.
   applying a custom `DataTemplate` to the inherited `ContentTemplate`
   property, verifying that the main presenter receives that exact template,
   and verifying the template's bound visual content.
-- NavigationView product/source-audit tests pass 63/63; SplitView product tests
-  pass 14/14; the focused Gallery sample/source-shape slice passes 8/8 on net8
-  and net10. Gallery builds successfully on net462, net8, and net10 with zero
-  errors; current target builds retain existing unrelated warnings.
+- `NavigationViewItemAltSpaceRemainsUnhandledForSystemMenuLikeCurrentWinUI`
+  guards the current stable system-menu shortcut while proving ordinary Space
+  still invokes and handles the item.
+- The prior detailed-baseline NavigationView product/source-audit slice passed
+  63/63. The epoch adds the Alt+Space guard; the final serialized epoch gate
+  reruns the complete project. SplitView product tests passed 14/14; the
+  focused Gallery sample/source-shape slice passed 8/8 on net8 and net10.
+  Gallery built successfully on net462, net8, and net10 with zero errors;
+  current target builds retained existing unrelated warnings.
 
 ```powershell
 dotnet test .\test\ModernWpf.WinUI.Tests\ModernWpf.WinUI.Tests.csproj --no-restore --filter FullyQualifiedName~NavigationView

--- a/docs/official-fluent-winui-consistency.md
+++ b/docs/official-fluent-winui-consistency.md
@@ -1,17 +1,19 @@
 # Official WPF Fluent And WinUI Consistency
 
-This matrix tracks the 1.x theme strategy after the WinUI 2.8.7 sync and the
-later WinUI 3 source-parity pivot. ModernWpf
-uses two upstreams:
+This matrix tracks the 1.x theme strategy after the historical WinUI 2.8.7
+sync and the WinUI 3 source-parity pivot. ModernWpf uses two active upstreams:
 
 - official WPF Fluent for stock WPF controls where the target framework provides
   `PresentationFramework.Fluent`;
 - WinUI 3 for ModernWpf-specific controls, WinUI-compatible resource keys,
   and element-level theme behavior.
 
-The goal is not to replace one upstream with the other. The goal is to keep a
-stable ModernWpf API while making the stock-control layer look and behave like
-the platform Fluent theme on new WPF runtimes.
+The goal is not to replace one upstream with the other. During previews,
+public-surface changes remain deliberate but current applicable WinUI API shape
+is authoritative for WinUI-derived controls, including documented breaking
+changes. Stable 1.x releases preserve their SemVer contract while the
+stock-control layer continues to look and behave like the platform Fluent theme
+on new WPF runtimes.
 
 ## Source Map
 
@@ -19,9 +21,9 @@ the platform Fluent theme on new WPF runtimes.
 | --- | --- | --- | --- | --- |
 | Stock WPF control styles on `net10.0-windows7.0` | `D:\repos\wpf\src\Microsoft.DotNet.Wpf\src\Themes\PresentationFramework.Fluent` | `FluentControlsResources` entry-point composition | `FluentControlsResources` enables the platform ThemeMode bridge and layers `ModernWpfControlsResources.xaml`; WPF supplies the official Fluent stock-control dictionary. | Verify the official Fluent dictionary is active once and that ModernWpf-only control resources still resolve. |
 | Stock WPF control styles on `net462` and `net8.0-windows7.0` | ModernWpf backport, periodically compared with official WPF Fluent XAML | `ControlsResources.xaml`, `StockControlsResources.xaml`, `ThemeResources/*.xaml`, `DensityStyles/Compact.xaml` | Older targets still use the existing ModernWpf controls/resources path. | `docs/official-fluent-style-coverage.md` must account for every official `Styles` source file as backported, folded, substituted, or excluded. |
-| ModernWpf WinUI-derived controls | WinUI 3 source and `docs/winui3-source-parity.md` | `ModernWpf.Controls` and `ModernWpf` control implementations | The WinUI-derived WPF test harness covers implemented controls and documented exclusions. | Do not remove WinUI resource aliases or template contracts while adopting official stock-control styles. |
-| Shared theme tokens and aliases | WinUI 2.8.7 names plus official WPF Fluent values where they overlap | `ThemeResources`, `UISettingsResources`, `ModernWpfControlsResources.xaml` | Existing resources provide WinUI-compatible brush, typography, density, and accent aliases. | Alias keys remain stable; overlapping stock-control values may map to official Fluent values when feasible. |
-| Recommended resource entry | ModernWpf compatibility contract | `<ui:ThemeResources />` plus `<ui:FluentControlsResources />` | README and Gallery use the new entry, and `ModernWpf.Theme.Tests` plus `ModernWpf.Gallery.Tests` exercise the entry on net8 and net10. | Keep focused net10 smoke coverage for the recommended entry and keep legacy entry behavior unchanged. |
+| ModernWpf WinUI-derived controls | Current applicable WinUI 3 source and `docs/winui3-source-parity.md` | `ModernWpf.Controls` and `ModernWpf` control implementations | The WinUI-derived WPF test harness covers implemented controls and documented exclusions. | During previews, classify and test upstream API/resource changes and document migrations or WPF adaptations; after stable 1.0, preserve the SemVer contract or defer a break to the next major. |
+| Shared theme tokens and aliases | Current applicable WinUI 3 resources plus official WPF Fluent values where they overlap; WinUI 2.8.7 is historical reference only | `ThemeResources`, `UISettingsResources`, `ModernWpfControlsResources.xaml` | Existing resources provide WinUI-compatible brush, typography, density, and accent aliases. | Audit aliases against current upstream; preview changes may be deliberately rebaselined, while stable 1.x keys follow the public contract. |
+| Recommended resource entry | ModernWpf preview governance and stable compatibility contract | `<ui:ThemeResources />` plus `<ui:FluentControlsResources />` | README and Gallery use the new entry, and `ModernWpf.Theme.Tests` plus `ModernWpf.Gallery.Tests` exercise the entry on net8 and net10. | Keep focused net10 smoke coverage for the recommended entry and keep legacy entry behavior unchanged. |
 | Legacy resource entry | ModernWpf 0.9.x compatibility | `<ui:ThemeResources />` plus `<ui:XamlControlsResources />` | Legacy path still merges `ControlsResources` and `UISettingsResources`. | Do not force official `ThemeMode` or platform Fluent behavior through this path. |
 | Application theme preference | ModernWpf public API plus official WPF `Application.ThemeMode` on net10+ | `ThemeManager.ApplicationTheme`, `ThemeResources.RequestedTheme` | `FluentControlsResources` opts into `PlatformThemeModeBridge` on net10. ModernWpf still applies Light/Dark/HighContrast dictionaries for its own resource aliases. | Bridge only on `net10.0-windows7.0`; `null` maps to official `System`, Light/Dark map directly. |
 | Window theme preference | ModernWpf `ThemeManager.RequestedTheme` attached property plus official WPF `Window.ThemeMode` on net10+ | `ThemeManager` window path | Window `RequestedTheme` is bridged through `PlatformThemeModeBridge` after the Fluent entry opts in. | Bridge Window Default to official `None`, Light/Dark to direct values. |

--- a/docs/public-api-contract-1x.md
+++ b/docs/public-api-contract-1x.md
@@ -1,17 +1,26 @@
 # ModernWpf 1.x Public API Contract
 
-This document defines the compatibility boundary beginning with
-`1.0.0-preview.1`.
+This document defines preview-era API governance and the stable 1.x
+compatibility boundary. `1.0.0-preview.1` records the first public audit and
+migration baseline; it does not freeze later 1.0 previews to that exact shape.
 
 ## Compatibility policy
 
-- `1.0.0-preview.1` is the first forward-stable baseline.
+- `1.0.0-preview.1` is the first audit, migration, and package-comparison
+  baseline.
 - Source and binary compatibility with 0.9.x is intentionally not promised.
-- After preview 1, shipped public CLR APIs and explicitly listed public
-  resource keys must remain compatible. A deliberate break requires a new
-  major-version decision, not an incidental source or template change.
-- Additive APIs remain possible. Add members to base classes or new interfaces
-  instead of extending an already shipped interface.
+- During the 1.0 preview series, current applicable WinUI API shape is
+  authoritative for WinUI-derived controls. Source-audited additions, changes,
+  and removals may deliberately break an earlier preview when the same change
+  updates the checked-in inventories, documents WPF adaptations, supplies
+  migration guidance, and adds focused tests.
+- Checked-in API/resource inventories and package validation are drift
+  detectors. They reject accidental changes; they are deliberately rebaselined
+  when an accepted preview-era parity change alters the public contract.
+- Stable `1.0.0` establishes the SemVer compatibility baseline. Within the
+  stable 1.x line, additions remain possible, but an upstream breaking change
+  must use a compatible ModernWpf adaptation or wait for the next ModernWpf
+  major version.
 
 The contract applies to all supported package targets:
 
@@ -23,10 +32,10 @@ The contract applies to all supported package targets:
 
 | Surface | Role in ModernWpf 1.x | Compatibility decision |
 | --- | --- | --- |
-| Current ModernWpf | The API that ships in `ModernWpf.dll` and `ModernWpf.Controls.dll`. | Frozen forward from `1.0.0-preview.1` by checked-in API inventories and package validation. |
+| Current ModernWpf | The API that ships in `ModernWpf.dll` and `ModernWpf.Controls.dll`. | Audited against `1.0.0-preview.1` and later accepted package baselines. Preview changes may be deliberately rebaselined; stable 1.x changes follow SemVer. |
 | `0.9.7-preview.2` | Last public prerelease and historical migration input. | Not a compatibility baseline. It has 263 ModernWpf top-level public types; the v1 candidate has 347. The v1 set adds 117 and removes 33 relative to this release. |
 | `0.9.6` | Last stable public release and historical migration input. | Not a compatibility baseline. It has 261 ModernWpf top-level public types; v1 adds 119 and removes 33 relative to it. |
-| Current WinUI | Primary naming, control-shape, event, sealing, and versionability authority for WinUI-derived ModernWpf controls. | Follow current WinUI unless WPF requires a documented adaptation. Audited product source is [`microsoft-ui-xaml` commit `de3e7673`](https://github.com/microsoft/microsoft-ui-xaml/commit/de3e767333c2f0717a6a70cb22bd192ced5ad885). |
+| Current WinUI | Primary naming, control-shape, event, sealing, and versionability authority for WinUI-derived ModernWpf controls. | Follow current applicable WinUI, including API changes during previews, unless WPF requires a documented adaptation. The adopted product epoch is [`microsoft-ui-xaml` commit `eb75504a`](https://github.com/microsoft/microsoft-ui-xaml/commit/eb75504a1978df0d37a3ad4574d6f72bf4d21583), reconciled with stable `winui3/release/2.3.1` and Gallery in `docs/winui3-sync-2026-07-29.md`; moving selectors and family mappings live in `tools/upstream/upstream-sync.json`. |
 | Official WPF Fluent | Primary styling and behavior authority for stock WPF controls, and the platform Fluent implementation used on .NET 10. | Complements WinUI; it does not rename ModernWpf custom-control CLR APIs. Audited source is [`dotnet/wpf` commit `7f005faa`](https://github.com/dotnet/wpf/commit/7f005faa89e79b0b1fa1cb2c21283bab7916c092). |
 
 The current checked-in CLR baseline contains 1,558 API entries for
@@ -35,10 +44,10 @@ assemblies expose 122 and 225 supported top-level types respectively. WPF's
 generated `GeneratedInternalTypeHelper` is compiler infrastructure and is not
 a supported ModernWpf API.
 
-## v1 surface decisions
+## Preview 1 surface record
 
-The prerelease cleanup made these versionability decisions before freezing the
-baseline:
+Preview 1 recorded these versionability decisions. They remain the migration
+starting point and are re-evaluated when current WinUI changes:
 
 - WinRT projection implementation types are internal. `ABI.*`, embedded WinRT
   contract markers, and other generated projection namespaces must never
@@ -92,9 +101,9 @@ These public names or shapes are not accidental WinUI drift:
 | `ToggleSwitch` | Remains inheritable to preserve its WPF protected customization hooks. |
 | `NavigationViewItemAutomationPeer` set-position overrides | Exist only on WPF target frameworks whose base automation peer exposes those virtual methods; package validation tracks the per-target shape. |
 
-## Interface stability
+## Interface versioning
 
-The shipped public interfaces are:
+The Preview 1 public interfaces are:
 
 - `ICommandBarElement`
 - `IElementFactory`
@@ -105,8 +114,12 @@ The shipped public interfaces are:
 - `IScrollControllerPanningInfo`
 - `IScrollSnapPointsInfo`
 
-Do not add members to these interfaces after preview 1. Add a new capability
-interface or an extensible base class instead.
+For a ModernWpf-originated capability, add a new interface or an extensible
+base-class member instead of changing one of these interfaces. During previews,
+however, a current WinUI change to the corresponding interface is authoritative:
+mirror the feasible source shape, update the inventories, and document the
+consumer migration. After stable 1.0, preserve the shipped interface throughout
+1.x or defer the upstream break to the next major version.
 
 ## Resource-key contract
 
@@ -115,9 +128,9 @@ Only entries in these files are public XAML resource contracts:
 - `ModernWpf/PublicResourceKeys.Shipped.txt`
 - `ModernWpf/PublicResourceKeys.Unshipped.txt`
 
-Each entry identifies a literal, top-level `x:Key` and the dictionary in which
-it must continue to exist. The preview-1 baseline contains 5,320
-source-qualified entries from:
+Each entry identifies a literal, top-level `x:Key` and the dictionary that
+owned it in the accepted public snapshot. The Preview 1 audit baseline contains
+5,320 source-qualified entries from:
 
 - `ThemeResources/Light.xaml`
 - `ThemeResources/Dark.xaml`
@@ -125,7 +138,12 @@ source-qualified entries from:
 - `ModernWpfControlsResources.xaml`
 - `DensityStyles/Compact.xaml`
 
-The following are not forward contracts unless later added to an explicit
+During previews, an upstream-driven change may deliberately add, move, rename,
+or remove an inventoried key under the same audit, migration, and rebaseline
+rules as a CLR API change. After stable 1.0, these keys are part of the SemVer
+contract for the stable 1.x line.
+
+The following are not public contract entries unless later added to an explicit
 manifest:
 
 - Template parts
@@ -140,23 +158,40 @@ existing manifest and add newly chosen public keys to the unshipped file.
 ## Enforcement and release workflow
 
 1. Make the API change.
-2. For a CLR addition, run `dotnet format` with diagnostic `RS0016`, include
-   generated source, and review the new `PublicAPI.Unshipped.txt` entries.
-3. For a supported resource-key addition, run
+2. Classify it as additive, a deliberate current-WinUI parity change, a
+   documented WPF adaptation, or an accidental change. A deliberate preview
+   break must cite the upstream source audit and add a `## Breaking changes`
+   migration entry to the current release notes.
+3. For a CLR addition or replacement, run `dotnet format` with diagnostic
+   `RS0016`, include generated source, and review the new
+   `PublicAPI.Unshipped.txt` entries. Remove obsolete shipped entries only for
+   an accepted preview break.
+4. For a supported resource-key addition, run
    `tools/api-contracts/Update-PublicResourceKeyContract.ps1` and review the
-   unshipped resource entries.
-4. Build every target framework and run the theme/resource tests.
-5. Before publishing a new compatibility baseline, promote every accepted
-   entry to the corresponding shipped inventory. Baseline builds require all
-   unshipped inventories to be empty.
-6. Pack the NuGet package. Package validation compares compatible target
-   frameworks and, after preview 1, compares with the published
-   `1.0.0-preview.1` baseline.
-7. Run `tools/release/Verify-ModernWpfPackage.ps1`. It rejects namespace leaks,
+   unshipped resource entries. Update or remove an existing entry only under
+   the deliberate-break rule.
+5. Build every target framework and run the theme/resource tests.
+6. Before publishing an accepted package baseline, promote every accepted
+   entry to the corresponding shipped inventory. A build whose version equals
+   the active package baseline requires all unshipped inventories to be empty.
+7. Pack the NuGet package. Strict cross-target validation always applies. When
+   the current version differs from
+   `ModernWpfPackageValidationBaselineVersion`, NuGet also compares with that
+   published package. To accept a deliberate break during previews, advance
+   that property to the current development version in the same change as the
+   source audit, inventory updates, tests, and release-note migration entry.
+   `ModernWpfPreviewAuditBaselineVersion` remains fixed at
+   `1.0.0-preview.1` as the machine-readable identifier of the published
+   historical package. It is available for explicit migration audits, but it
+   is intentionally not the active NuGet compatibility gate.
+8. Run `tools/release/Verify-ModernWpfPackage.ps1`. It rejects namespace leaks,
    cross-target top-level type drift, stale XML documentation, and malformed
    package assets.
 
-The analyzer treats API removals, signature changes, and accidental public
-members as build errors. Nullable annotations are not yet a v1 contract
-because the existing codebase is nullable-oblivious; they can be introduced as
-a separately reviewed contract improvement.
+The analyzer treats differences from the checked-in accepted API inventories
+as build errors; an intentional preview change updates those inventories rather
+than suppressing the analyzer. Once stable `1.0.0` is published, do not advance
+the active package baseline within 1.x to hide an incompatibility. Nullable
+annotations are not yet a v1 contract because the existing codebase is
+nullable-oblivious; they can be introduced as a separately reviewed contract
+improvement.

--- a/docs/release-notes-1.0.0-preview.1.md
+++ b/docs/release-notes-1.0.0-preview.1.md
@@ -1,8 +1,10 @@
 # ModernWPF 1.0.0-preview.1
 
 `1.0.0-preview.1` starts the actively maintained ModernWPF 1.x line. It is the
-first forward-compatibility baseline for the CLR APIs and public resource keys
-shipped by `ModernWpfUI`.
+first audit and migration baseline for the CLR APIs and public resource keys
+shipped by `ModernWpfUI`. It records the Preview 1 package shape rather than
+freezing later previews: current WinUI parity may require documented breaking
+changes before stable 1.0.
 
 ## Highlights
 

--- a/docs/release-notes-1.0.0-preview.2.md
+++ b/docs/release-notes-1.0.0-preview.2.md
@@ -8,13 +8,42 @@ the version is tagged.
 
 ## Development baseline
 
-- `1.0.0-preview.1` remains the immutable forward-compatibility and package
-  validation baseline.
+- `1.0.0-preview.1` remains the immutable historical audit and migration
+  comparison, not an API freeze across later previews.
+- Current applicable WinUI API shape is authoritative for WinUI-derived
+  controls. A deliberate breaking parity change must update the checked-in
+  inventories and active package-validation baseline, add focused tests, and
+  document consumer migration under `## Breaking changes`.
 - New public CLR APIs and resource keys must be recorded in the checked-in
-  unshipped inventories.
+  inventories. Stable `1.0.0` will establish the SemVer compatibility baseline
+  for subsequent 1.x releases.
 - NuGet publication uses Trusted Publishing with a short-lived OIDC credential;
   the repository does not store a long-lived NuGet API key.
 
 See [Migrating from ModernWPF 0.9.x](migrating-from-0.9.md) and the
-[1.x public API contract](public-api-contract-1x.md) for the compatibility
-boundary.
+[1.x public API contract](public-api-contract-1x.md) for the preview governance
+and stable compatibility policy.
+
+## WinUI 3 synchronization
+
+- Reconciles every existing WinUI-derived control family through product
+  `winui3/main` commit
+  `eb75504a1978df0d37a3ad4574d6f72bf4d21583`, latest stable
+  `winui3/release/2.3.1`, and WinUI Gallery commit
+  `f4dc3eb367f4bcecac1793829d9a221e924e5bfb`. The complete disposition is in
+  [the synchronization epoch record](winui3-sync-2026-07-29.md).
+- Ports CommandBar's fractional-DPI compact-height threshold, WindowedPopup's
+  pending XAML open lifecycle, and ItemsRepeater's ownerless recycling during
+  nonvirtualizing source replacement.
+- Adds regression guards for UniformGrid narrow-width layout and
+  NavigationView's Alt+Space system-menu shortcut, and corrects the WinUI
+  TitleBar drag-region API status to public V11.
+- Adds a machine-readable stable/main/Gallery source manifest and a weekly,
+  read-only drift report. New mapped or unmapped upstream changes require human
+  review; the automation never ports, merges, commits, or advances a pin.
+
+## Breaking changes
+
+This synchronization epoch requires no public CLR or explicit public
+resource-key change, so there is no consumer migration for the control fixes
+above.

--- a/docs/release-readiness-1x.md
+++ b/docs/release-readiness-1x.md
@@ -31,23 +31,42 @@ framework-reference groups for the modern .NET targets. NuGet normalizes the
 `net462` dependency group to `.NETFramework4.6.2` in the generated nuspec. Its
 dependency versions must match the central values in `Directory.Build.props`.
 
-## Forward contract gate
+## Preview governance and stable contract gate
 
-`1.0.0-preview.1` is the first forward-compatibility baseline. Compatibility
-with 0.9.x is not a release requirement.
+`1.0.0-preview.1` is the first audit and migration baseline. It records the
+public surface users received, but it does not freeze later 1.0 previews to that
+exact API. Compatibility with 0.9.x is not a release requirement.
+
+During the 1.0 preview series, current applicable WinUI API shape remains
+authoritative for WinUI-derived controls. A deliberate upstream parity change
+may break an earlier preview only when the source audit, WPF adaptation,
+inventory rebaseline, focused tests, and `## Breaking changes` migration notes
+land together. When the active package baseline advances, that section must
+contain `Preview compatibility baseline: <old> → <new>`, at least one
+breaking-change bullet, and explicit `**Migration:**` guidance; a no-change
+placeholder cannot satisfy the gate. Stable `1.0.0` establishes the SemVer
+baseline; later 1.x releases must preserve it or defer an upstream break to the
+next major version.
 
 The release gate enforces:
 
 - The shipped CLR inventories in `ModernWpf/PublicAPI.Shipped.txt` and
-  `ModernWpf.Controls/PublicAPI.Shipped.txt`. New APIs go in the corresponding
-  `PublicAPI.Unshipped.txt`; removals and signature changes fail the build.
+  `ModernWpf.Controls/PublicAPI.Shipped.txt`. New APIs normally go in the
+  corresponding `PublicAPI.Unshipped.txt`; removals and signature changes fail
+  until an accepted preview break deliberately updates the inventories.
 - NuGet package validation, including strict validation between compatible
-  target frameworks. Releases after preview 1 automatically use
-  `1.0.0-preview.1` as their package-validation baseline.
+  target frameworks. `ModernWpfPackageValidationBaselineVersion` selects the
+  active published-package comparison. During previews it may advance to the
+  current development version only as part of the audited breaking-change
+  workflow; equality disables the unavailable previous-package comparison
+  while the inventories remain authoritative. The immutable
+  `ModernWpfPreviewAuditBaselineVersion` identifies the published
+  `1.0.0-preview.1` package for explicit historical migration audits; it is
+  informational and is not the active NuGet compatibility gate.
 - The source-qualified public resource-key inventories in
   `ModernWpf/PublicResourceKeys.Shipped.txt` and
   `ModernWpf/PublicResourceKeys.Unshipped.txt`.
-- When the current package version equals the compatibility baseline, every
+- When the current package version equals the active package baseline, every
   unshipped CLR and resource-key inventory must contain no contract entries.
 - Package export checks. Public top-level types must be in `ModernWpf`
   namespaces, apart from WPF's compiler-generated
@@ -57,7 +76,7 @@ The release gate enforces:
 
 Template parts, visual states, implicit/type resource keys, and unlisted style
 or template resources are intentionally outside this contract. See
-`docs/public-api-contract-1x.md` for the complete boundary.
+`docs/public-api-contract-1x.md` for the complete governance policy.
 
 ## Local release gate
 
@@ -172,4 +191,8 @@ Some WinUI behavior is intentionally adapted rather than copied:
 - WinUI visual baseline and raw pixel parity are tracked through focused gallery visual checks, not the package gate.
 - Official WPF Fluent remains an input to stock-control styling, but ModernWpf still owns WinUI-compatible resource dictionaries, element theme islands, and ModernWpf-specific controls.
 
-Broader per-control parity status stays in `docs/winui2-2.8.7-sync.md`; this file defines the release gate for packaging and consumption.
+Current per-control parity policy and status live in
+`docs/winui3-source-parity.md` and
+`docs/winui3-control-source-coverage.md`. The WinUI 2.8.7 matrix is retained
+only as a historical migration snapshot; it is not an active release authority.
+This file defines the release gate for packaging and consumption.

--- a/docs/repeater-winui3-source-audit.md
+++ b/docs/repeater-winui3-source-audit.md
@@ -1,6 +1,7 @@
 # Repeater WinUI 3 Source Audit
 
 Date: 2026-07-18
+Updated: 2026-07-30
 
 ModernWpf `ItemsRepeater`, its layout family, item/source/recycle helpers, and
 selection model are tracked as a source-backed WPF port of official
@@ -10,6 +11,12 @@ contract is pinned to WinUI Gallery commit
 `29f62479d5c046a0b854a5868e5a7cd484572d87` (2026-07-13). Live comparison uses
 the installed WinUI 3 Controls Gallery `2.9.3.0` with Windows App Runtime
 `2.2.3.0.0`.
+
+The central synchronization epoch in `docs/winui3-sync-2026-07-29.md`
+reconciles this detailed baseline with stable `winui3/release/2.3.1`
+`a97562621a1d1ea397a38a3f512c9eef99db52d8`, product `winui3/main`
+`eb75504a1978df0d37a3ad4574d6f72bf4d21583`, and Gallery
+`f4dc3eb367f4bcecac1793829d9a221e924e5bfb`.
 
 ## Product Source Baseline
 
@@ -91,6 +98,20 @@ documented WPF-feasible `UniformGridLayout` adaptations.
 - `FlowLayout` and `UniformGridLayout` ignore collection forwarding when their
   context has no correctly typed layout state, and always invalidate layout,
   matching `9018b87d...`.
+- Stable commit `bfc240e263b935e645b00f1b50de97284f4954bf`
+  clears realized children during a nonvirtualizing source replacement without
+  assigning the soon-to-be-cleared repeater as their recycle owner.
+  `ItemsRepeater` scopes the same ownerless-recycle mode with `try/finally`;
+  `ViewManager` passes a null factory parent, and the WPF `RecyclePool`
+  adaptation suppresses its normal visual-parent inference only for that
+  explicit three-argument null-owner call. The existing two-argument WPF
+  convenience overload continues to infer and detach an actual parent.
+- Stable commit `fce9db16349395cd9617ed8dc08ab40df1f46415`
+  floors UniformGrid's calculated items per line at one when the available
+  minor size is narrower than an item. ModernWpf already carries that
+  source-equivalent floor as its unconditional default. WinAppSDK's
+  containment/KIR rollout switch is platform servicing machinery and is not
+  ported; the epoch adds a narrow-width regression guard.
 - `StackLayout`, `FlowLayout`, and `UniformGridLayout` retain source layout
   properties and WPF-feasible virtualization, spacing, wrapping, uniform-slot,
   and orientation algorithms.
@@ -152,6 +173,13 @@ documented WPF-feasible `UniformGridLayout` adaptations.
   descendants. Only the three correct peers remain, in data-index order.
 - `RepeaterLayoutTests.FlowLayoutsIgnoreCollectionChangesWhenContextStateIsUnavailableLikeCurrentWinUI`
   covers the current null-state collection-change contract.
+- `RepeaterLayoutTests.NonVirtualItemsSourceReplacementRecyclesWithoutStaleOwner`
+  uses two repeaters sharing one factory and pool. It clears the first
+  nonvirtualizing owner, realizes through the second, and proves the exact
+  element can be reused without attempting removal from the stale owner.
+- `RepeaterLayoutTests.UniformGridLayoutFloorsNarrowAvailableWidthAtOneItemPerLine`
+  measures a 100-DIP item family in a 50-DIP viewport and proves layout retains
+  one item per line without a zero divisor.
 - `GalleryAutomationHookTests.ItemsRepeaterSampleMatchesWinUIGalleryExamples`
   covers all six examples, snippets, source names, add/remove behavior, layout
   switching, filtering/sorting, and Low chrome.
@@ -172,8 +200,10 @@ documented WPF-feasible `UniformGridLayout` adaptations.
   recording `artifacts/gallery-recordings/20260718-203249-206/report.md` passes
   with `6.231` / `11.4`. Both record local scroll evidence and finish after
   `1.5s` of the six-second maximum window.
-- The complete Repeater product/source/accessibility slice passes 69/69 on
-  `net8.0-windows7.0`.
+- The prior detailed-baseline Repeater product/source/accessibility slice
+  passed 69/69 on `net8.0-windows7.0`. The epoch adds the ownerless-recycle and
+  narrow-width regressions; the final serialized epoch gate reruns the complete
+  project.
 - The ItemsRepeater Gallery sample/crop slice passes 2/2 on
   `net8.0-windows7.0` and `net10.0-windows7.0`.
 - `ModernWpf.Gallery` builds for net462, net8, and net10 with zero warnings and

--- a/docs/titlebar-winui3-gallery-parity.md
+++ b/docs/titlebar-winui3-gallery-parity.md
@@ -1,12 +1,15 @@
 # TitleBar current WinUI 3 and Gallery parity audit
 
 Date: 2026-07-18
+Updated: 2026-07-30
 
 ## Pinned upstream snapshots
 
 | Source | Commit | Purpose |
 | --- | --- | --- |
-| microsoft-ui-xaml | `de3e767333c2f0717a6a70cb22bd192ced5ad885` | Current `winui3/main` product source audited here. |
+| microsoft-ui-xaml | `de3e767333c2f0717a6a70cb22bd192ced5ad885` | Detailed `winui3/main` product/template snapshot audited here. |
+| microsoft-ui-xaml | `eb75504a1978df0d37a3ad4574d6f72bf4d21583` | Current-source epoch target; its TitleBar API-status delta is disposed below. |
+| microsoft-ui-xaml | `a97562621a1d1ea397a38a3f512c9eef99db52d8` | Latest stable `winui3/release/2.3.1` snapshot content-reconciled with the main epoch. |
 | microsoft-ui-xaml | `8463f45162149de0ec3ad7df752596893fe3e13e` | 2026-05-30 root-layout move from `src\controls` to `controls`; no TitleBar behavior or template change. |
 | WinUI Gallery | `29f62479d5c046a0b854a5868e5a7cd484572d87` | Current Gallery source and installed-app comparison target. |
 | WinUI Gallery | `14a4a1a2b8ddc527dc4a7d5f7e743d7c2bc97db7` | Gallery sample-folder conversion baseline. |
@@ -20,6 +23,24 @@ changing from `const auto` to `const auto&` in `UpdateDragRegion`, avoiding a
 copy without changing behavior. The Performance2026 theme dictionary was also
 added and expresses the same resources, geometry, and visual states with
 setter-style assignments.
+
+### 2026-07-29 epoch reconciliation
+
+Main-line commit `54c81dcacb9d6e01a30da7c5299bfd4bf661d43e`
+changes `AutoRefreshDragRegions`, nullable attached `IsDragRegion`, and
+`RecomputeDragRegions` in `TitleBar.idl` from `MUX_PREVIEW` to
+`MUX_PUBLIC_V11`. These are current public V11 APIs, not preview APIs. The
+change is API-status metadata only; it does not change TitleBar runtime,
+template, resources, or Gallery behavior.
+
+ModernWpf does not currently ship a WinUI `TitleBar` clone. Its
+`WindowTitleBar` attached-property surface and `WindowTitleBarControl` remain a
+documented WPF window-shell facade that adapts title content, buttons, drag
+behavior, and `WindowChrome`. Promoting WinUI's APIs therefore corrects the
+authority/status record but does not add those members to the differently
+scoped facade. A future source-shaped `TitleBar` port can use the unclaimed
+`TitleBar` name and must treat these V11 members as public API from its first
+preview.
 
 ## Current WinUI product inventory
 
@@ -52,7 +73,7 @@ The following Git blob IDs pin the exact product inputs:
 The current control surface contains `Title`, `Subtitle`, `IconSource`,
 `LeftHeader`, `Content`, `RightHeader`, `IsBackButtonVisible`,
 `IsBackButtonEnabled`, `IsPaneToggleButtonVisible`, `TemplateSettings`,
-`BackRequested`, and `PaneToggleRequested`. Preview APIs add
+`BackRequested`, and `PaneToggleRequested`. Public V11 APIs add
 `AutoRefreshDragRegions`, nullable attached `IsDragRegion`, and
 `RecomputeDragRegions`.
 

--- a/docs/winui-visualstate-setters-audit.md
+++ b/docs/winui-visualstate-setters-audit.md
@@ -1,10 +1,12 @@
 # WinUI VisualState.Setters Audit
 
 This tracks WinUI `VisualState.Setters` parity for ModernWpf 1.x. The primary
-source is the local final WinUI 2.8.7 checkout:
-`D:\repos\microsoft-ui-xaml-v2.8.7\dev`. The current WinUI 3 checkout at
-`D:\repos\microsoft-ui-xaml\src\controls\dev` was also counted to identify
-newer deltas, but the repo-wide sync matrix is still anchored on WinUI 2.8.7.
+authority is current applicable WinUI 3 source as pinned by
+`docs/winui3-source-parity.md` and the related per-control source audits.
+The WinUI 2.8.7 paths and setter counts below are retained only as the
+historical enumeration that started this conversion audit; they do not define
+current behavior, API shape, exclusions, or completion. Refresh decisions
+against current WinUI 3 source before changing a mapped control.
 
 ## Status Legend
 
@@ -24,7 +26,7 @@ newer deltas, but the repo-wide sync matrix is still anchored on WinUI 2.8.7.
 
 ## Current Conversions
 
-| WinUI 2.8.7 source | Setter blocks | ModernWpf file | Status | Notes |
+| Historical WinUI 2.8.7 source label | Setter blocks | ModernWpf file | Status | Notes |
 | --- | ---: | --- | --- | --- |
 | `dev\ProgressBar\ProgressBar.xaml` | 4 | `ModernWpf\ProgressBar\ProgressBar.xaml` | Converted | Direct opacity setters and the `UpdatingError` nested brush-color setter now use `VisualStateEx.Setters`; `VisualStateManagerEx` resolves WinUI-style nested target paths such as `(Shape.Fill).(SolidColorBrush.Color)`. Transition storyboards remain for animated progress movement and color transitions. |
 | `dev\CommonStyles\AppBarSeparator_themeresources.xaml` | 2 | `ModernWpf.Controls\CommandBar\AppBarSeparator.xaml` | Converted | Compact and overflow layout states now use `VisualStateEx.Setters` instead of a `VisualStateGroupListener` trigger bridge. |
@@ -42,9 +44,9 @@ newer deltas, but the repo-wide sync matrix is still anchored on WinUI 2.8.7.
 | `dev\CommonStyles\ToggleSwitch_themeresources.xaml` | 1 | `ModernWpf.Controls\ToggleSwitch\ToggleSwitch.xaml` | Converted | WinUI's pressed knob alignment setters are represented in ModernWpf's active `Dragging` state, because this WPF port routes thumb interaction through that state instead of `CommonStates.Pressed`. |
 | `dev\MenuBar\MenuBarItem.xaml` | 3 | `ModernWpf.Controls\MenuBar\MenuBar.xaml` | Converted | MenuBarItem common/selected state setters now use `VisualStateEx.Setters` in the source-backed MenuBar template; the old WPF `Menu` / `MenuItem` mapping has been deleted. |
 
-## Relevant Mapped WinUI 2.8.7 Sources
+## Historical Source Enumeration And Current Mappings
 
-| WinUI 2.8.7 source | Setter blocks | ModernWpf mapping | Status | Main blocker or next action |
+| Historical WinUI 2.8.7 source label | Setter blocks | ModernWpf mapping | Status | Main blocker or next action |
 | --- | ---: | --- | --- | --- |
 | `dev\AutoSuggestBox\AutoSuggestBox_themeresources.xaml` | 2 | `ModernWpf\Styles\AutoSuggestBox.xaml` | Converted | Query-button pointer-over and pressed `AnimatedIcon.State` setters now use `VisualStateEx.Setters` on the static `ContentPresenterEx` fallback while preserving the existing WPF trigger chrome. |
 | `dev\Breadcrumb\BreadcrumbBar.xaml` | 16 | `ModernWpf.Controls\BreadcrumbBar\BreadcrumbBar.xaml` | Converted | Inline item, last item, ellipsis, ellipsis dropdown layout/focus, dropdown common states, and nested item-button common states now use `VisualStateEx.Setters` driven by `BreadcrumbBarItem`. WinUI `Control.IsTemplateFocusTarget` and `FocusVisualMargin` setter targets are represented by `FocusVisualHelper` on WPF template parts. |
@@ -77,7 +79,7 @@ newer deltas, but the repo-wide sync matrix is still anchored on WinUI 2.8.7.
 
 ## Excluded Or Non-Product Sources
 
-| WinUI 2.8.7 source | Setter blocks | Reason |
+| Historical WinUI 2.8.7 source label | Setter blocks | Reason |
 | --- | ---: | --- |
 | `dev\AnimatedIcon\TestUI\AnimatedIconPage.xaml` | 12 | TestUI sample only; `AnimatedIcon` itself is excluded from ModernWpf core. |
 | `dev\CommonStyles\InkToolbar_themeresources.xaml` | 112 | InkToolbar is not carried as a ModernWpf control. |

--- a/docs/winui2-2.8.7-sync.md
+++ b/docs/winui2-2.8.7-sync.md
@@ -1,8 +1,13 @@
 # WinUI 2.8.7 Sync Matrix
 
-This is now a legacy/reference matrix. Current parity work targets WinUI 3 source behavior for existing ModernWpf controls; see `docs/winui3-source-parity.md`.
+> Historical snapshot only. This matrix records the completed WinUI 2.8.7
+> migration and must not be used as the current behavior, API-shape, resource,
+> or exclusion authority.
 
-Source of truth: `D:\repos\microsoft-ui-xaml-v2.8.7`, a detached worktree at tag `v2.8.7`
+Current parity work targets applicable WinUI 3 source behavior for existing
+ModernWpf controls; see `docs/winui3-source-parity.md` and
+`docs/winui3-control-source-coverage.md`. The recorded historical snapshot came
+from `D:\repos\microsoft-ui-xaml-v2.8.7`, a detached worktree at tag `v2.8.7`.
 
 Verified tag:
 
@@ -12,7 +17,8 @@ Verified tag:
 Merged PR 12217986: WebView2 test fixes and update TSA options area path
 ```
 
-This file tracks the ModernWpf parity plan against final WinUI 2.8.7. Every upstream area should end in one of these states:
+This file records the former ModernWpf parity plan against final WinUI 2.8.7.
+The statuses below describe that historical migration only:
 
 - `Parity`: implemented in ModernWpf with the core WinUI user semantics and upstream-derived tests.
 - `WPF-equivalent`: covered by an existing WPF or ModernWpf equivalent with tests.

--- a/docs/winui3-control-source-coverage.md
+++ b/docs/winui3-control-source-coverage.md
@@ -10,11 +10,20 @@ resource inventory. Existing controls may be grouped by source audit evidence,
 but each shipped resource dictionary still gets its own row so a new or renamed
 control resource cannot bypass source-parity review.
 
-Current product authority is `microsoft/microsoft-ui-xaml` `main` commit
-`de3e767333c2f0717a6a70cb22bd192ced5ad885`. In addition to the one-to-one
-resource inventory below, `TemplateParityTests` requires every
-`*winui3-source-audit.md` document to carry that current pin. This prevents a
-new resource or a later product refresh from leaving a silently stale audit.
+Current authority is the adopted epoch recorded in
+`docs/winui3-sync-2026-07-29.md`: product `winui3/main`
+`eb75504a1978df0d37a3ad4574d6f72bf4d21583`, latest stable
+`a97562621a1d1ea397a38a3f512c9eef99db52d8`, and Gallery `main`
+`f4dc3eb367f4bcecac1793829d9a221e924e5bfb`. Detailed family audits retain
+their prior blob-level pins; the central epoch record reconciles every change
+after those pins.
+
+`tools/upstream/upstream-sync.json` maps every audit and shipped resource
+family to its product and Gallery inputs. Repository tests require that
+mapping to remain exhaustive and unique, while the scheduled drift report
+treats any new unmapped upstream file as action-required. This prevents a new
+resource, API input, control file, or later product refresh from silently
+bypassing parity review.
 
 ## Status
 

--- a/docs/winui3-source-parity.md
+++ b/docs/winui3-source-parity.md
@@ -2,18 +2,35 @@
 
 ModernWpf parity work now uses official WPF Fluent as the primary source for stock WPF controls, and WinUI 3 source behavior for existing ModernWpf controls that are not covered by official WPF Fluent.
 
-Current source of truth: official `winui3/main` commit
-`de3e767333c2f0717a6a70cb22bd192ced5ad885` (2026-07-17). The local clone is
-used as a full-source mirror:
+The adopted synchronization epoch is official `winui3/main` commit
+`eb75504a1978df0d37a3ad4574d6f72bf4d21583`, latest stable
+`winui3/release/2.3.1` commit
+`a97562621a1d1ea397a38a3f512c9eef99db52d8`, and WinUI Gallery `main` commit
+`f4dc3eb367f4bcecac1793829d9a221e924e5bfb`. The complete reconciliation from
+the prior detailed-audit pins is recorded in
+`docs/winui3-sync-2026-07-29.md`.
+
+The detailed family audits retain their exact blob and history evidence at
+product commit `de3e767333c2f0717a6a70cb22bd192ced5ad885` and Gallery commit
+`29f62479d5c046a0b854a5868e5a7cd484572d87`; the central epoch record closes
+the bounded delta from those pins. The machine-readable authority, including
+the stable/main/Gallery tracks and every family path mapping, is
+`tools/upstream/upstream-sync.json`. A scheduled read-only report compares
+each adopted epoch target with its moving upstream head and requires every
+changed file to be mapped, explicitly ignored with a justification, or
+reported as unmapped action-required drift.
+
+The local clone remains a full-source mirror:
 
 ```text
 c70471c511a0168b61dcca13af9556465f26b673
 reference/winui3-current
 ```
 
-Current audits query the official repository for changes after that local
-mirror before making latest-source claims. Current repository paths use the
-post-May-2026 root layout (`controls/...` rather than `src/controls/...`).
+Current audits query the official repository before making latest-source
+claims. Current repository paths use the post-May-2026 root layout
+(`controls/...` rather than `src/controls/...`); the stable track's leading
+`src/` is normalized by the drift reporter.
 
 ## Rules
 

--- a/docs/winui3-sync-2026-07-29.md
+++ b/docs/winui3-sync-2026-07-29.md
@@ -1,0 +1,169 @@
+# WinUI 3 Synchronization Epoch — 2026-07-29
+
+This is the adoption record for ModernWpf's first bounded synchronization
+epoch after `1.0.0-preview.1`. The cutoff is the latest upstream state selected
+on 2026-07-29 and adopted on 2026-07-30. It records the finite source range
+that was audited and implemented before continuous monitoring began. Later
+upstream movement is reported separately and does not reopen this epoch.
+
+## Pinned sources
+
+| Source | Prior reviewed baseline | Adopted epoch target |
+| --- | --- | --- |
+| WinUI 3 `winui3/main` | `de3e767333c2f0717a6a70cb22bd192ced5ad885` | `eb75504a1978df0d37a3ad4574d6f72bf4d21583` |
+| Latest stable WinUI 3 | — | `winui3/release/2.3.1` at `a97562621a1d1ea397a38a3f512c9eef99db52d8` |
+| WinUI Gallery `main` | `29f62479d5c046a0b854a5868e5a7cd484572d87` | `f4dc3eb367f4bcecac1793829d9a221e924e5bfb` |
+
+The machine-readable source tracks, family path mappings, and moving selectors
+live in `tools/upstream/upstream-sync.json`. The scheduled monitor always
+compares the adopted epoch targets above with the current upstream heads; it
+does not port or advance a baseline automatically.
+
+## Dispositions
+
+The audit covered API metadata and generated inputs, runtime behavior,
+templates and resources, layout and input, accessibility, localization, tests,
+and Gallery pages/snippets for every existing mapped ModernWpf family. New
+upstream controls remain outside this epoch's implementation scope, but their
+files are not silently ignored by continuous monitoring.
+
+The stable branch is not an ancestor of the adopted main pin. Its merge base
+with the prior product pin is
+`b1db15715bfead9fe8ad2e7f78b0172589225e69`; stable has 11 unique commits and
+the prior/main epoch pins have 448/484 unique commits respectively. Stable was
+therefore content-reconciled rather than cherry-picked.
+
+### Applicable parity changes
+
+| Dimension | Epoch result |
+| --- | --- |
+| Public API | No ModernWpf public CLR or resource-key edit is applicable. WinUI's `FrameworkElement.SetThemeResourceBinding` maps to WPF's existing `SetResourceReference`; the new public V11 TitleBar drag-region APIs belong to a WinUI control ModernWpf does not clone. The local `WindowTitleBar` remains a documented WPF facade. |
+| Runtime and layout | Ported CommandBar's half-physical-pixel compact-height threshold, WindowedPopup's pending XAML open lifecycle, and ItemsRepeater's ownerless recycling during nonvirtualizing source replacement. |
+| Existing equivalent behavior | Added guards for UniformGrid's at-least-one-item narrow-width calculation and NavigationView's preservation of the WPF `Alt+Space` system shortcut. |
+| Templates and resources | No epoch delta requires a local edit. Applicable stable `*_perf2026.xaml` inputs were already reconciled with the prior detailed audits; current classic/perf content and existing WPF adaptations remain authoritative. |
+| Input, accessibility, and localization | Popup liveness and NavigationView `Alt+Space` are covered above. No other mapped default input, UIA, or localization delta applies; platform/WinRT-only work is documented below. |
+| Gallery | The only Gallery commit updates the Axe.Windows UITest dependency. No mapped page, snippet, option, automation identity, or visual surface changed. |
+
+### Product `winui3/main`: all 36 commits
+
+| # | Commit | Classification and disposition |
+| ---: | --- | --- |
+| 1 | `ba60e13d4a55910d8d68ba1ccd4fb91a41056d1d` | Azure Maps token-injection script; repository infrastructure, no control input. |
+| 2 | `f41c31c2aabaf2f67c1373ac3120f98145b03280` | `Version.Details.xml` dependency bookkeeping; infrastructure. |
+| 3 | `5b896a1656130dac2a9a28ebe149fd0e2c0500a9` | Setup/test/build comment scrub; infrastructure/documentation only. |
+| 4 | `edd107d4f7312f6dad40c4bc797f4c1b290d0143` | New upstream `Samples/` content; outside the existing-control product/Gallery surface. |
+| 5 | `32bc32c2e8f19ddb8e5a3010fc1e65237a91beb5` | WinUI 2/3 cohabitation packaging tests; WinUI-specific test infrastructure. |
+| 6 | `2f5aafa8b39358c5ad58638ead5a0b544956881d` | `Version.Details.xml`; infrastructure. |
+| 7 | `e20accccfef15706f3ae60bf2a9ab38435b2c6a8` | x86 checked-build solution configuration; infrastructure. |
+| 8 | `8dca4cd76468ac49cd2aa31cafa2e320835cb17b` | Applicable CommandBar fix. Port the Auto-overflow compact-height comparison at `abs(delta) >= 0.5 / rasterizationScale`; implemented with WPF DPI and focused below/exact/above-threshold coverage. |
+| 9 | `cd6ace080a08387ac90450c75f3462c44475bf62` | Win11 25H2 test-image and public-package pipeline changes; test infrastructure. |
+| 10 | `ce96a1586e0fc7826f4e1ed0a39f33e01ab59768` | Applicable Popup lifecycle fix plus unrelated compiler files. Adapted to WindowedPopup through WPF initialization/Loaded liveness; compiler portion is platform-owned. |
+| 11 | `23be4c9bae97fd797890f107ea30ad8b8977847d` | `Version.Details.xml`; infrastructure. |
+| 12 | `fcd28372ae3698662a848708692361a3151f7a63` | Validation and Gallery-submodule bookkeeping; infrastructure. |
+| 13 | `54c81dcacb9d6e01a30da7c5299bfd4bf661d43e` | Makes WinUI TitleBar drag-region APIs public V11. ModernWpf does not ship the WinUI TitleBar control; corrected the status documentation for its WPF facade. |
+| 14 | `16ff74d626f676d92920855984c2e1eb991d1bef` | `FrameworkElement.SetThemeResourceBinding`; WPF already supplies the applicable `SetResourceReference(DependencyProperty, object)` model, so no duplicate API is added. |
+| 15 | `d05ac536ab3e73d73b02e35e1cf63f732dc5380f` | Validation wrapper; infrastructure. |
+| 16 | `489646c67288a1b3976329295e43435a8123ebcc` | Gallery submodule wiring; infrastructure/source bookkeeping. |
+| 17 | `fbb695757af8517132ac047c6fb0fec4e7bd53a3` | Upstream `perf/` tree; performance test infrastructure, not control runtime/template input. |
+| 18 | `34ce6e65fa2521e1644cdb362ce3b34087426c02` | ItemContainer runtime/tests; outside scope because ModernWpf does not ship ItemContainer. |
+| 19 | `675f10de00bea9c826bef663536f360d265c8be2` | Manifest XSLT; infrastructure. |
+| 20 | `1d9d8b3c06aab8c7c87e7965aee33b63ac410cbf` | Low-level compositor helpers; WPF/platform-owned implementation. |
+| 21 | `bdcb39626675a2fb4751779c57c737c3f990a1f4` | Compiler/build LMR exclusions; infrastructure. |
+| 22 | `94aed47b6e69a75dcca8b96fb6159674fe7e8d87` | ARM64 setup scripts; infrastructure. |
+| 23 | `8c56fd082fdfcd1f32adf9aa84c5a917fffe25d7` | XamlGeneratedMain compiler/tests and upstream samples; WPF uses a different XAML build pipeline. |
+| 24 | `4a23325fe6d4ade9336dab2d888eef22e22a6831` | Build-PR workflow; infrastructure. |
+| 25 | `b59befc9ee0041da8c4fa89b37ccf7a34a16f924` | Azure Maps token script; infrastructure. |
+| 26 | `7d1ea589ca5cc70b5523c52edbd8d3395b519596` | Build/nuspec copyright scrub; infrastructure/documentation only. |
+| 27 | `cf585ea36a9bba78bfeadc6021f23e01ed7f8905` | Gallery test-data project; upstream test infrastructure. |
+| 28 | `74bea0c72cfe3e8b34b31c93ec726474e5c903ac` | C++/WinRT x:Bind compiler changes; WPF compiler pipeline is separate. |
+| 29 | `9a350d1d9e9a12784823a778891687d9b9198dcb` | Nested-template compiler/codegen changes; WPF compiler pipeline is separate. |
+| 30 | `0566e698c98ada46307f5dc4d2dca6be55121101` | Build-PR workflow merge; infrastructure. |
+| 31 | `09b7bb4fe553007a9601b69773cadadd31afeacb` | Validation YAML; infrastructure. |
+| 32 | `ca3188171a7c2aab54131cc091044dc969d8313f` | WebView2 package configuration; outside scope because ModernWpf deliberately owns no WebView2 control/runtime dependency. |
+| 33 | `e5710f313dc8a4a701909b717a2f31add9d3bc0c` | Test-stage YAML; infrastructure. |
+| 34 | `619b541e8c7b8fdce4e44959d532c9af02bd7591` | Local-init/LKG feed script; infrastructure. |
+| 35 | `adf8f5dbc8b015a3874c8169d3c89b46c3160469` | Removal of unused experimental island/input interfaces; WinUI platform internals with no WPF API counterpart. |
+| 36 | `eb75504a1978df0d37a3ad4574d6f72bf4d21583` | `Version.Details.xml` dependency sync; infrastructure and the finite main cutoff. |
+
+### Latest stable: all 11 unique commits
+
+| Commit | Stable/default analysis and disposition |
+| --- | --- |
+| `bfc240e263b935e645b00f1b50de97284f4954bf` | Contains the applicable default ItemsRepeater ownerless-recycle fix, now ported and tested. Breadcrumb/SplitButton content is already represented by later current-source audits; TabView/TitleBar are unshipped control surfaces; the remainder is platform/build material. |
+| `4387af80d9d5950c9edd752f8c4bfcadfd812500` | Intermediate WrapPanel/SystemBackdropHost/SelectorBar work. Reconciled to later main rather than adopting an intermediate API; local WrapPanel already follows current spacing/stretch APIs and SelectorBar already contains the correction. |
+| `993027834805109e182618e9dfea29cd71257496` | Adds transient SplitMenuFlyoutItem and platform/SystemBackdropHost work. The control is removed by the next stable sync and absent at the main cutoff; no port. |
+| `1c8a4def42520f8dc5c585ee240b69e74a49b483` | FlowLayout rename, later WrapPanel API, NavigationView teardown, IconSource tests, and unshipped platform controls. Current local APIs/behavior already represent the applicable final shapes; disconnected WPF dependency properties do not need WinUI's ABI guard. |
+| `e5d2c481b35a62e3a2a7b3818f896e6470a25514` | CommandBarFlyout radius and NavigationView `Alt+Space`, then temporarily reverted. Radius is already covered by the WPF template/pixel adaptation; `Alt+Space` receives the WPF guard described below. |
+| `72e7be771aea8288ff8d2ae7916ea4257da4cbbc` | Explicit transient revert of the preceding changes; no independent port. |
+| `a4d23ee1161d5dacd221f8b8dfb730fcc2f27e73` | Reapplies final radius/`Alt+Space` behavior and adds WinUI WebView2 drag work. The first two are reconciled through existing behavior/guard tests; WebView2 remains outside the owned control surface. |
+| `978ab6363339e6219c0c4eba5c7339d282f17d09` | `Version.Details.xml`; infrastructure. |
+| `fce9db16349395cd9617ed8dc08ab40df1f46415` | Applicable UniformGrid narrow-width floor already exists locally and gains a regression guard. The Repeater reference-tracker change is WinRT lifetime-specific; managed GC collects unrooted cycles. TitleBar APIs are public V11 but belong to an unshipped WinUI control. Remaining Popup/island/compiler work is platform-owned. |
+| `fb389b88af6d358f09d0adb614f941b64a82515d` | ScrollView timer fix and core `Setter.ValueProperty`/`XamlBindingHelper` APIs. ScrollView is unshipped; WPF owns Setter and its XAML conversion/compiler services. |
+| `a97562621a1d1ea397a38a3f512c9eef99db52d8` | 2.3.1 rollup. Repeater null `LayoutState` and side-flyout clamp were already ported. Applicable perf2026 resources were already reconciled. `IconNoGridOptimization`, `OptimizeApplyStyles`, `DefaultStyleOptimizations`, and `DeferContextFlyoutInit` are explicit WinUI engine opt-ins, not an existing ModernWpf control API; no `XamlOptionalChanges` clone is exposed. PopupRoot/island/UIA and MediaPlayerPresenter work is platform-owned. |
+
+### Gallery
+
+`f4dc3eb367f4bcecac1793829d9a221e924e5bfb` changes only
+`tests/WinUIGallery.UITests/WinUIGallery.UITests.csproj`, updating Axe.Windows
+from 2.4.1 to 2.4.2. All tracked Gallery pages, snippets, option surfaces, and
+source blobs remain unchanged from
+`29f62479d5c046a0b854a5868e5a7cd484572d87`.
+
+## Implementation evidence
+
+| Slice | ModernWpf adaptation | Focused evidence |
+| --- | --- | --- |
+| CommandBar fractional DPI | `ModernWpf.Controls/CommandBar/CommandBar.cs` uses `VisualTreeHelper.GetDpi(...).DpiScaleY` and the upstream half-physical-pixel threshold when calculating Auto More-button visibility. | `CommandBarAutoOverflowButtonUsesPhysicalPixelCompactHeightThreshold` exercises live layout below/above the boundary; `CommandBarCompactHeightThresholdUsesFractionalRasterizationScale` pins below/exact/negative behavior at 1.25 scale. |
+| WindowedPopup pending open | `ModernWpf/Controls/Primitives/WindowedPopup.cs` retains `IsOpen=true`, uses WPF `ISupportInitialize` plus child/popup/target Loaded retries, and cancels pending work on close while preserving parentless programmatic Auto opens. | `WindowedPopupApiTests` covers both XAML property orders, close-before-Loaded, and the existing parentless programmatic path. |
+| ItemsRepeater ownerless recycle | `ItemsRepeater.cs` scopes ownerless clearing with `try/finally`; `ViewManager.cs` supplies a null recycle parent; `RecyclePool.cs` distinguishes an explicit null owner from the WPF two-argument parent-inference convenience. | `NonVirtualItemsSourceReplacementRecyclesWithoutStaleOwner` reuses the same element through a second repeater without a stale-parent removal failure. |
+| UniformGrid narrow width | Existing local calculation already floors items per line at one; no product edit. | Focused narrow-width layout regression prevents a zero-items-per-line divide-by-zero regression. |
+| NavigationView `Alt+Space` | Existing WPF routing sees the chord as `Key.System` with `SystemKey=Space`, so NavigationView does not consume the window-system shortcut; no product edit. | Focused keyboard regression and source-audit guard pin the WPF equivalence. |
+| TitleBar status | `WindowTitleBar` remains a WPF title-bar facade rather than a clone of the upstream WinUI TitleBar control. | TitleBar parity documentation records that upstream drag-region APIs are public V11, not Preview. |
+
+No accepted epoch slice changes the shipped CLR or explicit public resource-key
+surface, so the checked-in API/resource inventories require no entry update.
+The preview governance change explains how a future applicable WinUI API break
+would be deliberately rebaselined; it does not hide an API change in this
+epoch.
+
+## Continuous monitoring
+
+`tools/upstream/upstream-sync.json` is validated against
+`upstream-sync.schema.json`. It gives stable, product main, and Gallery their
+own reviewed baseline, adopted target, moving selector, family mappings, and
+justified ignore rules. `Get-UpstreamDriftReport.ps1` classifies every changed
+path as mapped, explicitly ignored, or unmapped/action-required. Stable
+leading `src/` paths are normalized before matching.
+
+`.github/workflows/upstream-drift.yml` runs weekly and on manual dispatch with
+read-only repository permissions. Its normal mode compares only adopted
+targets with moving heads; the historical baseline-to-epoch report is opt-in.
+Any mapped or unmapped observed change is actionable, incomplete comparisons
+fail, and reports are written to the job summary and an artifact. The workflow
+does not modify source, advance pins, port code, commit, merge, open issues, or
+open pull requests.
+
+## Validation record
+
+The epoch was validated serially on 2026-07-30:
+
+| Gate | Result |
+| --- | --- |
+| Restore and Release solution build | `dotnet restore ModernWpf.sln` and `dotnet build ModernWpf.sln --configuration Release --no-restore` passed with no warnings or errors. |
+| Focused regressions | The affected CommandBar, WindowedPopup, ItemsRepeater, UniformGrid, NavigationView, TitleBar, source-audit, and Gallery-audit filters passed: 30 WinUI tests and 1 Gallery test, with no skips. |
+| Drift and governance tooling | `dotnet test .\test\ModernWpf.Tools.Tests\ModernWpf.Tools.Tests.csproj --configuration Release --framework net10.0 --no-build --no-restore` passed 23/23 with no skips. This includes schema/manifest coverage, a two-page cross-train stable-tag selector, clean/drift/incomplete fixtures, exact scheduled exit codes 0/2/3, and rejection of a no-change placeholder when a preview package baseline is deliberately advanced. |
+| Theme contracts | The complete Theme suite passed 20/20 on `net8.0-windows7.0` and 23/23 on `net10.0-windows7.0`, with no skips. |
+| Gallery | The complete Gallery suite passed 717/717 on each of `net8.0-windows7.0` and `net10.0-windows7.0`, with no skips. |
+| WinUI behavior | The complete `net8.0-windows7.0` WinUI suite passed 1071/1071 with no skips on three consecutive final-source runs. |
+| Retained .NET Framework suite | The complete `net48` suite passed 181 tests and skipped the 11 specifically documented legacy retirements; no undocumented skip was added. |
+| Package shape and consumption | Release pack and `Verify-ModernWpfPackage.ps1` passed. `Test-ModernWpfPackageSmoke.ps1` passed both `FluentControlsResources` and `XamlControlsResources` consumers on `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0` (6/6). |
+| Live scheduled drift mode | `Get-UpstreamDriftReport.ps1 -FailOnObservedDrift -FailOnIncompleteComparison` passed. Stable `winui3/release/2.3.1`, product `winui3/main`, and Gallery `main` resolved to the three adopted targets above, each with 0 mapped, 0 unmapped, and 0 ignored post-epoch files. |
+| Focused visual parity | The authoritative CommandBar crop was exactly 271x48 in both themes and passed the documented 2.5 delta gate: Light 1.70 and Dark 2.08. The Dark full `ControlExample` comparison also passed. The generic Light full-card comparison was red because the capture host produced a 693-pixel card against a 771-pixel reference; the unchanged Gallery host/capture composition, not the exact-size CommandBar crop, accounts for the padded-region delta. Raw full-card parity is not a package gate. |
+
+The optional live `-IncludeEpochComparison` diagnostic exits 3 for the product
+main historical range because GitHub truncates that 36-commit comparison at its
+300-file limit. That fail-closed behavior is intentional and covered by the
+incomplete fixture. It does not replace the complete commit-by-commit audit
+above; scheduled mode compares only each adopted epoch target to its moving
+head and therefore does not repeatedly query the already reviewed historical
+range.

--- a/test/ModernWpf.Gallery.Tests/CommandBarSourceAuditTests.cs
+++ b/test/ModernWpf.Gallery.Tests/CommandBarSourceAuditTests.cs
@@ -29,6 +29,10 @@ namespace ModernWpf.Gallery.Tests
             var recorder = Read(root, "tools", "visual-checks", "Record-GalleryControlInteractions.ps1");
 
             StringAssert.Contains(audit, "de3e767333c2f0717a6a70cb22bd192ced5ad885");
+            StringAssert.Contains(audit, "eb75504a1978df0d37a3ad4574d6f72bf4d21583");
+            StringAssert.Contains(audit, "a97562621a1d1ea397a38a3f512c9eef99db52d8");
+            StringAssert.Contains(audit, "f4dc3eb367f4bcecac1793829d9a221e924e5bfb");
+            StringAssert.Contains(audit, "8dca4cd76468ac49cd2aa31cafa2e320835cb17b");
             StringAssert.Contains(audit, "f524c6d543ea735b7b4e833294891eec448b8b5f");
             StringAssert.Contains(audit, "ecf554e134db0793668a5993f87f8c80e487ef04");
             StringAssert.Contains(audit, "3089af2b982481552e3f713ddfccd1edab1b5bc2");
@@ -55,6 +59,8 @@ namespace ModernWpf.Gallery.Tests
             StringAssert.Contains(control, "if (!IsSticky)");
             StringAssert.Contains(control, "RefreshOverflowPopupPosition()");
             StringAssert.Contains(control, "CustomPlacementMode.BottomEdgeAlignedRight");
+            StringAssert.Contains(control, "IsCompactHeightDifferenceSignificant(");
+            StringAssert.Contains(control, "0.5 / rasterizationScale");
             StringAssert.Contains(control, "public event EventHandler<object> Opening");
             StringAssert.Contains(control, "public event EventHandler<object> Closing");
             StringAssert.Contains(control, "public event TypedEventHandler<CommandBar, DynamicOverflowItemsChangingEventArgs> DynamicOverflowItemsChanging");
@@ -78,6 +84,8 @@ namespace ModernWpf.Gallery.Tests
             StringAssert.Contains(productTests, "CommandBarOpenLifecycleUsesCurrentWinUIEventAndVirtualHookOrder");
             StringAssert.Contains(productTests, "CommandBarAutomationPeerUsesCurrentWinUIAppBarPatterns");
             StringAssert.Contains(productTests, "CommandBarMoreButtonIconDataCanBeOverriddenPerInstance");
+            StringAssert.Contains(productTests, "CommandBarAutoOverflowButtonUsesPhysicalPixelCompactHeightThreshold");
+            StringAssert.Contains(productTests, "CommandBarCompactHeightThresholdUsesFractionalRasterizationScale");
             StringAssert.Contains(audit, "Issue #262");
             StringAssert.Contains(audit, "`CommandBarMoreButtonIconData`");
             StringAssert.Contains(publicDocumentation, "E:ModernWpf.Controls.CommandBar.DynamicOverflowItemsChanging");

--- a/test/ModernWpf.Tools.Tests/Fixtures/Upstream/upstream-clean.fixture.json
+++ b/test/ModernWpf.Tools.Tests/Fixtures/Upstream/upstream-clean.fixture.json
@@ -1,0 +1,85 @@
+{
+  "generatedAt": "2026-07-30T12:34:56Z",
+  "stableTagPages": [
+    {
+      "repository": "winui-product",
+      "track": "stable",
+      "tags": [
+        {
+          "name": "winui3/release/1.8.10",
+          "commit": {
+            "sha": "3333333333333333333333333333333333333333"
+          },
+          "published_at": "2026-07-29T12:00:00Z"
+        }
+      ]
+    },
+    {
+      "repository": "winui-product",
+      "track": "stable",
+      "tags": [
+        {
+          "name": "winui3/release/2.3.1",
+          "commit": {
+            "sha": "a97562621a1d1ea397a38a3f512c9eef99db52d8"
+          },
+          "published_at": "2026-07-17T12:00:00Z"
+        }
+      ]
+    }
+  ],
+  "observedHeads": [
+    {
+      "repository": "winui-product",
+      "track": "stable",
+      "revision": "a97562621a1d1ea397a38a3f512c9eef99db52d8",
+      "label": "winui3/release/2.3.1"
+    },
+    {
+      "repository": "winui-product",
+      "track": "main",
+      "revision": "eb75504a1978df0d37a3ad4574d6f72bf4d21583",
+      "label": "winui3/main"
+    },
+    {
+      "repository": "winui-gallery",
+      "track": "main",
+      "revision": "f4dc3eb367f4bcecac1793829d9a221e924e5bfb",
+      "label": "main"
+    }
+  ],
+  "comparisons": [
+    {
+      "repository": "winui-product",
+      "base": "de3e767333c2f0717a6a70cb22bd192ced5ad885",
+      "head": "eb75504a1978df0d37a3ad4574d6f72bf4d21583",
+      "status": "ahead",
+      "aheadBy": 36,
+      "behindBy": 0,
+      "totalCommits": 36,
+      "isComplete": true,
+      "files": [
+        {
+          "filename": "controls/dev/CommonStyles/CommandBar_themeresources.xaml",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "repository": "winui-gallery",
+      "base": "29f62479d5c046a0b854a5868e5a7cd484572d87",
+      "head": "f4dc3eb367f4bcecac1793829d9a221e924e5bfb",
+      "status": "ahead",
+      "aheadBy": 1,
+      "behindBy": 0,
+      "totalCommits": 1,
+      "isComplete": true,
+      "files": [
+        {
+          "filename": "eng/Versions.props",
+          "status": "modified"
+        }
+      ]
+    }
+  ]
+}

--- a/test/ModernWpf.Tools.Tests/Fixtures/Upstream/upstream-drift.fixture.json
+++ b/test/ModernWpf.Tools.Tests/Fixtures/Upstream/upstream-drift.fixture.json
@@ -1,0 +1,135 @@
+{
+  "generatedAt": "2026-07-30T12:34:56Z",
+  "stableTags": [
+    {
+      "repository": "winui-product",
+      "track": "stable",
+      "name": "winui3/release/1.8.10",
+      "revision": "3333333333333333333333333333333333333333",
+      "published_at": "2026-07-30T12:00:00Z"
+    },
+    {
+      "repository": "winui-product",
+      "track": "stable",
+      "name": "winui3/release/2.3.2",
+      "revision": "2222222222222222222222222222222222222222",
+      "published_at": "2026-07-01T12:00:00Z"
+    }
+  ],
+  "observedHeads": [
+    {
+      "repository": "winui-product",
+      "track": "stable",
+      "revision": "2222222222222222222222222222222222222222",
+      "label": "winui3/release/2.3.2"
+    },
+    {
+      "repository": "winui-product",
+      "track": "main",
+      "revision": "1111111111111111111111111111111111111111",
+      "label": "winui3/main"
+    },
+    {
+      "repository": "winui-gallery",
+      "track": "main",
+      "revision": "f4dc3eb367f4bcecac1793829d9a221e924e5bfb",
+      "label": "main"
+    }
+  ],
+  "comparisons": [
+    {
+      "repository": "winui-product",
+      "base": "de3e767333c2f0717a6a70cb22bd192ced5ad885",
+      "head": "eb75504a1978df0d37a3ad4574d6f72bf4d21583",
+      "status": "ahead",
+      "aheadBy": 36,
+      "behindBy": 0,
+      "totalCommits": 36,
+      "isComplete": true,
+      "files": [
+        {
+          "filename": "controls/dev/CommonStyles/CommandBar_themeresources.xaml",
+          "status": "modified"
+        },
+        {
+          "filename": "dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.cs",
+          "status": "modified"
+        },
+        {
+          "filename": "dxaml/xcp/dxaml/lib/FrameworkElement_Partial.cpp",
+          "status": "modified"
+        },
+        {
+          "filename": "dxaml/xcp/core/core/elements/Popup.cpp",
+          "status": "modified"
+        },
+        {
+          "filename": "controls/dev/NewControl/NewControl.idl",
+          "status": "added"
+        },
+        {
+          "filename": ".github/workflows/moved.yml",
+          "previous_filename": "controls/dev/NewControl/OldControl.idl",
+          "status": "renamed"
+        },
+        {
+          "filename": ".github/workflows/build.yml",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "repository": "winui-product",
+      "base": "a97562621a1d1ea397a38a3f512c9eef99db52d8",
+      "head": "2222222222222222222222222222222222222222",
+      "status": "ahead",
+      "aheadBy": 1,
+      "behindBy": 0,
+      "totalCommits": 1,
+      "isComplete": true,
+      "files": [
+        {
+          "filename": "src/controls/dev/NumberBox/NumberBox.cpp",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "repository": "winui-product",
+      "base": "eb75504a1978df0d37a3ad4574d6f72bf4d21583",
+      "head": "1111111111111111111111111111111111111111",
+      "status": "ahead",
+      "aheadBy": 1,
+      "behindBy": 0,
+      "totalCommits": 1,
+      "isComplete": true,
+      "files": [
+        {
+          "filename": "controls/dev/NumberBox/NumberBox.cpp",
+          "status": "modified"
+        },
+        {
+          "filename": "controls/dev/FutureControl/FutureControl.idl",
+          "status": "added"
+        }
+      ]
+    },
+    {
+      "repository": "winui-gallery",
+      "base": "29f62479d5c046a0b854a5868e5a7cd484572d87",
+      "head": "f4dc3eb367f4bcecac1793829d9a221e924e5bfb",
+      "status": "ahead",
+      "aheadBy": 1,
+      "behindBy": 0,
+      "totalCommits": 1,
+      "isComplete": true,
+      "files": [
+        {
+          "filename": "WinUIGallery/Samples/CommandBar/CommandBarPage.xaml",
+          "previous_filename": "WinUIGallery/Samples/ControlPages/CommandBarPage.xaml",
+          "status": "renamed"
+        }
+      ]
+    }
+  ]
+}

--- a/test/ModernWpf.Tools.Tests/Fixtures/Upstream/upstream-incomplete.fixture.json
+++ b/test/ModernWpf.Tools.Tests/Fixtures/Upstream/upstream-incomplete.fixture.json
@@ -1,0 +1,45 @@
+{
+  "generatedAt": "2026-07-30T12:34:56Z",
+  "stableTags": [
+    {
+      "repository": "winui-product",
+      "track": "stable",
+      "name": "winui3/release/2.3.1",
+      "revision": "a97562621a1d1ea397a38a3f512c9eef99db52d8",
+      "published_at": "2026-07-17T12:00:00Z"
+    }
+  ],
+  "observedHeads": [
+    {
+      "repository": "winui-product",
+      "track": "stable",
+      "revision": "a97562621a1d1ea397a38a3f512c9eef99db52d8",
+      "label": "winui3/release/2.3.1"
+    },
+    {
+      "repository": "winui-product",
+      "track": "main",
+      "revision": "1111111111111111111111111111111111111111",
+      "label": "winui3/main"
+    },
+    {
+      "repository": "winui-gallery",
+      "track": "main",
+      "revision": "f4dc3eb367f4bcecac1793829d9a221e924e5bfb",
+      "label": "main"
+    }
+  ],
+  "comparisons": [
+    {
+      "repository": "winui-product",
+      "base": "eb75504a1978df0d37a3ad4574d6f72bf4d21583",
+      "head": "1111111111111111111111111111111111111111",
+      "status": "ahead",
+      "aheadBy": 1,
+      "behindBy": 0,
+      "totalCommits": 1,
+      "isComplete": false,
+      "files": []
+    }
+  ]
+}

--- a/test/ModernWpf.Tools.Tests/ReleaseVersioningTests.cs
+++ b/test/ModernWpf.Tools.Tests/ReleaseVersioningTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -11,14 +12,14 @@ namespace ModernWpf.Tools.Tests
     public class ReleaseVersioningTests
     {
         [TestMethod]
-        public void PreviewBaselineShipsEveryPublicContractEntry()
+        public void ActivePackageBaselineShipsEveryPublicContractEntry()
         {
             var repoRoot = FindRepoRoot();
             var props = XDocument.Load(Path.Combine(repoRoot, "Directory.Build.props"));
             var version = GetPropertyValue(props, "Version");
             var baseline = GetPropertyValue(
                 props,
-                "ModernWpfCompatibilityBaselineVersion");
+                "ModernWpfPackageValidationBaselineVersion");
 
             if (!string.Equals(version, baseline, StringComparison.Ordinal))
             {
@@ -55,25 +56,119 @@ namespace ModernWpf.Tools.Tests
         }
 
         [TestMethod]
-        public void PackageValidationUsesCentralCompatibilityBaseline()
+        public void PackageValidationSeparatesHistoricalAuditFromActiveBaseline()
         {
             var repoRoot = FindRepoRoot();
             var props = XDocument.Load(Path.Combine(repoRoot, "Directory.Build.props"));
-            var baseline = props
-                .Descendants("ModernWpfCompatibilityBaselineVersion")
-                .Select(element => element.Value)
-                .SingleOrDefault() ?? string.Empty;
+            var auditBaseline = GetPropertyValue(
+                props,
+                "ModernWpfPreviewAuditBaselineVersion");
+            var packageBaseline = GetPropertyValue(
+                props,
+                "ModernWpfPackageValidationBaselineVersion");
             var packageProject = File.ReadAllText(
                 Path.Combine(repoRoot, "ModernWpf.Controls", "ModernWpf.Controls.csproj"));
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(baseline));
+            Assert.AreEqual("1.0.0-preview.1", auditBaseline);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(packageBaseline));
             StringAssert.Contains(
                 packageProject,
-                "'$(Version)' != '$(ModernWpfCompatibilityBaselineVersion)'");
+                "'$(Version)' != '$(ModernWpfPackageValidationBaselineVersion)'");
             StringAssert.Contains(
                 packageProject,
-                ">$(ModernWpfCompatibilityBaselineVersion)</PackageValidationBaselineVersion>");
-            Assert.IsFalse(packageProject.Contains(baseline, StringComparison.Ordinal));
+                ">$(ModernWpfPackageValidationBaselineVersion)</PackageValidationBaselineVersion>");
+            Assert.IsFalse(packageProject.Contains(
+                "ModernWpfPreviewAuditBaselineVersion",
+                StringComparison.Ordinal));
+            Assert.IsFalse(packageProject.Contains(packageBaseline, StringComparison.Ordinal));
+        }
+
+        [TestMethod]
+        public void PreviewRebaselineRequiresBreakingChangeMigrationNotes()
+        {
+            var repoRoot = FindRepoRoot();
+            var props = XDocument.Load(Path.Combine(repoRoot, "Directory.Build.props"));
+            var version = GetPropertyValue(props, "Version");
+            var auditBaseline = GetPropertyValue(
+                props,
+                "ModernWpfPreviewAuditBaselineVersion");
+            var packageBaseline = GetPropertyValue(
+                props,
+                "ModernWpfPackageValidationBaselineVersion");
+
+            if (!version.Contains("-", StringComparison.Ordinal) ||
+                string.Equals(packageBaseline, auditBaseline, StringComparison.Ordinal) ||
+                !string.Equals(packageBaseline, version, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var releaseNotesPath = Path.Combine(
+                repoRoot,
+                "docs",
+                $"release-notes-{version}.md");
+            Assert.IsTrue(
+                File.Exists(releaseNotesPath),
+                $"Release notes are missing for preview rebaseline '{version}'.");
+
+            var releaseNotes = File.ReadAllText(releaseNotesPath);
+            Assert.IsTrue(
+                HasSubstantivePreviewRebaselineNotes(
+                    releaseNotes,
+                    auditBaseline,
+                    packageBaseline),
+                "An intentional preview rebaseline must identify the old and new " +
+                "compatibility baselines and include a breaking-change bullet with " +
+                "explicit consumer migration guidance.");
+        }
+
+        [TestMethod]
+        public void PreviewRebaselineMigrationValidatorRejectsNoChangePlaceholder()
+        {
+            const string oldBaseline = "1.0.0-preview.1";
+            const string newBaseline = "1.0.0-preview.2";
+            const string placeholder = """
+                ## Breaking changes
+
+                This release requires no public CLR or resource-key change, so
+                there is no consumer migration.
+                """;
+            const string substantive = """
+                ## Breaking changes
+
+                Preview compatibility baseline: `1.0.0-preview.1` → `1.0.0-preview.2`
+
+                - `OldMember` was replaced by `NewMember`.
+                  **Migration:** Replace calls to `OldMember` with `NewMember`.
+                """;
+
+            Assert.IsFalse(HasSubstantivePreviewRebaselineNotes(
+                placeholder,
+                oldBaseline,
+                newBaseline));
+            Assert.IsTrue(HasSubstantivePreviewRebaselineNotes(
+                substantive,
+                oldBaseline,
+                newBaseline));
+        }
+
+        [TestMethod]
+        public void StableOneXKeepsTheOneZeroSemVerBaseline()
+        {
+            var repoRoot = FindRepoRoot();
+            var props = XDocument.Load(Path.Combine(repoRoot, "Directory.Build.props"));
+            var version = GetPropertyValue(props, "Version");
+
+            if (version.Contains("-", StringComparison.Ordinal) ||
+                !version.StartsWith("1.", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            Assert.AreEqual(
+                "1.0.0",
+                GetPropertyValue(props, "ModernWpfPackageValidationBaselineVersion"),
+                "Stable 1.x must not advance its package baseline to hide a breaking change.");
         }
 
         [TestMethod]
@@ -330,6 +425,30 @@ namespace ModernWpf.Tools.Tests
                 .Descendants(name)
                 .Select(element => element.Value)
                 .Single();
+        }
+
+        private static bool HasSubstantivePreviewRebaselineNotes(
+            string releaseNotes,
+            string oldBaseline,
+            string newBaseline)
+        {
+            var section = Regex.Match(
+                releaseNotes,
+                @"(?ms)^## Breaking changes\s*(?<body>.*?)(?=^## |\z)");
+            if (!section.Success)
+            {
+                return false;
+            }
+
+            var body = section.Groups["body"].Value;
+            var baselineMarker =
+                $"Preview compatibility baseline: `{oldBaseline}` → `{newBaseline}`";
+            return body.Contains(baselineMarker, StringComparison.Ordinal) &&
+                Regex.IsMatch(body, @"(?m)^\s*[-*]\s+\S") &&
+                body.Contains("**Migration:**", StringComparison.Ordinal) &&
+                !Regex.IsMatch(
+                    body,
+                    @"(?i)\bno\s+public\s+(?:CLR|API|resource)|\bno\s+consumer\s+migration\b");
         }
 
         private static int CountOccurrences(string text, string value)

--- a/test/ModernWpf.Tools.Tests/UpstreamDriftTests.cs
+++ b/test/ModernWpf.Tools.Tests/UpstreamDriftTests.cs
@@ -1,0 +1,772 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ModernWpf.Tools.Tests
+{
+    [TestClass]
+    public class UpstreamDriftTests
+    {
+        private const string ProductReviewedRevision =
+            "de3e767333c2f0717a6a70cb22bd192ced5ad885";
+        private const string ProductEpochRevision =
+            "eb75504a1978df0d37a3ad4574d6f72bf4d21583";
+        private const string StableEpochRevision =
+            "a97562621a1d1ea397a38a3f512c9eef99db52d8";
+        private const string GalleryReviewedRevision =
+            "29f62479d5c046a0b854a5868e5a7cd484572d87";
+        private const string GalleryEpochRevision =
+            "f4dc3eb367f4bcecac1793829d9a221e924e5bfb";
+
+        [TestMethod]
+        public void ManifestSchemaCoversAuditedFamiliesAndGenericResources()
+        {
+            var repoRoot = FindRepoRoot();
+            var upstreamDirectory = Path.Combine(repoRoot, "tools", "upstream");
+            var schemaPath = Path.Combine(upstreamDirectory, "upstream-sync.schema.json");
+            var manifestPath = Path.Combine(upstreamDirectory, "upstream-sync.json");
+
+            using var schema = JsonDocument.Parse(File.ReadAllText(schemaPath));
+            Assert.AreEqual(
+                "https://json-schema.org/draft/2020-12/schema",
+                schema.RootElement.GetProperty("$schema").GetString());
+            Assert.AreEqual(
+                "object",
+                schema.RootElement.GetProperty("type").GetString());
+            Assert.IsTrue(schema.RootElement.GetProperty("$defs").TryGetProperty(
+                "family",
+                out _));
+            Assert.IsTrue(schema.RootElement.GetProperty("$defs").TryGetProperty(
+                "ignorePath",
+                out _));
+            Assert.IsTrue(schema.RootElement.GetProperty("$defs").TryGetProperty(
+                "epochAdoption",
+                out _));
+            Assert.AreEqual(
+                "adopted",
+                schema.RootElement
+                    .GetProperty("$defs")
+                    .GetProperty("epochAdoption")
+                    .GetProperty("properties")
+                    .GetProperty("status")
+                    .GetProperty("const")
+                    .GetString());
+
+            using var manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            var root = manifest.RootElement;
+            Assert.AreEqual("./upstream-sync.schema.json", root.GetProperty("$schema").GetString());
+            Assert.AreEqual(1, root.GetProperty("schemaVersion").GetInt32());
+
+            var repositories = root.GetProperty("repositories")
+                .EnumerateArray()
+                .ToArray();
+            var repositoryIds = repositories
+                .Select(repository => RequiredString(repository, "id"))
+                .ToArray();
+            CollectionAssert.AreEquivalent(
+                new[] { "winui-product", "winui-gallery" },
+                repositoryIds);
+            Assert.AreEqual(
+                repositoryIds.Length,
+                repositoryIds.Distinct(StringComparer.Ordinal).Count());
+
+            foreach (var repository in repositories)
+            {
+                var ignorePaths = repository.GetProperty("ignorePaths")
+                    .EnumerateArray()
+                    .ToArray();
+                Assert.IsTrue(ignorePaths.Length > 0);
+                foreach (var ignorePath in ignorePaths)
+                {
+                    Assert.IsFalse(RequiredString(ignorePath, "path").Contains('\\'));
+                    Assert.IsFalse(string.IsNullOrWhiteSpace(
+                        RequiredString(ignorePath, "justification")));
+                }
+
+                var tracks = repository.GetProperty("tracks")
+                    .EnumerateArray()
+                    .ToArray();
+                var trackIds = tracks
+                    .Select(track => RequiredString(track, "id"))
+                    .ToArray();
+                Assert.AreEqual(
+                    trackIds.Length,
+                    trackIds.Distinct(StringComparer.Ordinal).Count());
+                foreach (var track in tracks)
+                {
+                    var epochAdoption = track.GetProperty("epochAdoption");
+                    Assert.AreEqual(
+                        "adopted",
+                        RequiredString(epochAdoption, "status"));
+                    var dispositionDocument = RequiredString(
+                        epochAdoption,
+                        "dispositionDocument");
+                    Assert.IsFalse(dispositionDocument.Contains('\\'));
+                    Assert.IsTrue(File.Exists(Path.Combine(
+                        repoRoot,
+                        dispositionDocument.Replace(
+                            '/',
+                            Path.DirectorySeparatorChar))));
+                }
+            }
+
+            var product = GetRepository(root, "winui-product");
+            var stable = GetTrack(product, "stable");
+            AssertRevision(stable, "reviewedBaseline", StableEpochRevision);
+            AssertRevision(stable, "epochTarget", StableEpochRevision);
+            Assert.AreEqual(
+                StableEpochRevision,
+                RequiredString(stable.GetProperty("latestStableAtEpoch"), "revision"));
+            Assert.AreEqual(
+                "winui3/release/2.3.1",
+                RequiredString(stable.GetProperty("latestStableAtEpoch"), "tag"));
+            Assert.AreEqual(
+                "latestStableRelease",
+                RequiredString(stable.GetProperty("observedHead"), "kind"));
+
+            var productMain = GetTrack(product, "main");
+            AssertRevision(productMain, "reviewedBaseline", ProductReviewedRevision);
+            AssertRevision(productMain, "epochTarget", ProductEpochRevision);
+            Assert.AreEqual(
+                "ref",
+                RequiredString(productMain.GetProperty("observedHead"), "kind"));
+            Assert.AreEqual(
+                "winui3/main",
+                RequiredString(productMain.GetProperty("observedHead"), "ref"));
+
+            var gallery = GetRepository(root, "winui-gallery");
+            var galleryMain = GetTrack(gallery, "main");
+            AssertRevision(galleryMain, "reviewedBaseline", GalleryReviewedRevision);
+            AssertRevision(galleryMain, "epochTarget", GalleryEpochRevision);
+            Assert.AreEqual(
+                "main",
+                RequiredString(galleryMain.GetProperty("observedHead"), "ref"));
+
+            var families = root.GetProperty("families")
+                .EnumerateArray()
+                .ToArray();
+            var familyIds = families
+                .Select(family => RequiredString(family, "id"))
+                .ToArray();
+            Assert.AreEqual(
+                familyIds.Length,
+                familyIds.Distinct(StringComparer.Ordinal).Count());
+
+            var manifestAuditDocuments = new List<string>();
+            foreach (var family in families)
+            {
+                var auditDocuments = family.GetProperty("auditDocuments")
+                    .EnumerateArray()
+                    .Select(value => value.GetString() ?? string.Empty)
+                    .ToArray();
+                Assert.IsTrue(auditDocuments.Length > 0);
+                foreach (var auditDocument in auditDocuments)
+                {
+                    Assert.IsFalse(auditDocument.Contains('\\'));
+                    Assert.IsTrue(
+                        File.Exists(Path.Combine(
+                            repoRoot,
+                            auditDocument.Replace(
+                                '/',
+                                Path.DirectorySeparatorChar))),
+                        $"Missing audit document '{auditDocument}'.");
+                    manifestAuditDocuments.Add(auditDocument);
+                }
+
+                var watches = family.GetProperty("watches")
+                    .EnumerateArray()
+                    .ToArray();
+                Assert.IsTrue(watches.Length > 0);
+                foreach (var watch in watches)
+                {
+                    CollectionAssert.Contains(
+                        repositoryIds,
+                        RequiredString(watch, "repository"));
+                    var paths = watch.GetProperty("paths")
+                        .EnumerateArray()
+                        .Select(value => value.GetString() ?? string.Empty)
+                        .ToArray();
+                    Assert.IsTrue(paths.Length > 0);
+                    Assert.IsFalse(paths.Any(path =>
+                        string.IsNullOrWhiteSpace(path) ||
+                        path.Contains('\\')));
+                }
+            }
+            CollectionAssert.Contains(
+                manifestAuditDocuments,
+                "docs/custom-popup-source-findings.md",
+                "Popup platform changes must route to the governing WindowedPopup source record.");
+            CollectionAssert.Contains(
+                manifestAuditDocuments,
+                "docs/titlebar-winui3-gallery-parity.md",
+                "TitleBar API metadata must route to the WPF-facade parity record.");
+
+            var sourceAudits = Directory
+                .GetFiles(Path.Combine(repoRoot, "docs"), "*winui3-source-audit.md")
+                .Select(path => Path.GetRelativePath(repoRoot, path).Replace('\\', '/'))
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray();
+            Assert.IsTrue(sourceAudits.Length >= 30);
+            foreach (var sourceAudit in sourceAudits)
+            {
+                Assert.AreEqual(
+                    1,
+                    manifestAuditDocuments.Count(path =>
+                        string.Equals(path, sourceAudit, StringComparison.Ordinal)),
+                    $"Current WinUI source audit '{sourceAudit}' must map to exactly one family.");
+            }
+
+            var expectedResources = XDocument
+                .Load(Path.Combine(
+                    repoRoot,
+                    "ModernWpf.Controls",
+                    "Themes",
+                    "Generic.xaml"))
+                .Descendants()
+                .Where(element => element.Name.LocalName == "ResourceDictionary")
+                .Select(element => element.Attribute("Source")?.Value)
+                .OfType<string>()
+                .Where(source => source.StartsWith(
+                    "/ModernWpf.Controls;component/",
+                    StringComparison.OrdinalIgnoreCase))
+                .Select(source => source.Substring(
+                    "/ModernWpf.Controls;component/".Length))
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var coverageRows = ParseControlCoverageRows(Path.Combine(
+                repoRoot,
+                "docs",
+                "winui3-control-source-coverage.md"));
+            var coveredResources = coverageRows
+                .Select(row => row.Resource)
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            CollectionAssert.AreEqual(expectedResources, coveredResources);
+            Assert.AreEqual(
+                coverageRows.Count,
+                coverageRows
+                    .Select(row => row.Resource)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Count(),
+                "Generic resource coverage rows must be unique.");
+            foreach (var row in coverageRows)
+            {
+                CollectionAssert.Contains(
+                    manifestAuditDocuments,
+                    row.AuditDocument,
+                    $"Generic resource '{row.Resource}' is not mapped by the upstream manifest.");
+            }
+        }
+
+        [TestMethod]
+        public void ReporterValidatesManifestAgainstSchemaAndUsesSemanticStableOrder()
+        {
+            var repoRoot = FindRepoRoot();
+            var upstreamDirectory = Path.Combine(repoRoot, "tools", "upstream");
+            var script = File.ReadAllText(Path.Combine(
+                upstreamDirectory,
+                "Get-UpstreamDriftReport.ps1"));
+
+            StringAssert.Contains(script, "Test-Json");
+            StringAssert.Contains(script, "-SchemaFile $resolvedSchemaPath");
+            StringAssert.Contains(script, "Get-StableTagVersion");
+            StringAssert.Contains(script, "Select-LatestStableTag");
+            StringAssert.Contains(script, "ConvertTo-StableTags");
+            StringAssert.Contains(script, "/tags?per_page=100&page=$pageNumber");
+            StringAssert.Contains(script, "while ($pageTags.Count -eq 100)");
+            Assert.IsFalse(script.Contains(
+                "$tags = @(" + Environment.NewLine + "        Invoke-GitHubApi",
+                StringComparison.Ordinal),
+                "Invoke-RestMethod JSON arrays must be assigned before @() enumeration.");
+            StringAssert.Contains(
+                script,
+                "$encodedBase...${encodedHead}?per_page=100",
+                "The compare URI must delimit encodedHead because '?' is valid in a PowerShell variable name.");
+            StringAssert.Contains(script, "Sort-Object -Property version -Descending");
+            Assert.IsFalse(script.Contains(
+                "Sort-Object -Property published_at",
+                StringComparison.Ordinal));
+
+            var temporaryDirectory = Path.Combine(
+                Path.GetTempPath(),
+                $"modernwpf-upstream-schema-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(temporaryDirectory);
+            try
+            {
+                File.Copy(
+                    Path.Combine(upstreamDirectory, "upstream-sync.schema.json"),
+                    Path.Combine(temporaryDirectory, "upstream-sync.schema.json"));
+                var invalidManifest = File
+                    .ReadAllText(Path.Combine(upstreamDirectory, "upstream-sync.json"))
+                    .Replace(
+                        "\"schemaVersion\": 1,",
+                        "\"schemaVersion\": 1,\n  \"unexpectedProperty\": true,",
+                        StringComparison.Ordinal);
+                var invalidManifestPath = Path.Combine(
+                    temporaryDirectory,
+                    "upstream-sync.json");
+                File.WriteAllText(invalidManifestPath, invalidManifest);
+
+                var result = RunReport(
+                    repoRoot,
+                    Path.Combine(
+                        repoRoot,
+                        "test",
+                        "ModernWpf.Tools.Tests",
+                        "Fixtures",
+                        "Upstream",
+                        "upstream-clean.fixture.json"),
+                    "-ManifestPath",
+                    invalidManifestPath);
+
+                Assert.AreNotEqual(0, result.ExitCode);
+                Assert.IsTrue(string.IsNullOrWhiteSpace(result.Json));
+                StringAssert.Contains(result.StandardError, "unexpectedProperty");
+            }
+            finally
+            {
+                Directory.Delete(temporaryDirectory, recursive: true);
+            }
+        }
+
+        [TestMethod]
+        public void OfflineFixtureSeparatesEpochObservedIgnoredAndUnmappedChanges()
+        {
+            var repoRoot = FindRepoRoot();
+            var fixturePath = Path.Combine(
+                repoRoot,
+                "test",
+                "ModernWpf.Tools.Tests",
+                "Fixtures",
+                "Upstream",
+                "upstream-drift.fixture.json");
+            var result = RunReport(
+                repoRoot,
+                fixturePath,
+                "-IncludeEpochComparison");
+
+            Assert.AreEqual(
+                0,
+                result.ExitCode,
+                result.StandardOutput + Environment.NewLine + result.StandardError);
+            using var report = JsonDocument.Parse(result.Json);
+            var root = report.RootElement;
+            Assert.IsTrue(root.GetProperty("hasEpochDrift").GetBoolean());
+            Assert.IsTrue(root.GetProperty("hasObservedDrift").GetBoolean());
+            Assert.IsTrue(root.GetProperty("hasEpochUnmappedDrift").GetBoolean());
+            Assert.IsTrue(root.GetProperty("hasObservedUnmappedDrift").GetBoolean());
+            Assert.IsFalse(root.GetProperty("hasIncompleteComparison").GetBoolean());
+            Assert.AreEqual(
+                DateTimeOffset.Parse("2026-07-30T12:34:56Z"),
+                DateTimeOffset.Parse(RequiredString(root, "generatedAt")));
+
+            var stable = GetReportTrack(root, "winui-product", "stable");
+            Assert.AreEqual(
+                "winui3/release/2.3.2",
+                RequiredString(stable.GetProperty("observedHead"), "label"));
+            Assert.AreEqual(
+                1,
+                stable
+                    .GetProperty("observed")
+                    .GetProperty("comparison")
+                    .GetProperty("watchedChangedFileCount")
+                    .GetInt32());
+            var stableFile = stable
+                .GetProperty("observed")
+                .GetProperty("comparison")
+                .GetProperty("families")[0]
+                .GetProperty("files")[0];
+            Assert.AreEqual(
+                "src/controls/dev/NumberBox/NumberBox.cpp",
+                RequiredString(stableFile, "filename"));
+
+            var productMain = GetReportTrack(root, "winui-product", "main");
+            Assert.AreEqual(
+                "adopted",
+                RequiredString(productMain.GetProperty("epochAdoption"), "status"));
+            Assert.AreEqual(
+                "docs/winui3-sync-2026-07-29.md",
+                RequiredString(
+                    productMain.GetProperty("epochAdoption"),
+                    "dispositionDocument"));
+            var epoch = productMain
+                .GetProperty("epoch")
+                .GetProperty("comparison");
+            Assert.IsTrue(epoch.GetProperty("isEvaluated").GetBoolean());
+            Assert.AreEqual(4, epoch.GetProperty("watchedChangedFileCount").GetInt32());
+            Assert.AreEqual(1, epoch.GetProperty("ignoredChangedFileCount").GetInt32());
+            Assert.AreEqual(2, epoch.GetProperty("unmappedChangedFileCount").GetInt32());
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
+                    "command-bar",
+                    "popup-gallery",
+                    "theme-shadow",
+                    "xaml-core-api-surface"
+                },
+                epoch
+                    .GetProperty("families")
+                    .EnumerateArray()
+                    .Select(family => RequiredString(family, "id"))
+                    .ToArray());
+            Assert.AreEqual(
+                ".github/**",
+                RequiredString(epoch.GetProperty("ignoredFiles")[0], "ignorePattern"));
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
+                    ".github/workflows/moved.yml",
+                    "controls/dev/NewControl/NewControl.idl"
+                },
+                epoch
+                    .GetProperty("unmappedFiles")
+                    .EnumerateArray()
+                    .Select(file => RequiredString(file, "filename"))
+                    .ToArray());
+
+            var observed = productMain
+                .GetProperty("observed")
+                .GetProperty("comparison");
+            Assert.AreEqual(2, observed.GetProperty("actionableChangedFileCount").GetInt32());
+            Assert.AreEqual(
+                "number-box",
+                RequiredString(observed.GetProperty("families")[0], "id"));
+            Assert.AreEqual(
+                "controls/dev/FutureControl/FutureControl.idl",
+                RequiredString(observed.GetProperty("unmappedFiles")[0], "filename"));
+
+            var galleryMain = GetReportTrack(root, "winui-gallery", "main");
+            Assert.AreEqual(
+                "command-bar",
+                RequiredString(
+                    galleryMain
+                        .GetProperty("epoch")
+                        .GetProperty("comparison")
+                        .GetProperty("families")[0],
+                    "id"));
+
+            StringAssert.Contains(
+                result.Markdown,
+                "Reviewed baseline → finite epoch target");
+            StringAssert.Contains(
+                result.Markdown,
+                "Finite epoch target → moving observed head");
+            StringAssert.Contains(result.Markdown, "Explicitly ignored files");
+            StringAssert.Contains(result.Markdown, "Unmapped files (action required)");
+            StringAssert.Contains(
+                result.Markdown,
+                "dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.cs");
+            StringAssert.Contains(
+                result.Markdown,
+                "dxaml/xcp/dxaml/lib/FrameworkElement_Partial.cpp");
+            StringAssert.Contains(
+                result.Markdown,
+                "Popup platform primitive and Gallery sample");
+            StringAssert.Contains(result.Markdown, "ThemeShadow");
+            StringAssert.Contains(
+                result.Markdown,
+                "controls/dev/NewControl/NewControl.idl");
+            StringAssert.Contains(result.Markdown, ".github/workflows/moved.yml");
+            StringAssert.Contains(
+                result.Markdown,
+                "src/controls/dev/NumberBox/NumberBox.cpp");
+            StringAssert.Contains(
+                result.Markdown,
+                "does not port, merge, or advance any baseline");
+            StringAssert.Contains(
+                result.Markdown,
+                "Epoch adoption: `adopted`; disposition `docs/winui3-sync-2026-07-29.md`.");
+        }
+
+        [TestMethod]
+        public void ScheduledModeSkipsHistoricalComparisonAndFailsOnNewDrift()
+        {
+            var repoRoot = FindRepoRoot();
+            var fixtureDirectory = Path.Combine(
+                repoRoot,
+                "test",
+                "ModernWpf.Tools.Tests",
+                "Fixtures",
+                "Upstream");
+            var clean = RunReport(
+                repoRoot,
+                Path.Combine(fixtureDirectory, "upstream-clean.fixture.json"),
+                "-FailOnObservedDrift",
+                "-FailOnIncompleteComparison");
+            Assert.AreEqual(
+                0,
+                clean.ExitCode,
+                clean.StandardOutput + Environment.NewLine + clean.StandardError);
+            using (var cleanReport = JsonDocument.Parse(clean.Json))
+            {
+                Assert.IsFalse(cleanReport.RootElement
+                    .GetProperty("hasObservedDrift")
+                    .GetBoolean());
+                foreach (var track in cleanReport.RootElement
+                    .GetProperty("tracks")
+                    .EnumerateArray())
+                {
+                    Assert.IsFalse(track
+                        .GetProperty("epoch")
+                        .GetProperty("comparison")
+                        .GetProperty("isEvaluated")
+                        .GetBoolean());
+                }
+                var cleanStable = GetReportTrack(
+                    cleanReport.RootElement,
+                    "winui-product",
+                    "stable");
+                Assert.AreEqual(
+                    "winui3/release/2.3.1",
+                    RequiredString(cleanStable.GetProperty("observedHead"), "label"),
+                    "Stable selection must use highest SemVer even when an older train was published later.");
+            }
+            StringAssert.Contains(
+                clean.Markdown,
+                "The historical epoch comparison was not queried.");
+
+            var drift = RunReport(
+                repoRoot,
+                Path.Combine(fixtureDirectory, "upstream-drift.fixture.json"),
+                "-FailOnObservedDrift");
+            Assert.AreNotEqual(0, drift.ExitCode);
+            Assert.AreEqual(2, drift.ExitCode);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(drift.Json));
+            using var driftReport = JsonDocument.Parse(drift.Json);
+            Assert.IsTrue(driftReport.RootElement
+                .GetProperty("hasObservedDrift")
+                .GetBoolean());
+        }
+
+        [TestMethod]
+        public void IncompleteComparisonEmitsReportAndExitsThree()
+        {
+            var repoRoot = FindRepoRoot();
+            var result = RunReport(
+                repoRoot,
+                Path.Combine(
+                    repoRoot,
+                    "test",
+                    "ModernWpf.Tools.Tests",
+                    "Fixtures",
+                    "Upstream",
+                    "upstream-incomplete.fixture.json"),
+                "-FailOnIncompleteComparison");
+
+            Assert.AreEqual(3, result.ExitCode);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(result.Json));
+            using var report = JsonDocument.Parse(result.Json);
+            Assert.IsTrue(report.RootElement
+                .GetProperty("hasIncompleteComparison")
+                .GetBoolean());
+            StringAssert.Contains(
+                result.StandardError,
+                "At least one upstream comparison was incomplete.");
+        }
+
+        [TestMethod]
+        public void MonitoringWorkflowIsScheduledManualReadOnlyAndNonPorting()
+        {
+            var repoRoot = FindRepoRoot();
+            var workflow = File.ReadAllText(Path.Combine(
+                    repoRoot,
+                    ".github",
+                    "workflows",
+                    "upstream-drift.yml"))
+                .Replace("\r\n", "\n", StringComparison.Ordinal);
+
+            StringAssert.Contains(workflow, "on:\n  schedule:");
+            StringAssert.Contains(workflow, "  workflow_dispatch:");
+            StringAssert.Contains(workflow, "permissions:\n  contents: read");
+            StringAssert.Contains(
+                workflow,
+                @".\tools\upstream\Get-UpstreamDriftReport.ps1");
+            StringAssert.Contains(workflow, "-FailOnObservedDrift");
+            StringAssert.Contains(workflow, "-FailOnIncompleteComparison");
+            StringAssert.Contains(workflow, "uses: actions/upload-artifact@v7");
+            Assert.IsFalse(workflow.Contains(
+                "-IncludeEpochComparison",
+                StringComparison.Ordinal));
+            Assert.IsFalse(Regex.IsMatch(
+                workflow,
+                @"(?m)^  (push|pull_request):"));
+            Assert.IsFalse(workflow.Contains("issues: write", StringComparison.Ordinal));
+            Assert.IsFalse(workflow.Contains("pull-requests: write", StringComparison.Ordinal));
+            Assert.IsFalse(workflow.Contains("git commit", StringComparison.OrdinalIgnoreCase));
+            Assert.IsFalse(workflow.Contains("git merge", StringComparison.OrdinalIgnoreCase));
+            Assert.IsFalse(workflow.Contains("gh pr", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static void AssertRevision(
+            JsonElement track,
+            string propertyName,
+            string expectedRevision)
+        {
+            Assert.AreEqual(
+                expectedRevision,
+                RequiredString(track.GetProperty(propertyName), "revision"));
+        }
+
+        private static JsonElement GetRepository(JsonElement root, string id)
+        {
+            return root.GetProperty("repositories")
+                .EnumerateArray()
+                .Single(repository => RequiredString(repository, "id") == id);
+        }
+
+        private static JsonElement GetTrack(JsonElement repository, string id)
+        {
+            return repository.GetProperty("tracks")
+                .EnumerateArray()
+                .Single(track => RequiredString(track, "id") == id);
+        }
+
+        private static JsonElement GetReportTrack(
+            JsonElement root,
+            string repository,
+            string track)
+        {
+            return root.GetProperty("tracks")
+                .EnumerateArray()
+                .Single(item =>
+                    RequiredString(item, "repository") == repository &&
+                    RequiredString(item, "track") == track);
+        }
+
+        private static string RequiredString(JsonElement element, string propertyName)
+        {
+            var value = element.GetProperty(propertyName).GetString();
+            Assert.IsFalse(
+                string.IsNullOrWhiteSpace(value),
+                $"Property '{propertyName}' must be a non-empty string.");
+            return value!;
+        }
+
+        private static IReadOnlyList<CoverageRow> ParseControlCoverageRows(
+            string path)
+        {
+            var rows = new List<CoverageRow>();
+            foreach (var line in File.ReadLines(path))
+            {
+                if (!line.StartsWith("| `", StringComparison.Ordinal) ||
+                    !line.Contains("docs\\", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var values = Regex.Matches(line, @"`([^`]+)`")
+                    .Cast<Match>()
+                    .Select(match => match.Groups[1].Value)
+                    .ToArray();
+                Assert.IsTrue(
+                    values.Length >= 2,
+                    $"Malformed WinUI control coverage row: {line}");
+                rows.Add(new CoverageRow(
+                    values[0],
+                    values[^1].Replace('\\', '/')));
+            }
+
+            return rows;
+        }
+
+        private static ReportRun RunReport(
+            string repoRoot,
+            string fixturePath,
+            params string[] additionalArguments)
+        {
+            var temporaryDirectory = Path.Combine(
+                Path.GetTempPath(),
+                $"modernwpf-upstream-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(temporaryDirectory);
+            var markdownPath = Path.Combine(temporaryDirectory, "report.md");
+            var jsonPath = Path.Combine(temporaryDirectory, "report.json");
+
+            try
+            {
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = "pwsh",
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    WorkingDirectory = repoRoot
+                };
+                foreach (var argument in new[]
+                {
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-File",
+                    Path.Combine(
+                        repoRoot,
+                        "tools",
+                        "upstream",
+                        "Get-UpstreamDriftReport.ps1"),
+                    "-FixturePath",
+                    fixturePath,
+                    "-OutputPath",
+                    markdownPath,
+                    "-JsonOutputPath",
+                    jsonPath
+                }.Concat(additionalArguments))
+                {
+                    startInfo.ArgumentList.Add(argument);
+                }
+
+                using var process = Process.Start(startInfo);
+                Assert.IsNotNull(process);
+                var standardOutput = process.StandardOutput.ReadToEnd();
+                var standardError = process.StandardError.ReadToEnd();
+                process.WaitForExit();
+
+                return new ReportRun(
+                    process.ExitCode,
+                    standardOutput,
+                    standardError,
+                    File.Exists(markdownPath)
+                        ? File.ReadAllText(markdownPath)
+                        : string.Empty,
+                    File.Exists(jsonPath)
+                        ? File.ReadAllText(jsonPath)
+                        : string.Empty);
+            }
+            finally
+            {
+                Directory.Delete(temporaryDirectory, recursive: true);
+            }
+        }
+
+        private static string FindRepoRoot()
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (directory != null)
+            {
+                if (File.Exists(Path.Combine(directory.FullName, "ModernWpf.sln")))
+                {
+                    return directory.FullName;
+                }
+
+                directory = directory.Parent;
+            }
+
+            Assert.Fail("Could not locate ModernWpf.sln from the test output directory.");
+            return string.Empty;
+        }
+
+        private sealed record CoverageRow(string Resource, string AuditDocument);
+
+        private sealed record ReportRun(
+            int ExitCode,
+            string StandardOutput,
+            string StandardError,
+            string Markdown,
+            string Json);
+    }
+}

--- a/test/ModernWpf.WinUI.Tests/CommandBar/CommandBarApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/CommandBar/CommandBarApiTests.cs
@@ -1794,6 +1794,59 @@ public class CommandBarApiTests
     }
 
     [TestMethod]
+    public void CommandBarAutoOverflowButtonUsesPhysicalPixelCompactHeightThreshold()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var commandBar = new ModernWpf.Controls.CommandBar
+            {
+                IsDynamicOverflowEnabled = false,
+                UseLayoutRounding = false
+            };
+
+            using var host = new TestWindowHost(commandBar, width: 240, height: 120);
+            host.UpdateLayout();
+
+            var compactHeight = (double)commandBar.TryFindResource("AppBarThemeCompactHeight");
+            var rasterizationScale = VisualTreeHelper.GetDpi(commandBar).DpiScaleY;
+            var halfPhysicalPixel = 0.5 / rasterizationScale;
+
+            commandBar.Height = compactHeight + halfPhysicalPixel * 0.75;
+            host.UpdateLayout();
+
+            Assert.AreEqual(
+                Visibility.Collapsed,
+                commandBar.CommandBarTemplateSettings.EffectiveOverflowButtonVisibility);
+
+            commandBar.Height = compactHeight + halfPhysicalPixel * 1.25;
+            host.UpdateLayout();
+
+            Assert.AreEqual(
+                Visibility.Visible,
+                commandBar.CommandBarTemplateSettings.EffectiveOverflowButtonVisibility);
+        });
+    }
+
+    [TestMethod]
+    public void CommandBarCompactHeightThresholdUsesFractionalRasterizationScale()
+    {
+        const double rasterizationScale = 1.25;
+        double halfPhysicalPixel = 0.5 / rasterizationScale;
+
+        Assert.IsFalse(ModernWpf.Controls.CommandBar.IsCompactHeightDifferenceSignificant(
+            halfPhysicalPixel * 0.75,
+            rasterizationScale));
+        Assert.IsTrue(ModernWpf.Controls.CommandBar.IsCompactHeightDifferenceSignificant(
+            halfPhysicalPixel,
+            rasterizationScale));
+        Assert.IsTrue(ModernWpf.Controls.CommandBar.IsCompactHeightDifferenceSignificant(
+            -halfPhysicalPixel,
+            rasterizationScale));
+    }
+
+    [TestMethod]
     public void CommandBarAutoOverflowButtonTreatsEmptyAppBarLabelsAsPresent()
     {
         WpfTestHost.Run(() =>

--- a/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewApiTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Automation.Peers;
@@ -144,6 +145,74 @@ public class NavigationViewApiTests
                 .OfType<TextBlock>()
                 .Single();
             Assert.AreEqual(navView.Content, text.Text);
+        });
+    }
+
+    [TestMethod]
+    public void NavigationViewItemAltSpaceRemainsUnhandledForSystemMenuLikeCurrentWinUI()
+    {
+        WpfTestHost.Run(() =>
+        {
+            TestApplication.EnsureInitialized();
+
+            var item = new ModernWpf.Controls.NavigationViewItem
+            {
+                Content = "Home"
+            };
+            var navView = new ModernWpf.Controls.NavigationView
+            {
+                Width = 640,
+                Height = 360,
+                PaneDisplayMode = ModernWpf.Controls.NavigationViewPaneDisplayMode.Left
+            };
+            navView.MenuItems.Add(item);
+
+            var invokedCount = 0;
+            navView.ItemInvoked += (_, _) => invokedCount++;
+
+            using var host = new TestWindowHost(navView, width: 640, height: 360);
+            host.UpdateLayout();
+
+            var source = PresentationSource.FromVisual(item)
+                ?? throw new AssertFailedException("Expected the navigation item to have a presentation source.");
+
+            var systemSpace = new KeyEventArgs(
+                Keyboard.PrimaryDevice,
+                source,
+                Environment.TickCount,
+                Key.Space)
+            {
+                RoutedEvent = Keyboard.KeyDownEvent,
+                Source = item
+            };
+            var markSystem = typeof(KeyEventArgs).GetMethod(
+                "MarkSystem",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(markSystem);
+            markSystem!.Invoke(systemSpace, null);
+
+            Assert.AreEqual(Key.System, systemSpace.Key);
+            Assert.AreEqual(Key.Space, systemSpace.SystemKey);
+
+            item.RaiseEvent(systemSpace);
+
+            Assert.IsFalse(systemSpace.Handled);
+            Assert.AreEqual(0, invokedCount);
+
+            var plainSpace = new KeyEventArgs(
+                Keyboard.PrimaryDevice,
+                source,
+                Environment.TickCount + 1,
+                Key.Space)
+            {
+                RoutedEvent = Keyboard.KeyDownEvent,
+                Source = item
+            };
+
+            item.RaiseEvent(plainSpace);
+
+            Assert.IsTrue(plainSpace.Handled);
+            Assert.AreEqual(1, invokedCount);
         });
     }
 

--- a/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewSourceAuditTests.cs
+++ b/test/ModernWpf.WinUI.Tests/NavigationView/NavigationViewSourceAuditTests.cs
@@ -18,8 +18,20 @@ public class NavigationViewSourceAuditTests
         var template = File.ReadAllText(Path.Combine(repoRoot, "ModernWpf.Controls", "NavigationView", "NavigationView.xaml"));
         var navigationView = File.ReadAllText(Path.Combine(repoRoot, "ModernWpf.Controls", "NavigationView", "NavigationView.cs"));
         var navigationViewItem = File.ReadAllText(Path.Combine(repoRoot, "ModernWpf.Controls", "NavigationView", "NavigationViewItem.cs"));
+        var apiTests = File.ReadAllText(
+            Path.Combine(
+                repoRoot,
+                "test",
+                "ModernWpf.WinUI.Tests",
+                "NavigationView",
+                "NavigationViewApiTests.cs"));
 
         StringAssert.Contains(audit, "de3e767333c2f0717a6a70cb22bd192ced5ad885");
+        StringAssert.Contains(audit, "eb75504a1978df0d37a3ad4574d6f72bf4d21583");
+        StringAssert.Contains(audit, "a97562621a1d1ea397a38a3f512c9eef99db52d8");
+        StringAssert.Contains(audit, "e5d2c481b35a62e3a2a7b3818f896e6470a25514");
+        StringAssert.Contains(audit, "72e7be771aea8288ff8d2ae7916ea4257da4cbbc");
+        StringAssert.Contains(audit, "a4d23ee1161d5dacd221f8b8dfb730fcc2f27e73");
         StringAssert.Contains(audit, "29f62479d5c046a0b854a5868e5a7cd484572d87");
         StringAssert.Contains(audit, "b6e31de9b2bdf825b894cc831581439ecfaf4579");
         StringAssert.Contains(audit, "834625ee535b767ca8ab3e381468e52ebed6aeb5");
@@ -45,6 +57,9 @@ public class NavigationViewSourceAuditTests
         StringAssert.Contains(navigationViewItem, "IsExpanded &&");
         StringAssert.Contains(navigationViewItem, "ShouldRepeaterShowInFlyout() &&");
         StringAssert.Contains(navigationViewItem, "FlyoutBase.GetAttachedFlyout(m_rootGrid) != null");
+        StringAssert.Contains(apiTests, "NavigationViewItemAltSpaceRemainsUnhandledForSystemMenuLikeCurrentWinUI");
+        StringAssert.Contains(apiTests, "Assert.AreEqual(Key.System, systemSpace.Key);");
+        StringAssert.Contains(apiTests, "Assert.AreEqual(Key.Space, systemSpace.SystemKey);");
     }
 
     private static string FindRepoRoot()

--- a/test/ModernWpf.WinUI.Tests/Popup/WindowedPopupApiTests.cs
+++ b/test/ModernWpf.WinUI.Tests/Popup/WindowedPopupApiTests.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
+using System.Windows.Markup;
 using System.Windows.Media;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ModernWpf.Controls.Primitives;
@@ -188,6 +189,120 @@ public class WindowedPopupApiTests
 
                 Assert.AreEqual(PopupPlacementMode.TopEdgeAlignedLeft, popup.ActualPlacement);
                 Assert.IsTrue(actualPlacements.Contains(PopupPlacementMode.TopEdgeAlignedLeft));
+            }
+            finally
+            {
+                popup.IsOpen = false;
+            }
+        });
+    }
+
+    [TestMethod]
+    public void XamlReaderIsOpenBeforeChildDefersUntilLoaded()
+    {
+        WpfTestHost.Run(() =>
+        {
+            var (root, popup, child) = ParsePendingPopup(isOpenBeforeChild: true);
+            var openedCount = 0;
+            popup.Opened += (_, _) => openedCount++;
+
+            Assert.IsTrue(popup.IsOpen);
+            Assert.IsNull(PresentationSource.FromVisual(child));
+
+            using var host = CreateVisibleHost(root, width: 320, height: 220);
+
+            try
+            {
+                Assert.IsTrue(popup.IsOpen);
+                Assert.AreEqual(1, openedCount);
+                Assert.IsNotNull(PresentationSource.FromVisual(child));
+                Assert.AreEqual(100.0, child.ActualWidth);
+                Assert.AreEqual(100.0, child.ActualHeight);
+            }
+            finally
+            {
+                popup.IsOpen = false;
+            }
+        });
+    }
+
+    [TestMethod]
+    public void XamlReaderChildBeforeIsOpenDefersUntilLoaded()
+    {
+        WpfTestHost.Run(() =>
+        {
+            var (root, popup, child) = ParsePendingPopup(isOpenBeforeChild: false);
+            var openedCount = 0;
+            popup.Opened += (_, _) => openedCount++;
+
+            Assert.IsTrue(popup.IsOpen);
+            Assert.IsNull(PresentationSource.FromVisual(child));
+
+            using var host = CreateVisibleHost(root, width: 320, height: 220);
+
+            try
+            {
+                Assert.IsTrue(popup.IsOpen);
+                Assert.AreEqual(1, openedCount);
+                Assert.IsNotNull(PresentationSource.FromVisual(child));
+                Assert.AreEqual(100.0, child.ActualWidth);
+                Assert.AreEqual(100.0, child.ActualHeight);
+            }
+            finally
+            {
+                popup.IsOpen = false;
+            }
+        });
+    }
+
+    [TestMethod]
+    public void ClosingPendingXamlPopupBeforeLoadedCancelsDeferredOpen()
+    {
+        WpfTestHost.Run(() =>
+        {
+            var (root, popup, child) = ParsePendingPopup(isOpenBeforeChild: true);
+            var openedCount = 0;
+            var closedCount = 0;
+            popup.Opened += (_, _) => openedCount++;
+            popup.Closed += (_, _) => closedCount++;
+
+            Assert.IsTrue(popup.IsOpen);
+            popup.IsOpen = false;
+
+            Assert.IsFalse(popup.IsOpen);
+            Assert.IsNull(PresentationSource.FromVisual(child));
+
+            using var host = CreateVisibleHost(root, width: 320, height: 220);
+
+            Assert.IsFalse(popup.IsOpen);
+            Assert.AreEqual(0, openedCount);
+            Assert.AreEqual(0, closedCount);
+            Assert.IsNull(PresentationSource.FromVisual(child));
+        });
+    }
+
+    [TestMethod]
+    public void ParentlessProgrammaticAutoPopupStillOpensImmediately()
+    {
+        WpfTestHost.Run(() =>
+        {
+            var child = CreatePopupChild(width: 90, height: 42);
+            var popup = new WindowedPopup
+            {
+                Child = child,
+                HorizontalOffset = 20,
+                VerticalOffset = 20
+            };
+            var openedCount = 0;
+            popup.Opened += (_, _) => openedCount++;
+
+            try
+            {
+                popup.IsOpen = true;
+
+                Assert.IsTrue(popup.IsOpen);
+                Assert.AreEqual(1, openedCount);
+                Assert.IsNotNull(PresentationSource.FromVisual(child));
             }
             finally
             {
@@ -581,6 +696,32 @@ public class WindowedPopupApiTests
             Height = height,
             Background = Brushes.Transparent
         };
+    }
+
+    private static (Grid Root, WindowedPopup Popup, Border Child) ParsePendingPopup(bool isOpenBeforeChild)
+    {
+        var popupXaml = isOpenBeforeChild
+            ? @"
+                <primitives:WindowedPopup IsOpen='True'>
+                    <Border Width='100' Height='100' Background='Red' />
+                </primitives:WindowedPopup>"
+            : @"
+                <primitives:WindowedPopup>
+                    <primitives:WindowedPopup.Child>
+                        <Border Width='100' Height='100' Background='Red' />
+                    </primitives:WindowedPopup.Child>
+                    <primitives:WindowedPopup.IsOpen>True</primitives:WindowedPopup.IsOpen>
+                </primitives:WindowedPopup>";
+        var root = (Grid)XamlReader.Parse(
+            $@"
+                <Grid
+                    xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                    xmlns:primitives='clr-namespace:ModernWpf.Controls.Primitives;assembly=ModernWpf'>
+                    {popupXaml}
+                </Grid>");
+        var popup = (WindowedPopup)root.Children[0];
+        var child = (Border)popup.Child;
+        return (root, popup, child);
     }
 
     private static Grid CreateRoot(params UIElement[] children)

--- a/test/ModernWpf.WinUI.Tests/Repeater/RepeaterLayoutTests.cs
+++ b/test/ModernWpf.WinUI.Tests/Repeater/RepeaterLayoutTests.cs
@@ -43,6 +43,50 @@ public class RepeaterLayoutTests
     }
 
     [TestMethod]
+    public void NonVirtualItemsSourceReplacementRecyclesWithoutStaleOwner()
+    {
+        WpfTestHost.Run(() =>
+        {
+            var factory = new RecyclingElementFactory
+            {
+                RecyclePool = new RecyclePool(),
+                Templates = { { "item", CreateButtonTemplate(height: 32) } }
+            };
+            var firstRepeater = new ItemsRepeater
+            {
+                Layout = new NonVirtualStackLayout(),
+                ItemsSource = new[] { "first" },
+                ItemTemplate = factory
+            };
+            var secondRepeater = new ItemsRepeater
+            {
+                Layout = new NonVirtualStackLayout(),
+                ItemsSource = Array.Empty<string>(),
+                ItemTemplate = factory
+            };
+            var root = new StackPanel();
+            root.Children.Add(firstRepeater);
+            root.Children.Add(secondRepeater);
+
+            using var host = new TestWindowHost(root, width: 240, height: 160);
+            host.UpdateLayout();
+
+            var recycledElement = firstRepeater.TryGetElement(0);
+            Assert.IsNotNull(recycledElement);
+
+            firstRepeater.ItemsSource = Array.Empty<string>();
+            host.UpdateLayout();
+            Assert.AreEqual(0, firstRepeater.Children.Count);
+
+            secondRepeater.ItemsSource = new[] { "second" };
+            host.UpdateLayout();
+
+            Assert.AreSame(recycledElement, secondRepeater.TryGetElement(0));
+            Assert.AreSame(secondRepeater, ((FrameworkElement)recycledElement!).Parent);
+        });
+    }
+
+    [TestMethod]
     public void ValidateStackLayoutDoesNotRetainIncorrectMinorWidth()
     {
         WpfTestHost.Run(() =>
@@ -260,6 +304,43 @@ public class RepeaterLayoutTests
             AssertLayoutSlot((FrameworkElement)repeater.TryGetElement(1)!, new Rect(110, 0, 100, 50));
             AssertLayoutSlot((FrameworkElement)repeater.TryGetElement(2)!, new Rect(0, 55, 100, 50));
             AssertLayoutSlot((FrameworkElement)repeater.TryGetElement(3)!, new Rect(110, 55, 100, 50));
+        });
+    }
+
+    [TestMethod]
+    public void UniformGridLayoutFloorsNarrowAvailableWidthAtOneItemPerLine()
+    {
+        WpfTestHost.Run(() =>
+        {
+            var repeater = new ItemsRepeater
+            {
+                Layout = new UniformGridLayout
+                {
+                    MinItemWidth = 100,
+                    MinItemHeight = 50,
+                    MinColumnSpacing = 10,
+                    MinRowSpacing = 5
+                },
+                ItemsSource = Enumerable.Range(0, 3),
+                ItemTemplate = CreateButtonTemplate()
+            };
+            var scrollViewer = new ScrollViewer
+            {
+                Width = 50,
+                Height = 160,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                Content = repeater
+            };
+
+            using var host = new TestWindowHost(scrollViewer, width: 110, height: 220);
+            host.UpdateLayout();
+
+            AssertLayoutSlot((FrameworkElement)repeater.TryGetElement(0)!, new Rect(0, 0, 100, 50));
+            AssertLayoutSlot((FrameworkElement)repeater.TryGetElement(1)!, new Rect(0, 55, 100, 50));
+            AssertLayoutSlot((FrameworkElement)repeater.TryGetElement(2)!, new Rect(0, 110, 100, 50));
+            Assert.IsFalse(double.IsNaN(repeater.DesiredSize.Width));
+            Assert.IsFalse(double.IsInfinity(repeater.DesiredSize.Width));
         });
     }
 

--- a/test/ModernWpf.WinUI.Tests/Repeater/RepeaterSourceAuditTests.cs
+++ b/test/ModernWpf.WinUI.Tests/Repeater/RepeaterSourceAuditTests.cs
@@ -20,8 +20,44 @@ public class RepeaterSourceAuditTests
         var galleryFactory = Read(repoRoot, "ModernWpf.Gallery", "Pages", "CollectionsSampleFactory.cs");
         var galleryTests = Read(repoRoot, "test", "ModernWpf.Gallery.Tests", "GalleryAutomationHookTests.cs");
         var harness = Read(repoRoot, "tools", "visual-checks", "Run-GalleryVisualChecks.ps1");
+        var uniformGridState = Read(
+            repoRoot,
+            "ModernWpf.Controls",
+            "Repeater",
+            "Layouts",
+            "UniformGridLayout",
+            "UniformGridLayoutState.cs");
+        var layoutTests = Read(
+            repoRoot,
+            "test",
+            "ModernWpf.WinUI.Tests",
+            "Repeater",
+            "RepeaterLayoutTests.cs");
+        var itemsRepeater = Read(
+            repoRoot,
+            "ModernWpf.Controls",
+            "Repeater",
+            "ItemsRepeater",
+            "ItemsRepeater.cs");
+        var viewManager = Read(
+            repoRoot,
+            "ModernWpf.Controls",
+            "Repeater",
+            "ItemsRepeater",
+            "ViewManager.cs");
+        var recyclePool = Read(
+            repoRoot,
+            "ModernWpf.Controls",
+            "Repeater",
+            "ItemsRepeater",
+            "ItemTemplate",
+            "RecyclePool.cs");
 
         StringAssert.Contains(audit, "de3e767333c2f0717a6a70cb22bd192ced5ad885");
+        StringAssert.Contains(audit, "eb75504a1978df0d37a3ad4574d6f72bf4d21583");
+        StringAssert.Contains(audit, "a97562621a1d1ea397a38a3f512c9eef99db52d8");
+        StringAssert.Contains(audit, "bfc240e263b935e645b00f1b50de97284f4954bf");
+        StringAssert.Contains(audit, "fce9db16349395cd9617ed8dc08ab40df1f46415");
         StringAssert.Contains(audit, "c70471c511a0168b61dcca13af9556465f26b673");
         StringAssert.Contains(audit, "8463f45162149de0ec3ad7df752596893fe3e13e");
         StringAssert.Contains(audit, "262cf0f1f5dcbaf366ac2cb426713e4a961fc7be");
@@ -71,6 +107,13 @@ public class RepeaterSourceAuditTests
         StringAssert.Contains(automationTests, "AutomationPeerReportsOnlyRealizedChildrenInItemIndexOrderLikeWinUI");
         StringAssert.Contains(automationTests, "context.RecycleElement(element1);");
         StringAssert.Contains(automationTests, "Assert.AreSame(group.Children[1], owners[2]);");
+        StringAssert.Contains(uniformGridState, "(uint)Math.Max(1.0, availableSizeMinor /");
+        StringAssert.Contains(layoutTests, "UniformGridLayoutFloorsNarrowAvailableWidthAtOneItemPerLine");
+        StringAssert.Contains(layoutTests, "NonVirtualItemsSourceReplacementRecyclesWithoutStaleOwner");
+        StringAssert.Contains(itemsRepeater, "ViewManager.RecycleWithoutOwner(true);");
+        StringAssert.Contains(itemsRepeater, "ViewManager.RecycleWithoutOwner(false);");
+        StringAssert.Contains(viewManager, "context.Parent = m_recycleWithoutOwner ? null : m_owner;");
+        StringAssert.Contains(recyclePool, "m_suppressParentInference = owner == null;");
 
         StringAssert.Contains(galleryFactory, "Basic, non-interactive items laid out by ItemsRepeater");
         StringAssert.Contains(galleryFactory, "Virtualized, Content-Heavy Layout with Filtering and Sorting");

--- a/test/ModernWpf.WinUI.Tests/SyncMatrixTests.cs
+++ b/test/ModernWpf.WinUI.Tests/SyncMatrixTests.cs
@@ -8,14 +8,18 @@ namespace ModernWpf.WinUI.Tests;
 public class SyncMatrixTests
 {
     [TestMethod]
-    public void WinUI287SyncMatrixDocumentsSourceAndTestPolicy()
+    public void WinUI287SyncMatrixIsAPinnedHistoricalSnapshot()
     {
         var repoRoot = FindRepoRoot();
         var matrixPath = Path.Combine(repoRoot, "docs", "winui2-2.8.7-sync.md");
 
-        Assert.IsTrue(File.Exists(matrixPath), "Missing WinUI 2.8.7 sync matrix.");
+        Assert.IsTrue(File.Exists(matrixPath), "Missing historical WinUI 2.8.7 sync matrix.");
 
         var matrix = File.ReadAllText(matrixPath);
+        StringAssert.Contains(matrix, "Historical snapshot only");
+        StringAssert.Contains(matrix, "must not be used as the current behavior, API-shape, resource,");
+        StringAssert.Contains(matrix, "docs/winui3-source-parity.md");
+        StringAssert.Contains(matrix, "docs/winui3-control-source-coverage.md");
         StringAssert.Contains(matrix, "v2.8.7");
         StringAssert.Contains(matrix, "232a16e5ddfc22c9a1b79a2c51abeb9a39a94494");
         StringAssert.Contains(matrix, "ModernWpf.WinUI.Tests");
@@ -46,6 +50,23 @@ public class SyncMatrixTests
         AssertControlStatus(matrix, "NavigationView", "Source-backed WPF port");
         AssertControlStatus(matrix, "Repeater / ItemsRepeater layouts", "Source-backed WPF port");
         AssertControlStatus(matrix, "Expander", "Official WPF Fluent-backed stock control");
+    }
+
+    [TestMethod]
+    public void PreviewApiPolicyTreatsWinUIAsAuthorityWithoutFreezingPreviewOne()
+    {
+        var repoRoot = FindRepoRoot();
+        var contractPath = Path.Combine(repoRoot, "docs", "public-api-contract-1x.md");
+
+        Assert.IsTrue(File.Exists(contractPath), "Missing 1.x public API contract.");
+
+        var contract = File.ReadAllText(contractPath);
+        StringAssert.Contains(contract, "first audit, migration, and package-comparison");
+        StringAssert.Contains(contract, "does not freeze later 1.0 previews");
+        StringAssert.Contains(contract, "current applicable WinUI API shape is");
+        StringAssert.Contains(contract, "Stable `1.0.0` establishes the SemVer compatibility baseline");
+        StringAssert.Contains(contract, "ModernWpfPackageValidationBaselineVersion");
+        StringAssert.Contains(contract, "ModernWpfPreviewAuditBaselineVersion");
     }
 
     public TestContext? TestContext { get; set; }

--- a/test/ModernWpf.WinUI.Tests/TemplateParityTests.cs
+++ b/test/ModernWpf.WinUI.Tests/TemplateParityTests.cs
@@ -622,23 +622,78 @@ public class TemplateParityTests
     }
 
     [TestMethod]
-    public void WinUI3SourceAuditDocumentsPinCurrentProductAuthority()
+    public void WinUI3SourceAuthorityUsesAdoptedEpochManifest()
     {
-        const string currentProductCommit = "de3e767333c2f0717a6a70cb22bd192ced5ad885";
+        const string currentProductCommit = "eb75504a1978df0d37a3ad4574d6f72bf4d21583";
+        const string currentStableCommit = "a97562621a1d1ea397a38a3f512c9eef99db52d8";
+        const string currentGalleryCommit = "f4dc3eb367f4bcecac1793829d9a221e924e5bfb";
         var repoRoot = FindRepoRoot();
         var docsDirectory = Path.Combine(repoRoot, "docs");
-        var auditFiles = Directory.GetFiles(docsDirectory, "*winui3-source-audit.md");
-        var staleAudits = auditFiles
-            .Where(path => !File.ReadAllText(path).Contains(currentProductCommit, StringComparison.Ordinal))
-            .Select(Path.GetFileName)
-            .OrderBy(name => name, StringComparer.Ordinal)
+        using var manifest = JsonDocument.Parse(File.ReadAllText(Path.Combine(
+            repoRoot,
+            "tools",
+            "upstream",
+            "upstream-sync.json")));
+        var repositories = manifest.RootElement
+            .GetProperty("repositories")
+            .EnumerateArray()
+            .ToArray();
+        var product = repositories.Single(repository =>
+            repository.GetProperty("id").GetString() == "winui-product");
+        var productTracks = product.GetProperty("tracks")
+            .EnumerateArray()
+            .ToArray();
+        var productMain = productTracks.Single(track =>
+            track.GetProperty("id").GetString() == "main");
+        var productStable = productTracks.Single(track =>
+            track.GetProperty("id").GetString() == "stable");
+        var gallery = repositories.Single(repository =>
+            repository.GetProperty("id").GetString() == "winui-gallery");
+        var galleryMain = gallery.GetProperty("tracks")
+            .EnumerateArray()
+            .Single(track => track.GetProperty("id").GetString() == "main");
+
+        Assert.AreEqual(
+            currentProductCommit,
+            productMain.GetProperty("epochTarget").GetProperty("revision").GetString());
+        Assert.AreEqual(
+            currentStableCommit,
+            productStable.GetProperty("epochTarget").GetProperty("revision").GetString());
+        Assert.AreEqual(
+            currentGalleryCommit,
+            galleryMain.GetProperty("epochTarget").GetProperty("revision").GetString());
+
+        var manifestAudits = manifest.RootElement
+            .GetProperty("families")
+            .EnumerateArray()
+            .SelectMany(family => family
+                .GetProperty("auditDocuments")
+                .EnumerateArray())
+            .Select(document => document.GetString() ?? string.Empty)
+            .Where(path => Path.GetFileName(path).EndsWith(
+                "winui3-source-audit.md",
+                StringComparison.Ordinal))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+        var auditFiles = Directory
+            .GetFiles(docsDirectory, "*winui3-source-audit.md")
+            .Select(path => Path.GetRelativePath(repoRoot, path).Replace('\\', '/'))
+            .OrderBy(path => path, StringComparer.Ordinal)
             .ToArray();
 
         Assert.IsTrue(auditFiles.Length >= 30,
             "The current WinUI source-audit inventory unexpectedly shrank.");
-        Assert.IsFalse(staleAudits.Any(),
-            $"WinUI 3 source audits missing current product authority {currentProductCommit}: " +
-            string.Join("; ", staleAudits));
+        CollectionAssert.AreEqual(
+            auditFiles,
+            manifestAudits,
+            "Every current WinUI source audit must map exactly once in the upstream manifest.");
+
+        var epochDocument = File.ReadAllText(Path.Combine(
+            docsDirectory,
+            "winui3-sync-2026-07-29.md"));
+        StringAssert.Contains(epochDocument, currentProductCommit);
+        StringAssert.Contains(epochDocument, currentStableCommit);
+        StringAssert.Contains(epochDocument, currentGalleryCommit);
     }
 
     [TestMethod]

--- a/test/ModernWpf.WinUI.Tests/TitleBar/TitleBarSourceAuditTests.cs
+++ b/test/ModernWpf.WinUI.Tests/TitleBar/TitleBarSourceAuditTests.cs
@@ -32,6 +32,9 @@ public class TitleBarSourceAuditTests
         var harness = Read(repoRoot, "tools", "visual-checks", "Run-GalleryVisualChecks.ps1");
 
         StringAssert.Contains(audit, "de3e767333c2f0717a6a70cb22bd192ced5ad885");
+        StringAssert.Contains(audit, "eb75504a1978df0d37a3ad4574d6f72bf4d21583");
+        StringAssert.Contains(audit, "a97562621a1d1ea397a38a3f512c9eef99db52d8");
+        StringAssert.Contains(audit, "54c81dcacb9d6e01a30da7c5299bfd4bf661d43e");
         StringAssert.Contains(audit, "8463f45162149de0ec3ad7df752596893fe3e13e");
         StringAssert.Contains(audit, "29f62479d5c046a0b854a5868e5a7cd484572d87");
         StringAssert.Contains(audit, "14a4a1a2b8ddc527dc4a7d5f7e743d7c2bc97db7");
@@ -64,6 +67,10 @@ public class TitleBarSourceAuditTests
         StringAssert.Contains(audit, "WindowChrome.CaptionHeight");
         StringAssert.Contains(audit, "WM_NCHITTEST");
         StringAssert.Contains(audit, "normal WPF content-font inheritance");
+        StringAssert.Contains(audit, "public V11");
+        StringAssert.Contains(audit, "`MUX_PUBLIC_V11`");
+        StringAssert.Contains(audit, "does not currently ship a WinUI `TitleBar` clone");
+        Assert.IsFalse(audit.Contains("Preview APIs add", StringComparison.Ordinal));
         Assert.IsFalse(audit.Contains("`src\\controls\\dev\\TitleBar", StringComparison.Ordinal));
 
         StringAssert.Contains(control, "return new WindowTitleBarControlAutomationPeer(this);");

--- a/test/ModernWpf.WinUI.Tests/WebView2/WebView2OptionalTests.cs
+++ b/test/ModernWpf.WinUI.Tests/WebView2/WebView2OptionalTests.cs
@@ -47,14 +47,15 @@ public class WebView2OptionalTests
     }
 
     [TestMethod]
-    public void SyncMatrixDocumentsWebView2AsOptional()
+    public void HistoricalSyncMatrixDocumentsWebView2Exclusion()
     {
         var repoRoot = FindRepoRoot();
         var matrixPath = Path.Combine(repoRoot, "docs", "winui2-2.8.7-sync.md");
 
-        Assert.IsTrue(File.Exists(matrixPath), "Missing WinUI 2.8.7 sync matrix.");
+        Assert.IsTrue(File.Exists(matrixPath), "Missing historical WinUI 2.8.7 sync matrix.");
 
         var matrix = File.ReadAllText(matrixPath);
+        StringAssert.Contains(matrix, "Historical snapshot only");
         StringAssert.Contains(matrix, "| WebView2 | Core excluded; gallery page pruned | No ModernWpf-owned control |");
         StringAssert.Contains(matrix, "WebView2 is not a ModernWpf-implemented WinUI control surface in this gallery scope");
     }

--- a/tools/upstream/Get-UpstreamDriftReport.ps1
+++ b/tools/upstream/Get-UpstreamDriftReport.ps1
@@ -1,0 +1,1168 @@
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$ManifestPath = (Join-Path $PSScriptRoot 'upstream-sync.json'),
+
+    [Parameter()]
+    [string]$OutputPath,
+
+    [Parameter()]
+    [string]$JsonOutputPath,
+
+    [Parameter()]
+    [string]$FixturePath,
+
+    [Parameter()]
+    [string]$GitHubToken = $env:GITHUB_TOKEN,
+
+    [Parameter()]
+    [string]$GeneratedAt,
+
+    [Parameter()]
+    [switch]$IncludeEpochComparison,
+
+    [Parameter()]
+    [switch]$FailOnEpochDrift,
+
+    [Parameter()]
+    [switch]$FailOnObservedDrift,
+
+    [Parameter()]
+    [switch]$FailOnIncompleteComparison
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-ObjectProperty {
+    param(
+        [Parameter(Mandatory)]
+        [object]$InputObject,
+
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [Parameter()]
+        [object]$DefaultValue = $null
+    )
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $DefaultValue
+    }
+
+    return $property.Value
+}
+
+function ConvertTo-NormalizedPath {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    return $Path.Replace('\', '/')
+}
+
+function Assert-Manifest {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Manifest,
+
+        [Parameter(Mandatory)]
+        [string]$RepositoryRoot
+    )
+
+    if ($Manifest.schemaVersion -ne 1) {
+        throw "Unsupported upstream manifest schema version '$($Manifest.schemaVersion)'."
+    }
+
+    $repositoryIds = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::Ordinal)
+
+    foreach ($repository in @($Manifest.repositories)) {
+        if (-not $repositoryIds.Add([string]$repository.id)) {
+            throw "Duplicate upstream repository id '$($repository.id)'."
+        }
+
+        foreach ($ignorePath in @($repository.ignorePaths)) {
+            if ([string]::IsNullOrWhiteSpace([string]$ignorePath.path) -or
+                ([string]$ignorePath.path).Contains('\', [StringComparison]::Ordinal) -or
+                [string]::IsNullOrWhiteSpace([string]$ignorePath.justification)) {
+                throw "Repository '$($repository.id)' has an invalid explicitly ignored path."
+            }
+        }
+
+        $trackIds = [System.Collections.Generic.HashSet[string]]::new(
+            [System.StringComparer]::Ordinal)
+
+        foreach ($track in @($repository.tracks)) {
+            if (-not $trackIds.Add([string]$track.id)) {
+                throw "Duplicate track '$($track.id)' in repository '$($repository.id)'."
+            }
+
+            foreach ($revisionName in @('reviewedBaseline', 'epochTarget')) {
+                $revision = Get-ObjectProperty -InputObject $track -Name $revisionName
+                if ($null -eq $revision -or
+                    [string]$revision.revision -notmatch '^[0-9a-f]{40}$') {
+                    throw "Track '$($repository.id)/$($track.id)' has an invalid $revisionName revision."
+                }
+            }
+
+            $epochAdoption = Get-ObjectProperty `
+                -InputObject $track `
+                -Name 'epochAdoption'
+            if ($null -eq $epochAdoption -or
+                [string]$epochAdoption.status -ne 'adopted' -or
+                [string]::IsNullOrWhiteSpace(
+                    [string]$epochAdoption.dispositionDocument)) {
+                throw "Track '$($repository.id)/$($track.id)' must have an adopted epoch with a disposition document."
+            }
+
+            $dispositionPath = Join-Path $RepositoryRoot (
+                ([string]$epochAdoption.dispositionDocument).Replace(
+                    '/',
+                    [IO.Path]::DirectorySeparatorChar))
+            if (-not (Test-Path -LiteralPath $dispositionPath -PathType Leaf)) {
+                throw "Track '$($repository.id)/$($track.id)' references missing epoch disposition '$($epochAdoption.dispositionDocument)'."
+            }
+
+            $observedKind = [string]$track.observedHead.kind
+            if ($observedKind -notin @('ref', 'latestStableRelease')) {
+                throw "Track '$($repository.id)/$($track.id)' has unsupported observed-head kind '$observedKind'."
+            }
+
+            if ($track.channel -eq 'stable') {
+                $latestStable = Get-ObjectProperty -InputObject $track -Name 'latestStableAtEpoch'
+                if ($null -eq $latestStable -or
+                    [string]$latestStable.revision -notmatch '^[0-9a-f]{40}$') {
+                    throw "Stable track '$($repository.id)/$($track.id)' must pin latestStableAtEpoch."
+                }
+
+                if ($observedKind -ne 'latestStableRelease') {
+                    throw "Stable track '$($repository.id)/$($track.id)' must use a latestStableRelease selector."
+                }
+            }
+        }
+    }
+
+    $familyIds = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::Ordinal)
+
+    foreach ($family in @($Manifest.families)) {
+        if (-not $familyIds.Add([string]$family.id)) {
+            throw "Duplicate upstream family id '$($family.id)'."
+        }
+
+        if (@($family.auditDocuments).Count -eq 0) {
+            throw "Upstream family '$($family.id)' has no audit document."
+        }
+
+        foreach ($auditDocument in @($family.auditDocuments)) {
+            $auditPath = Join-Path $RepositoryRoot (
+                ([string]$auditDocument).Replace('/', [IO.Path]::DirectorySeparatorChar))
+            if (-not (Test-Path -LiteralPath $auditPath -PathType Leaf)) {
+                throw "Upstream family '$($family.id)' references missing audit '$auditDocument'."
+            }
+        }
+
+        foreach ($watch in @($family.watches)) {
+            if (-not $repositoryIds.Contains([string]$watch.repository)) {
+                throw "Upstream family '$($family.id)' references unknown repository '$($watch.repository)'."
+            }
+
+            foreach ($path in @($watch.paths)) {
+                if ([string]::IsNullOrWhiteSpace([string]$path) -or
+                    ([string]$path).Contains('\', [StringComparison]::Ordinal)) {
+                    throw "Upstream family '$($family.id)' has invalid watched path '$path'."
+                }
+            }
+        }
+    }
+}
+
+function Invoke-GitHubApi {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Uri,
+
+        [Parameter()]
+        [string]$Token
+    )
+
+    $headers = @{
+        Accept = 'application/vnd.github+json'
+        'X-GitHub-Api-Version' = '2022-11-28'
+        'User-Agent' = 'ModernWpf-Upstream-Drift'
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($Token)) {
+        $headers.Authorization = "Bearer $Token"
+    }
+
+    return Invoke-RestMethod -Method Get -Uri $Uri -Headers $headers
+}
+
+function Get-FixtureObservedHead {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Fixture,
+
+        [Parameter(Mandatory)]
+        [string]$RepositoryId,
+
+        [Parameter(Mandatory)]
+        [string]$TrackId
+    )
+
+    $matches = @(
+        $Fixture.observedHeads |
+            Where-Object {
+                $_.repository -eq $RepositoryId -and
+                $_.track -eq $TrackId
+            })
+
+    if ($matches.Count -ne 1) {
+        throw "Fixture must contain exactly one observed head for '$RepositoryId/$TrackId'; found $($matches.Count)."
+    }
+
+    return $matches[0]
+}
+
+function Get-StableTagVersion {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Tag
+    )
+
+    $tagName = [string]$Tag.name
+    $match = [Regex]::Match(
+        $tagName,
+        '(?<version>[0-9]+\.[0-9]+\.[0-9]+)$',
+        [Text.RegularExpressions.RegexOptions]::CultureInvariant)
+    if (-not $match.Success) {
+        throw "Stable release tag '$tagName' does not end with a three-part semantic version."
+    }
+
+    return [Version]$match.Groups['version'].Value
+}
+
+function Select-LatestStableTag {
+    param(
+        [Parameter(Mandatory)]
+        [object[]]$Tags,
+
+        [Parameter(Mandatory)]
+        [string]$TagPattern
+    )
+
+    $selection = $Tags |
+        Where-Object {
+            [string]$_.name -match $TagPattern
+        } |
+        ForEach-Object {
+            [pscustomobject]@{
+                tag = $_
+                version = Get-StableTagVersion -Tag $_
+            }
+        } |
+        Sort-Object -Property version -Descending |
+        Select-Object -First 1
+
+    if ($null -eq $selection) {
+        throw "No stable release matched '$TagPattern'."
+    }
+
+    return $selection.tag
+}
+
+function ConvertTo-StableTags {
+    param(
+        [Parameter(Mandatory)]
+        [object[]]$Pages
+    )
+
+    return @(
+        foreach ($page in $Pages) {
+            foreach ($tag in @($page.tags)) {
+                [pscustomobject]@{
+                    name = [string]$tag.name
+                    revision = [string]$tag.commit.sha
+                }
+            }
+        })
+}
+
+function Get-ObservedHead {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Repository,
+
+        [Parameter(Mandatory)]
+        [object]$Track,
+
+        [Parameter()]
+        [object]$Fixture,
+
+        [Parameter()]
+        [string]$Token
+    )
+
+    $fixtureStableTags = if ($null -ne $Fixture) {
+        Get-ObjectProperty `
+            -InputObject $Fixture `
+            -Name 'stableTags' `
+            -DefaultValue @()
+    }
+    else {
+        @()
+    }
+    $fixtureStableTagPages = if ($null -ne $Fixture) {
+        Get-ObjectProperty `
+            -InputObject $Fixture `
+            -Name 'stableTagPages' `
+            -DefaultValue @()
+    }
+    else {
+        @()
+    }
+    if ($null -ne $Fixture -and
+        $Track.observedHead.kind -eq 'latestStableRelease' -and
+        @($fixtureStableTagPages).Count -gt 0) {
+        $fixturePages = @(
+            $fixtureStableTagPages |
+                Where-Object {
+                    $_.repository -eq $Repository.id -and
+                    $_.track -eq $Track.id
+                })
+        $fixtureTags = ConvertTo-StableTags -Pages $fixturePages
+        $tag = Select-LatestStableTag `
+            -Tags $fixtureTags `
+            -TagPattern ([string]$Track.observedHead.tagPattern)
+        return [pscustomobject][ordered]@{
+            repository = [string]$Repository.id
+            track = [string]$Track.id
+            revision = [string]$tag.revision
+            label = [string]$tag.name
+        }
+    }
+
+    if ($null -ne $Fixture -and
+        $Track.observedHead.kind -eq 'latestStableRelease' -and
+        @($fixtureStableTags).Count -gt 0) {
+        $tag = Select-LatestStableTag `
+            -Tags @(
+                $fixtureStableTags |
+                    Where-Object {
+                        $_.repository -eq $Repository.id -and
+                        $_.track -eq $Track.id
+                    }) `
+            -TagPattern ([string]$Track.observedHead.tagPattern)
+        return [pscustomobject][ordered]@{
+            repository = [string]$Repository.id
+            track = [string]$Track.id
+            revision = [string]$tag.revision
+            label = [string]$tag.name
+        }
+    }
+
+    if ($null -ne $Fixture) {
+        return Get-FixtureObservedHead `
+            -Fixture $Fixture `
+            -RepositoryId $Repository.id `
+            -TrackId $Track.id
+    }
+
+    $repositoryUri = "https://api.github.com/repos/$($Repository.owner)/$($Repository.name)"
+    if ($Track.observedHead.kind -eq 'ref') {
+        $ref = [string]$Track.observedHead.ref
+        $encodedRef = [Uri]::EscapeDataString($ref)
+        $commit = Invoke-GitHubApi `
+            -Uri "$repositoryUri/commits/$encodedRef" `
+            -Token $Token
+
+        return [pscustomobject][ordered]@{
+            repository = [string]$Repository.id
+            track = [string]$Track.id
+            revision = [string]$commit.sha
+            label = $ref
+        }
+    }
+
+    $tagPattern = [string]$Track.observedHead.tagPattern
+    $tagPages = [Collections.Generic.List[object]]::new()
+    $pageNumber = 1
+    do {
+        # Invoke-RestMethod returns a single Object[] pipeline item for JSON
+        # arrays. Assign first so @() enumerates the response instead of nesting
+        # the complete response as one tag.
+        $tagResponse = Invoke-GitHubApi `
+            -Uri "$repositoryUri/tags?per_page=100&page=$pageNumber" `
+            -Token $Token
+        $pageTags = @($tagResponse)
+        $tagPages.Add([pscustomobject]@{ tags = $pageTags })
+        $pageNumber++
+    }
+    while ($pageTags.Count -eq 100)
+
+    $stableTags = ConvertTo-StableTags -Pages @($tagPages)
+    $tag = Select-LatestStableTag `
+        -Tags $stableTags `
+        -TagPattern $tagPattern
+
+    return [pscustomobject][ordered]@{
+        repository = [string]$Repository.id
+        track = [string]$Track.id
+        revision = [string]$tag.revision
+        label = [string]$tag.name
+    }
+}
+
+function ConvertTo-Comparison {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Comparison
+    )
+
+    $files = @(
+        foreach ($file in @(Get-ObjectProperty -InputObject $Comparison -Name 'files' -DefaultValue @())) {
+            $previousFilename = [string](Get-ObjectProperty `
+                -InputObject $file `
+                -Name 'previous_filename' `
+                -DefaultValue '')
+            [pscustomobject][ordered]@{
+                filename = ConvertTo-NormalizedPath -Path ([string]$file.filename)
+                previousFilename = if ([string]::IsNullOrWhiteSpace($previousFilename)) {
+                    ''
+                }
+                else {
+                    ConvertTo-NormalizedPath -Path $previousFilename
+                }
+                status = [string](Get-ObjectProperty `
+                    -InputObject $file `
+                    -Name 'status' `
+                    -DefaultValue 'modified')
+            }
+        })
+
+    $isCompleteProperty = Get-ObjectProperty `
+        -InputObject $Comparison `
+        -Name 'isComplete'
+    $isComplete = if ($null -ne $isCompleteProperty) {
+        [bool]$isCompleteProperty
+    }
+    else {
+        $files.Count -lt 300
+    }
+
+    return [pscustomobject][ordered]@{
+        status = [string](Get-ObjectProperty `
+            -InputObject $Comparison `
+            -Name 'status' `
+            -DefaultValue 'unknown')
+        aheadBy = [int](Get-ObjectProperty `
+            -InputObject $Comparison `
+            -Name 'ahead_by' `
+            -DefaultValue (
+                Get-ObjectProperty `
+                    -InputObject $Comparison `
+                    -Name 'aheadBy' `
+                    -DefaultValue 0))
+        behindBy = [int](Get-ObjectProperty `
+            -InputObject $Comparison `
+            -Name 'behind_by' `
+            -DefaultValue (
+                Get-ObjectProperty `
+                    -InputObject $Comparison `
+                    -Name 'behindBy' `
+                    -DefaultValue 0))
+        totalCommits = [int](Get-ObjectProperty `
+            -InputObject $Comparison `
+            -Name 'total_commits' `
+            -DefaultValue (
+                Get-ObjectProperty `
+                    -InputObject $Comparison `
+                    -Name 'totalCommits' `
+                    -DefaultValue 0))
+        isComplete = $isComplete
+        files = $files
+    }
+}
+
+function Get-FixtureComparison {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Fixture,
+
+        [Parameter(Mandatory)]
+        [string]$RepositoryId,
+
+        [Parameter(Mandatory)]
+        [string]$BaseRevision,
+
+        [Parameter(Mandatory)]
+        [string]$HeadRevision
+    )
+
+    $matches = @(
+        $Fixture.comparisons |
+            Where-Object {
+                $_.repository -eq $RepositoryId -and
+                $_.base -eq $BaseRevision -and
+                $_.head -eq $HeadRevision
+            })
+
+    if ($matches.Count -ne 1) {
+        throw "Fixture must contain exactly one '$RepositoryId' comparison from '$BaseRevision' to '$HeadRevision'; found $($matches.Count)."
+    }
+
+    return ConvertTo-Comparison -Comparison $matches[0]
+}
+
+function Get-Comparison {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Repository,
+
+        [Parameter(Mandatory)]
+        [string]$BaseRevision,
+
+        [Parameter(Mandatory)]
+        [string]$HeadRevision,
+
+        [Parameter()]
+        [object]$Fixture,
+
+        [Parameter()]
+        [string]$Token
+    )
+
+    if ($BaseRevision -eq $HeadRevision) {
+        return [pscustomobject][ordered]@{
+            status = 'identical'
+            aheadBy = 0
+            behindBy = 0
+            totalCommits = 0
+            isComplete = $true
+            files = @()
+        }
+    }
+
+    if ($null -ne $Fixture) {
+        return Get-FixtureComparison `
+            -Fixture $Fixture `
+            -RepositoryId $Repository.id `
+            -BaseRevision $BaseRevision `
+            -HeadRevision $HeadRevision
+    }
+
+    $encodedBase = [Uri]::EscapeDataString($BaseRevision)
+    $encodedHead = [Uri]::EscapeDataString($HeadRevision)
+    $uri = "https://api.github.com/repos/$($Repository.owner)/$($Repository.name)/compare/$encodedBase...${encodedHead}?per_page=100"
+    $comparison = Invoke-GitHubApi -Uri $uri -Token $Token
+    return ConvertTo-Comparison -Comparison $comparison
+}
+
+function Get-FilePathCandidates {
+    param(
+        [Parameter(Mandatory)]
+        [object]$File
+    )
+
+    $candidates = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase)
+
+    foreach ($path in @([string]$File.filename, [string]$File.previousFilename)) {
+        if ([string]::IsNullOrWhiteSpace($path)) {
+            continue
+        }
+
+        $normalizedPath = ConvertTo-NormalizedPath -Path $path
+        [void]$candidates.Add($normalizedPath)
+        if ($normalizedPath.StartsWith('src/', [StringComparison]::OrdinalIgnoreCase)) {
+            [void]$candidates.Add($normalizedPath.Substring('src/'.Length))
+        }
+    }
+
+    return @($candidates)
+}
+
+function Test-FileMatchesPatterns {
+    param(
+        [Parameter(Mandatory)]
+        [object]$File,
+
+        [Parameter(Mandatory)]
+        [string[]]$Patterns
+    )
+
+    foreach ($candidatePath in @(Get-FilePathCandidates -File $File)) {
+        foreach ($pattern in $Patterns) {
+            if ($candidatePath -ilike [string]$pattern) {
+                return $true
+            }
+        }
+    }
+
+    return $false
+}
+
+function Get-MatchingIgnorePath {
+    param(
+        [Parameter(Mandatory)]
+        [object]$File,
+
+        [Parameter(Mandatory)]
+        [object]$Repository
+    )
+
+    $currentFile = [pscustomobject]@{
+        filename = [string]$File.filename
+        previousFilename = ''
+    }
+    $currentMatch = $null
+    foreach ($ignorePath in @($Repository.ignorePaths)) {
+        if (Test-FileMatchesPatterns `
+            -File $currentFile `
+            -Patterns @([string]$ignorePath.path)) {
+            $currentMatch = $ignorePath
+            break
+        }
+    }
+
+    if ($null -eq $currentMatch) {
+        return $null
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace([string]$File.previousFilename)) {
+        $previousFile = [pscustomobject]@{
+            filename = [string]$File.previousFilename
+            previousFilename = ''
+        }
+        $previousIsIgnored = $false
+        foreach ($ignorePath in @($Repository.ignorePaths)) {
+            if (Test-FileMatchesPatterns `
+                -File $previousFile `
+                -Patterns @([string]$ignorePath.path)) {
+                $previousIsIgnored = $true
+                break
+            }
+        }
+
+        if (-not $previousIsIgnored) {
+            return $null
+        }
+    }
+
+    return $currentMatch
+}
+
+function Get-ScopedComparison {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Manifest,
+
+        [Parameter(Mandatory)]
+        [object]$Repository,
+
+        [Parameter(Mandatory)]
+        [object]$Comparison
+    )
+
+    $matchedFiles = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::Ordinal)
+    $familyResults = @(
+        foreach ($family in @($Manifest.families)) {
+            $watches = @(
+                $family.watches |
+                    Where-Object { $_.repository -eq $Repository.id })
+            if ($watches.Count -eq 0) {
+                continue
+            }
+
+            $files = @(
+                foreach ($file in @($Comparison.files)) {
+                    $matched = $false
+                    foreach ($watch in $watches) {
+                        if (Test-FileMatchesPatterns `
+                            -File $file `
+                            -Patterns @($watch.paths)) {
+                            $matched = $true
+                            break
+                        }
+                    }
+
+                    if ($matched) {
+                        [void]$matchedFiles.Add([string]$file.filename)
+                        $file
+                    }
+                })
+
+            if ($files.Count -gt 0) {
+                [pscustomobject][ordered]@{
+                    id = [string]$family.id
+                    displayName = [string]$family.displayName
+                    auditDocuments = @($family.auditDocuments)
+                    files = $files
+                }
+            }
+        })
+
+    $ignoredFiles = @(
+        foreach ($file in @($Comparison.files)) {
+            if ($matchedFiles.Contains([string]$file.filename)) {
+                continue
+            }
+
+            $ignorePath = Get-MatchingIgnorePath `
+                -File $file `
+                -Repository $Repository
+            if ($null -ne $ignorePath) {
+                [pscustomobject][ordered]@{
+                    filename = [string]$file.filename
+                    previousFilename = [string]$file.previousFilename
+                    status = [string]$file.status
+                    ignorePattern = [string]$ignorePath.path
+                    justification = [string]$ignorePath.justification
+                }
+            }
+        })
+    $ignoredFileNames = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::Ordinal)
+    foreach ($ignoredFile in $ignoredFiles) {
+        [void]$ignoredFileNames.Add([string]$ignoredFile.filename)
+    }
+
+    $unmappedFiles = @(
+        foreach ($file in @($Comparison.files)) {
+            if (-not $matchedFiles.Contains([string]$file.filename) -and
+                -not $ignoredFileNames.Contains([string]$file.filename)) {
+                $file
+            }
+        })
+
+    return [pscustomobject][ordered]@{
+        isEvaluated = $true
+        status = [string]$Comparison.status
+        aheadBy = [int]$Comparison.aheadBy
+        behindBy = [int]$Comparison.behindBy
+        totalCommits = [int]$Comparison.totalCommits
+        isComplete = [bool]$Comparison.isComplete
+        changedFileCount = @($Comparison.files).Count
+        watchedChangedFileCount = $matchedFiles.Count
+        ignoredChangedFileCount = $ignoredFiles.Count
+        unmappedChangedFileCount = $unmappedFiles.Count
+        actionableChangedFileCount = $matchedFiles.Count + $unmappedFiles.Count
+        families = $familyResults
+        ignoredFiles = $ignoredFiles
+        unmappedFiles = $unmappedFiles
+    }
+}
+
+function Get-NotEvaluatedComparison {
+    return [pscustomobject][ordered]@{
+        isEvaluated = $false
+        status = 'notQueried'
+        aheadBy = 0
+        behindBy = 0
+        totalCommits = 0
+        isComplete = $true
+        changedFileCount = 0
+        watchedChangedFileCount = 0
+        ignoredChangedFileCount = 0
+        unmappedChangedFileCount = 0
+        actionableChangedFileCount = 0
+        families = @()
+        ignoredFiles = @()
+        unmappedFiles = @()
+    }
+}
+
+function Get-ShortRevision {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Revision
+    )
+
+    if ($Revision.Length -le 10) {
+        return $Revision
+    }
+
+    return $Revision.Substring(0, 10)
+}
+
+function ConvertTo-ReportTimestamp {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Value
+    )
+
+    $styles = [Globalization.DateTimeStyles]::AssumeUniversal -bor
+        [Globalization.DateTimeStyles]::AdjustToUniversal
+    return [DateTimeOffset]::Parse(
+        $Value,
+        [Globalization.CultureInfo]::InvariantCulture,
+        $styles)
+}
+
+function Add-PhaseMarkdown {
+    param(
+        [Parameter(Mandatory)]
+        [Text.StringBuilder]$Builder,
+
+        [Parameter(Mandatory)]
+        [string]$Title,
+
+        [Parameter(Mandatory)]
+        [object]$Phase
+    )
+
+    [void]$Builder.AppendLine("### $Title")
+    [void]$Builder.AppendLine()
+
+    if (-not $Phase.comparison.isEvaluated) {
+        [void]$Builder.AppendLine(
+            'The historical epoch comparison was not queried. The manifest pins ' +
+            'both revisions; checked-in family audits/dispositions are the durable ' +
+            'epoch record. Use `-IncludeEpochComparison` for an on-demand diagnostic.')
+        [void]$Builder.AppendLine()
+        return
+    }
+
+    [void]$Builder.AppendLine(
+        "- Comparison: ``$(Get-ShortRevision -Revision $Phase.baseRevision)`` → " +
+        "``$(Get-ShortRevision -Revision $Phase.headRevision)`` " +
+        "(``$($Phase.comparison.status)``; ahead $($Phase.comparison.aheadBy), " +
+        "behind $($Phase.comparison.behindBy)).")
+    [void]$Builder.AppendLine(
+        "- Classification: $($Phase.comparison.watchedChangedFileCount) mapped, " +
+        "$($Phase.comparison.unmappedChangedFileCount) unmapped, " +
+        "$($Phase.comparison.ignoredChangedFileCount) explicitly ignored " +
+        "of $($Phase.comparison.changedFileCount) changed files.")
+
+    if (-not $Phase.comparison.isComplete) {
+        [void]$Builder.AppendLine(
+            "- **Incomplete:** GitHub returned its 300-file comparison limit; " +
+            "review the upstream comparison directly before advancing a baseline.")
+    }
+
+    [void]$Builder.AppendLine()
+
+    if ($Phase.comparison.changedFileCount -eq 0) {
+        [void]$Builder.AppendLine("No files changed.")
+        [void]$Builder.AppendLine()
+        return
+    }
+
+    if (@($Phase.comparison.families).Count -eq 0) {
+        [void]$Builder.AppendLine("#### Mapped control families")
+        [void]$Builder.AppendLine()
+        [void]$Builder.AppendLine("No mapped control-family paths changed.")
+        [void]$Builder.AppendLine()
+    }
+    else {
+        foreach ($family in @($Phase.comparison.families)) {
+            [void]$Builder.AppendLine("#### $($family.displayName)")
+            [void]$Builder.AppendLine()
+            $audits = @($family.auditDocuments | ForEach-Object { "``$_``" })
+            [void]$Builder.AppendLine("- Audit: $($audits -join ', ')")
+            foreach ($file in @($family.files)) {
+                $rename = if ([string]::IsNullOrWhiteSpace([string]$file.previousFilename)) {
+                    ''
+                }
+                else {
+                    " (from ``$($file.previousFilename)``)"
+                }
+                [void]$Builder.AppendLine(
+                    "- ``$($file.status)`` ``$($file.filename)``$rename")
+            }
+            [void]$Builder.AppendLine()
+        }
+    }
+
+    [void]$Builder.AppendLine('#### Explicitly ignored files')
+    [void]$Builder.AppendLine()
+    if (@($Phase.comparison.ignoredFiles).Count -eq 0) {
+        [void]$Builder.AppendLine('None.')
+        [void]$Builder.AppendLine()
+    }
+    else {
+        foreach ($file in @($Phase.comparison.ignoredFiles)) {
+            [void]$Builder.AppendLine(
+                "- ``$($file.status)`` ``$($file.filename)`` matched " +
+                "``$($file.ignorePattern)`` — $($file.justification)")
+        }
+        [void]$Builder.AppendLine()
+    }
+
+    [void]$Builder.AppendLine('#### Unmapped files (action required)')
+    [void]$Builder.AppendLine()
+    if (@($Phase.comparison.unmappedFiles).Count -eq 0) {
+        [void]$Builder.AppendLine('None.')
+        [void]$Builder.AppendLine()
+    }
+    else {
+        foreach ($file in @($Phase.comparison.unmappedFiles)) {
+            $rename = if ([string]::IsNullOrWhiteSpace([string]$file.previousFilename)) {
+                ''
+            }
+            else {
+                " (from ``$($file.previousFilename)``)"
+            }
+            [void]$Builder.AppendLine(
+                "- ``$($file.status)`` ``$($file.filename)``$rename")
+        }
+        [void]$Builder.AppendLine()
+    }
+}
+
+$resolvedManifestPath = (Resolve-Path -LiteralPath $ManifestPath).Path
+$repositoryRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')).Path
+$manifestText = Get-Content -LiteralPath $resolvedManifestPath -Raw
+$manifest = $manifestText | ConvertFrom-Json
+$schemaReference = [string](Get-ObjectProperty `
+    -InputObject $manifest `
+    -Name '$schema')
+if ([string]::IsNullOrWhiteSpace($schemaReference)) {
+    throw "Upstream manifest '$resolvedManifestPath' does not declare a JSON schema."
+}
+
+$manifestDirectory = Split-Path -Parent $resolvedManifestPath
+$resolvedSchemaPath = (Resolve-Path -LiteralPath (
+    Join-Path $manifestDirectory $schemaReference)).Path
+if (-not (Test-Json `
+    -Json $manifestText `
+    -SchemaFile $resolvedSchemaPath `
+    -ErrorAction Stop)) {
+    throw "Upstream manifest '$resolvedManifestPath' does not satisfy '$resolvedSchemaPath'."
+}
+
+Assert-Manifest -Manifest $manifest -RepositoryRoot $repositoryRoot
+
+if ($FailOnEpochDrift -and -not $IncludeEpochComparison) {
+    throw '-FailOnEpochDrift requires -IncludeEpochComparison.'
+}
+
+$fixture = $null
+if (-not [string]::IsNullOrWhiteSpace($FixturePath)) {
+    $resolvedFixturePath = (Resolve-Path -LiteralPath $FixturePath).Path
+    $fixture = Get-Content -LiteralPath $resolvedFixturePath -Raw | ConvertFrom-Json
+}
+
+$generatedTimestamp = if (-not [string]::IsNullOrWhiteSpace($GeneratedAt)) {
+    ConvertTo-ReportTimestamp -Value $GeneratedAt
+}
+elseif ($null -ne $fixture -and
+    $null -ne (Get-ObjectProperty -InputObject $fixture -Name 'generatedAt')) {
+    ConvertTo-ReportTimestamp -Value ([string]$fixture.generatedAt)
+}
+else {
+    [DateTimeOffset]::UtcNow
+}
+
+$trackResults = @(
+    foreach ($repository in @($manifest.repositories)) {
+        foreach ($track in @($repository.tracks)) {
+            $observedHead = Get-ObservedHead `
+                -Repository $repository `
+                -Track $track `
+                -Fixture $fixture `
+                -Token $GitHubToken
+
+            if ([string]$observedHead.revision -notmatch '^[0-9a-f]{40}$') {
+                throw "Observed head '$($repository.id)/$($track.id)' returned invalid revision '$($observedHead.revision)'."
+            }
+
+            $epochComparison = if ($IncludeEpochComparison) {
+                $rawEpochComparison = Get-Comparison `
+                    -Repository $repository `
+                    -BaseRevision $track.reviewedBaseline.revision `
+                    -HeadRevision $track.epochTarget.revision `
+                    -Fixture $fixture `
+                    -Token $GitHubToken
+                Get-ScopedComparison `
+                    -Manifest $manifest `
+                    -Repository $repository `
+                    -Comparison $rawEpochComparison
+            }
+            else {
+                Get-NotEvaluatedComparison
+            }
+            $observedComparison = Get-Comparison `
+                -Repository $repository `
+                -BaseRevision $track.epochTarget.revision `
+                -HeadRevision $observedHead.revision `
+                -Fixture $fixture `
+                -Token $GitHubToken
+
+            [pscustomobject][ordered]@{
+                repository = [string]$repository.id
+                repositoryUrl = "https://github.com/$($repository.owner)/$($repository.name)"
+                track = [string]$track.id
+                channel = [string]$track.channel
+                reviewedBaseline = [pscustomobject][ordered]@{
+                    revision = [string]$track.reviewedBaseline.revision
+                    label = [string]$track.reviewedBaseline.label
+                }
+                epochTarget = [pscustomobject][ordered]@{
+                    revision = [string]$track.epochTarget.revision
+                    label = [string]$track.epochTarget.label
+                }
+                epochAdoption = [pscustomobject][ordered]@{
+                    status = [string]$track.epochAdoption.status
+                    dispositionDocument =
+                        [string]$track.epochAdoption.dispositionDocument
+                }
+                latestStableAtEpoch = Get-ObjectProperty `
+                    -InputObject $track `
+                    -Name 'latestStableAtEpoch'
+                observedHead = [pscustomobject][ordered]@{
+                    revision = [string]$observedHead.revision
+                    label = [string]$observedHead.label
+                    selector = [string]$track.observedHead.kind
+                }
+                epoch = [pscustomobject][ordered]@{
+                    baseRevision = [string]$track.reviewedBaseline.revision
+                    headRevision = [string]$track.epochTarget.revision
+                    comparison = $epochComparison
+                }
+                observed = [pscustomobject][ordered]@{
+                    baseRevision = [string]$track.epochTarget.revision
+                    headRevision = [string]$observedHead.revision
+                    comparison = Get-ScopedComparison `
+                        -Manifest $manifest `
+                        -Repository $repository `
+                        -Comparison $observedComparison
+                }
+            }
+        }
+    })
+
+$hasEpochDrift = @(
+    $trackResults |
+        Where-Object { $_.epoch.comparison.actionableChangedFileCount -gt 0 }
+).Count -gt 0
+$hasObservedDrift = @(
+    $trackResults |
+        Where-Object { $_.observed.comparison.actionableChangedFileCount -gt 0 }
+).Count -gt 0
+$hasEpochUnmappedDrift = @(
+    $trackResults |
+        Where-Object { $_.epoch.comparison.unmappedChangedFileCount -gt 0 }
+).Count -gt 0
+$hasObservedUnmappedDrift = @(
+    $trackResults |
+        Where-Object { $_.observed.comparison.unmappedChangedFileCount -gt 0 }
+).Count -gt 0
+$hasIncompleteComparison = @(
+    $trackResults |
+        Where-Object {
+            -not $_.epoch.comparison.isComplete -or
+            -not $_.observed.comparison.isComplete
+        }
+).Count -gt 0
+
+$report = [pscustomobject][ordered]@{
+    schemaVersion = 1
+    generatedAt = $generatedTimestamp.ToUniversalTime().ToString('O')
+    hasEpochDrift = $hasEpochDrift
+    hasObservedDrift = $hasObservedDrift
+    hasEpochUnmappedDrift = $hasEpochUnmappedDrift
+    hasObservedUnmappedDrift = $hasObservedUnmappedDrift
+    hasIncompleteComparison = $hasIncompleteComparison
+    tracks = $trackResults
+}
+
+$markdown = [Text.StringBuilder]::new()
+[void]$markdown.AppendLine('# ModernWpf upstream drift report')
+[void]$markdown.AppendLine()
+[void]$markdown.AppendLine("Generated: $($report.generatedAt)")
+[void]$markdown.AppendLine()
+[void]$markdown.AppendLine(
+    'The reviewed baseline, finite sync-epoch target, and moving observed head ' +
+    'are intentionally reported separately. This report classifies source drift; ' +
+    'it does not port, merge, or advance any baseline.')
+[void]$markdown.AppendLine()
+[void]$markdown.AppendLine('| Repository / track | Reviewed baseline | Epoch target | Observed head | Epoch mapped / unmapped / ignored | Post-epoch mapped / unmapped / ignored |')
+[void]$markdown.AppendLine('| --- | --- | --- | --- | --- | --- |')
+foreach ($trackResult in $trackResults) {
+    $epochClassification = if ($trackResult.epoch.comparison.isEvaluated) {
+        "$($trackResult.epoch.comparison.watchedChangedFileCount) / " +
+        "$($trackResult.epoch.comparison.unmappedChangedFileCount) / " +
+        "$($trackResult.epoch.comparison.ignoredChangedFileCount)"
+    }
+    else {
+        'not queried'
+    }
+    $observedClassification =
+        "$($trackResult.observed.comparison.watchedChangedFileCount) / " +
+        "$($trackResult.observed.comparison.unmappedChangedFileCount) / " +
+        "$($trackResult.observed.comparison.ignoredChangedFileCount)"
+    [void]$markdown.AppendLine(
+        "| $($trackResult.repository) / $($trackResult.track) " +
+        "| ``$(Get-ShortRevision -Revision $trackResult.reviewedBaseline.revision)`` " +
+        "| ``$(Get-ShortRevision -Revision $trackResult.epochTarget.revision)`` " +
+        "| ``$(Get-ShortRevision -Revision $trackResult.observedHead.revision)`` " +
+        "| $epochClassification " +
+        "| $observedClassification |")
+}
+[void]$markdown.AppendLine()
+
+foreach ($trackResult in $trackResults) {
+    [void]$markdown.AppendLine("## $($trackResult.repository) / $($trackResult.track)")
+    [void]$markdown.AppendLine()
+    [void]$markdown.AppendLine("- Source: $($trackResult.repositoryUrl)")
+    [void]$markdown.AppendLine(
+        "- Moving selector: ``$($trackResult.observedHead.selector)`` → " +
+        "``$($trackResult.observedHead.label)``.")
+    [void]$markdown.AppendLine(
+        "- Epoch adoption: ``$($trackResult.epochAdoption.status)``; disposition " +
+        "``$($trackResult.epochAdoption.dispositionDocument)``.")
+    [void]$markdown.AppendLine()
+
+    Add-PhaseMarkdown `
+        -Builder $markdown `
+        -Title 'Reviewed baseline → finite epoch target' `
+        -Phase $trackResult.epoch
+    Add-PhaseMarkdown `
+        -Builder $markdown `
+        -Title 'Finite epoch target → moving observed head' `
+        -Phase $trackResult.observed
+}
+
+$markdownText = $markdown.ToString()
+$jsonText = $report | ConvertTo-Json -Depth 20
+
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+    $outputDirectory = Split-Path -Parent $OutputPath
+    if (-not [string]::IsNullOrWhiteSpace($outputDirectory)) {
+        [void](New-Item -ItemType Directory -Path $outputDirectory -Force)
+    }
+    Set-Content -LiteralPath $OutputPath -Value $markdownText -Encoding utf8NoBOM
+}
+
+if (-not [string]::IsNullOrWhiteSpace($JsonOutputPath)) {
+    $jsonOutputDirectory = Split-Path -Parent $JsonOutputPath
+    if (-not [string]::IsNullOrWhiteSpace($jsonOutputDirectory)) {
+        [void](New-Item -ItemType Directory -Path $jsonOutputDirectory -Force)
+    }
+    Set-Content -LiteralPath $JsonOutputPath -Value $jsonText -Encoding utf8NoBOM
+}
+
+Write-Output $markdownText
+
+if ($FailOnIncompleteComparison -and $hasIncompleteComparison) {
+    [Console]::Error.WriteLine('At least one upstream comparison was incomplete.')
+    exit 3
+}
+
+if ($FailOnObservedDrift -and $hasObservedDrift) {
+    [Console]::Error.WriteLine(
+        'Actionable mapped or unmapped upstream changes arrived after the finite sync-epoch target.')
+    exit 2
+}
+
+if ($FailOnEpochDrift -and $hasEpochDrift) {
+    [Console]::Error.WriteLine(
+        'The finite sync epoch contains actionable mapped or unmapped changes that are not in the reviewed baseline.')
+    exit 2
+}

--- a/tools/upstream/upstream-sync.json
+++ b/tools/upstream/upstream-sync.json
@@ -1,0 +1,1177 @@
+{
+  "$schema": "./upstream-sync.schema.json",
+  "schemaVersion": 1,
+  "repositories": [
+    {
+      "id": "winui-product",
+      "owner": "microsoft",
+      "name": "microsoft-ui-xaml",
+      "ignorePaths": [
+        {
+          "path": ".devcontainer/**",
+          "justification": "Development-container configuration does not define shipped WinUI control behavior or API."
+        },
+        {
+          "path": ".github/**",
+          "justification": "Upstream GitHub automation and repository metadata do not define shipped WinUI control behavior or API."
+        },
+        {
+          "path": ".pipelines/**",
+          "justification": "Upstream pipeline configuration does not define shipped WinUI control behavior or API."
+        },
+        {
+          "path": ".gitattributes",
+          "justification": "Repository text-normalization metadata is not a WinUI control source input."
+        },
+        {
+          "path": ".gitignore",
+          "justification": "Repository ignore metadata is not a WinUI control source input."
+        },
+        {
+          "path": "CODE_OF_CONDUCT.md",
+          "justification": "Community policy is not a WinUI control source input."
+        },
+        {
+          "path": "CONTRIBUTING.md",
+          "justification": "Contributor guidance is not a WinUI control source input."
+        },
+        {
+          "path": "LICENSE",
+          "justification": "The repository license file is not a WinUI control source input."
+        },
+        {
+          "path": "README.md",
+          "justification": "The repository landing page is not a WinUI control source input."
+        },
+        {
+          "path": "SECURITY.md",
+          "justification": "Security-reporting policy is not a WinUI control source input."
+        },
+        {
+          "path": "SUPPORT.md",
+          "justification": "Support policy is not a WinUI control source input."
+        }
+      ],
+      "tracks": [
+        {
+          "id": "stable",
+          "channel": "stable",
+          "reviewedBaseline": {
+            "revision": "a97562621a1d1ea397a38a3f512c9eef99db52d8",
+            "label": "winui3/release/2.3.1"
+          },
+          "epochTarget": {
+            "revision": "a97562621a1d1ea397a38a3f512c9eef99db52d8",
+            "label": "winui3/release/2.3.1"
+          },
+          "epochAdoption": {
+            "status": "adopted",
+            "dispositionDocument": "docs/winui3-sync-2026-07-29.md"
+          },
+          "latestStableAtEpoch": {
+            "tag": "winui3/release/2.3.1",
+            "revision": "a97562621a1d1ea397a38a3f512c9eef99db52d8"
+          },
+          "observedHead": {
+            "kind": "latestStableRelease",
+            "tagPattern": "^winui3/release/[0-9]+\\.[0-9]+\\.[0-9]+$"
+          }
+        },
+        {
+          "id": "main",
+          "channel": "main",
+          "reviewedBaseline": {
+            "revision": "de3e767333c2f0717a6a70cb22bd192ced5ad885",
+            "label": "reviewed 2026-07-17 winui3/main"
+          },
+          "epochTarget": {
+            "revision": "eb75504a1978df0d37a3ad4574d6f72bf4d21583",
+            "label": "sync epoch 2026-07-30 winui3/main"
+          },
+          "epochAdoption": {
+            "status": "adopted",
+            "dispositionDocument": "docs/winui3-sync-2026-07-29.md"
+          },
+          "observedHead": {
+            "kind": "ref",
+            "ref": "winui3/main"
+          }
+        }
+      ]
+    },
+    {
+      "id": "winui-gallery",
+      "owner": "microsoft",
+      "name": "WinUI-Gallery",
+      "ignorePaths": [
+        {
+          "path": ".devcontainer/**",
+          "justification": "Development-container configuration does not define Gallery control examples."
+        },
+        {
+          "path": ".github/**",
+          "justification": "Upstream GitHub automation and repository metadata do not define Gallery control examples."
+        },
+        {
+          "path": ".pipelines/**",
+          "justification": "Upstream pipeline configuration does not define Gallery control examples."
+        },
+        {
+          "path": ".gitattributes",
+          "justification": "Repository text-normalization metadata is not a Gallery source input."
+        },
+        {
+          "path": ".gitignore",
+          "justification": "Repository ignore metadata is not a Gallery source input."
+        },
+        {
+          "path": "CODE_OF_CONDUCT.md",
+          "justification": "Community policy is not a Gallery source input."
+        },
+        {
+          "path": "CONTRIBUTING.md",
+          "justification": "Contributor guidance is not a Gallery source input."
+        },
+        {
+          "path": "LICENSE",
+          "justification": "The repository license file is not a Gallery source input."
+        },
+        {
+          "path": "README.md",
+          "justification": "The repository landing page is not a Gallery source input."
+        },
+        {
+          "path": "SECURITY.md",
+          "justification": "Security-reporting policy is not a Gallery source input."
+        },
+        {
+          "path": "SUPPORT.md",
+          "justification": "Support policy is not a Gallery source input."
+        },
+        {
+          "path": "tests/WinUIGallery.UITests/WinUIGallery.UITests.csproj",
+          "justification": "The Gallery UI-test project dependency set does not define shipped control pages, snippets, option surfaces, or behavior."
+        }
+      ],
+      "tracks": [
+        {
+          "id": "main",
+          "channel": "main",
+          "reviewedBaseline": {
+            "revision": "29f62479d5c046a0b854a5868e5a7cd484572d87",
+            "label": "reviewed 2026-07-13 main"
+          },
+          "epochTarget": {
+            "revision": "f4dc3eb367f4bcecac1793829d9a221e924e5bfb",
+            "label": "sync epoch 2026-07-30 main"
+          },
+          "epochAdoption": {
+            "status": "adopted",
+            "dispositionDocument": "docs/winui3-sync-2026-07-29.md"
+          },
+          "observedHead": {
+            "kind": "ref",
+            "ref": "main"
+          }
+        }
+      ]
+    }
+  ],
+  "families": [
+    {
+      "id": "annotated-scrollbar",
+      "displayName": "AnnotatedScrollBar",
+      "auditDocuments": [
+        "docs/annotatedscrollbar-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/AnnotatedScrollBar/**",
+            "controls/dev/Generated/AnnotatedScrollBar*",
+            "controls/dev/ScrollPresenter/ScrollPresenterPrimitives.idl"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/AnnotatedScrollBar/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "app-bar-elements",
+      "displayName": "AppBar element family",
+      "auditDocuments": [
+        "docs/appbarbutton-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/CommonStyles/AppBarButton*",
+            "controls/dev/CommonStyles/AppBarToggleButton*",
+            "controls/dev/CommonStyles/AppBarSeparator*",
+            "dxaml/xcp/dxaml/lib/AppBarButton*",
+            "dxaml/xcp/dxaml/lib/AppBarToggleButton*",
+            "dxaml/xcp/dxaml/lib/AppBarSeparator*",
+            "dxaml/xcp/dxaml/lib/AppBarElementContainer*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/AppBarButton/**",
+            "WinUIGallery/Samples/AppBarToggleButton/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "auto-suggest-box",
+      "displayName": "AutoSuggestBox",
+      "auditDocuments": [
+        "docs/autosuggestbox-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/AutoSuggestBox/**",
+            "controls/dev/Generated/AutoSuggestBox*",
+            "controls/test/MUXControlsTestApp/verification/AutoSuggestBox.xml",
+            "dxaml/test/native/external/controls/autosuggestbox/**",
+            "dxaml/xcp/dxaml/lib/AutoSuggestBox*",
+            "dxaml/xcp/tools/XCPTypesAutoGen/Modules/AutoSuggestBox/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/AutoSuggestBox/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "breadcrumb-bar",
+      "displayName": "BreadcrumbBar",
+      "auditDocuments": [
+        "docs/breadcrumbbar-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Breadcrumb/**",
+            "controls/dev/Generated/Breadcrumb*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/BreadcrumbBar/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "color-picker",
+      "displayName": "ColorPicker",
+      "auditDocuments": [
+        "docs/colorpicker-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/ColorPicker/**",
+            "controls/dev/Generated/ColorPicker*",
+            "controls/dev/Generated/ColorSpectrum*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/ColorPicker/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "command-bar",
+      "displayName": "CommandBar",
+      "auditDocuments": [
+        "docs/commandbar-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/CommonStyles/CommandBar*",
+            "controls/dev/CommonStyles/AppBarElementContainer*",
+            "dxaml/test/native/external/controls/commandbar/**",
+            "dxaml/xcp/dxaml/lib/AppBar_Partial*",
+            "dxaml/xcp/dxaml/lib/AppBarAutomationPeer*",
+            "dxaml/xcp/dxaml/lib/CommandBar*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/CommandBar/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "command-bar-flyout",
+      "displayName": "CommandBarFlyout",
+      "auditDocuments": [
+        "docs/commandbarflyout-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/CommandBarFlyout/**",
+            "controls/dev/Generated/CommandBarFlyout*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/CommandBarFlyout/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "content-dialog",
+      "displayName": "ContentDialog",
+      "auditDocuments": [
+        "docs/contentdialog-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/CommonStyles/ContentDialog*",
+            "dxaml/test/native/external/controls/contentdialog/**",
+            "dxaml/xcp/dxaml/lib/ContentDialog*",
+            "dxaml/xcp/tools/XCPTypesAutoGen/Modules/ContentDialog/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/ContentDialog/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "drop-down-button",
+      "displayName": "DropDownButton",
+      "auditDocuments": [
+        "docs/dropdownbutton-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/DropDownButton/**",
+            "controls/dev/Generated/DropDownButton*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/DropDownButton/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "flyout-base",
+      "displayName": "Flyout base and presenter",
+      "auditDocuments": [
+        "docs/flyoutbase-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/CommonStyles/FlyoutPresenter*",
+            "dxaml/xcp/dxaml/lib/FlyoutBase*",
+            "dxaml/xcp/dxaml/lib/FlyoutPresenter*",
+            "dxaml/xcp/dxaml/lib/Flyout_Partial*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/Flyout/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "hyperlink-button",
+      "displayName": "HyperlinkButton",
+      "auditDocuments": [
+        "docs/hyperlinkbutton-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/CommonStyles/HyperlinkButton*",
+            "dxaml/xcp/dxaml/lib/HyperLinkButton*",
+            "dxaml/xcp/tools/XCPTypesAutoGen/Modules/HyperlinkButton/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/HyperlinkButton/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "icon-element",
+      "displayName": "IconElement family",
+      "auditDocuments": [
+        "docs/iconelement-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/CommonStyles/BitmapIcon*",
+            "controls/dev/CommonStyles/FontIcon*",
+            "controls/dev/CommonStyles/IconElement*",
+            "controls/dev/CommonStyles/PathIcon*",
+            "controls/dev/CommonStyles/SymbolIcon*",
+            "dxaml/xcp/dxaml/lib/BitmapIcon*",
+            "dxaml/xcp/dxaml/lib/FontIcon*",
+            "dxaml/xcp/dxaml/lib/IconElement*",
+            "dxaml/xcp/dxaml/lib/PathIcon*",
+            "dxaml/xcp/dxaml/lib/SymbolIcon*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/IconElement/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "icon-source-image-icon",
+      "displayName": "IconSource and ImageIcon",
+      "auditDocuments": [
+        "docs/iconsource-imageicon-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/*IconSource*",
+            "controls/dev/Generated/ImageIcon*",
+            "controls/dev/IconSource/**",
+            "controls/dev/ImageIcon/**",
+            "dxaml/xcp/dxaml/lib/*IconSource*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/IconElement/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "info-badge",
+      "displayName": "InfoBadge",
+      "auditDocuments": [
+        "docs/infobadge-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/InfoBadge*",
+            "controls/dev/InfoBadge/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/InfoBadge/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "info-bar",
+      "displayName": "InfoBar",
+      "auditDocuments": [
+        "docs/infobar-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/InfoBar*",
+            "controls/dev/InfoBar/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/InfoBar/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "layout-chrome",
+      "displayName": "Layout chrome",
+      "auditDocuments": [
+        "docs/layout-chrome-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "dxaml/xcp/core/core/elements/Border.*",
+            "dxaml/xcp/core/core/elements/ContentPresenter.*",
+            "dxaml/xcp/core/core/elements/Grid.*",
+            "dxaml/xcp/core/core/elements/StackPanel.*",
+            "dxaml/xcp/core/core/elements/framework.*",
+            "dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.Controls.cs"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "layout-panel",
+      "displayName": "LayoutPanel",
+      "auditDocuments": [
+        "docs/layoutpanel-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/LayoutPanel*",
+            "controls/dev/LayoutPanel/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/LayoutPanel/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "list-view-grid-view",
+      "displayName": "ListView and GridView",
+      "auditDocuments": [
+        "docs/listview-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/CommonStyles/GridViewItem*",
+            "controls/dev/CommonStyles/ListViewItem*",
+            "dxaml/test/native/external/controls/listviewbaseitem/**",
+            "dxaml/test/native/external/enterprise/GridView/**",
+            "dxaml/test/native/external/enterprise/ListView/**",
+            "dxaml/xcp/dxaml/lib/GridView*",
+            "dxaml/xcp/dxaml/lib/ItemInvokeAdapter*",
+            "dxaml/xcp/dxaml/lib/ListView*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/GridView/**",
+            "WinUIGallery/Samples/ListView/**",
+            "WinUIGallery/Styles/GridViewItem.xaml"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "menu-bar",
+      "displayName": "MenuBar",
+      "auditDocuments": [
+        "docs/menubar-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/MenuBar*",
+            "controls/dev/MenuBar/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/MenuBar/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "menu-flyout",
+      "displayName": "MenuFlyout family",
+      "auditDocuments": [
+        "docs/menuflyout-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/CommonStyles/MenuFlyout*",
+            "dxaml/xcp/dxaml/lib/MenuFlyout*",
+            "dxaml/xcp/dxaml/lib/ToggleMenuFlyoutItem*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/MenuFlyout/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "navigation-view",
+      "displayName": "NavigationView",
+      "auditDocuments": [
+        "docs/navigationview-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/NavigationView*",
+            "controls/dev/NavigationView/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/NavigationView/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "number-box",
+      "displayName": "NumberBox",
+      "auditDocuments": [
+        "docs/numberbox-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/NumberBox*",
+            "controls/dev/NumberBox/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/NumberBox/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pager-control",
+      "displayName": "PagerControl",
+      "auditDocuments": [
+        "docs/pagercontrol-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/PagerControl*",
+            "controls/dev/PagerControl/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/PagerControl/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "person-picture",
+      "displayName": "PersonPicture",
+      "auditDocuments": [
+        "docs/personpicture-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/PersonPicture*",
+            "controls/dev/PersonPicture/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/PersonPicture/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "progress-bar",
+      "displayName": "ProgressBar",
+      "auditDocuments": [
+        "docs/progressbar-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/ProgressBar*",
+            "controls/dev/ProgressBar/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/ProgressBar/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "progress-ring",
+      "displayName": "ProgressRing",
+      "auditDocuments": [
+        "docs/progressring-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/ProgressRing*",
+            "controls/dev/ProgressRing/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/ProgressRing/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "radio-buttons",
+      "displayName": "RadioButtons",
+      "auditDocuments": [
+        "docs/radiobuttons-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/RadioButtons*",
+            "controls/dev/RadioButtons/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/RadioButtons/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "radio-menu-flyout-item",
+      "displayName": "RadioMenuFlyoutItem",
+      "auditDocuments": [
+        "docs/radiomenuflyoutitem-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/RadioMenuFlyoutItem*",
+            "controls/dev/RadioMenuFlyoutItem/**",
+            "dxaml/xcp/dxaml/lib/MenuFlyoutItemAutomationPeer*",
+            "dxaml/xcp/dxaml/lib/ToggleMenuFlyoutItemAutomationPeer*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/MenuFlyout/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "rating-control",
+      "displayName": "RatingControl",
+      "auditDocuments": [
+        "docs/ratingcontrol-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/RatingControl*",
+            "controls/dev/RatingControl/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/RatingControl/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "repeater",
+      "displayName": "ItemsRepeater",
+      "auditDocuments": [
+        "docs/repeater-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/ItemsRepeater*",
+            "controls/dev/Generated/Repeater*",
+            "controls/dev/Repeater/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/ItemsRepeater/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "selector-bar",
+      "displayName": "SelectorBar",
+      "auditDocuments": [
+        "docs/selectorbar-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/SelectorBar*",
+            "controls/dev/ItemContainer/**",
+            "controls/dev/ItemsView/**",
+            "controls/dev/SelectorBar/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/SelectorBar/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "split-button",
+      "displayName": "SplitButton family",
+      "auditDocuments": [
+        "docs/splitbutton-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/SplitButton*",
+            "controls/dev/Generated/ToggleSplitButton*",
+            "controls/dev/SplitButton/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/SplitButton/**",
+            "WinUIGallery/Samples/ToggleSplitButton/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "split-view",
+      "displayName": "SplitView",
+      "auditDocuments": [
+        "docs/splitview-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/SplitView/**",
+            "dxaml/xcp/dxaml/lib/SplitView*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/SplitView/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "teaching-tip",
+      "displayName": "TeachingTip",
+      "auditDocuments": [
+        "docs/teachingtip-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/TeachingTip*",
+            "controls/dev/TeachingTip/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/TeachingTip/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "toggle-switch",
+      "displayName": "ToggleSwitch",
+      "auditDocuments": [
+        "docs/toggleswitch-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/CommonStyles/ToggleSwitch*",
+            "dxaml/xcp/dxaml/lib/ToggleSwitch*",
+            "dxaml/xcp/tools/XCPTypesAutoGen/Modules/ToggleSwitch/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/ToggleSwitch/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "variable-sized-wrap-grid",
+      "displayName": "VariableSizedWrapGrid and wrap-grid family",
+      "auditDocuments": [
+        "docs/variablesizedwrapgrid-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "dxaml/xcp/dxaml/lib/ItemsWrapGrid*",
+            "dxaml/xcp/dxaml/lib/VariableSizedWrapGrid*",
+            "dxaml/xcp/dxaml/lib/WrapGrid*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/GridView/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "wrap-panel",
+      "displayName": "WrapPanel",
+      "auditDocuments": [
+        "docs/wrappanel-winui3-source-audit.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/WrapPanel*",
+            "controls/dev/WrapPanel/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/WrapPanel/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "frame-page-navigation",
+      "displayName": "Frame and Page navigation",
+      "auditDocuments": [
+        "docs/winui3-source-parity.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "dxaml/xcp/core/core/elements/Frame.*",
+            "dxaml/xcp/core/core/elements/Frame_*",
+            "dxaml/xcp/dxaml/lib/Frame.*",
+            "dxaml/xcp/dxaml/lib/Frame_*",
+            "dxaml/xcp/dxaml/lib/FrameAutomationPeer*",
+            "dxaml/xcp/dxaml/lib/FrameNavigation*",
+            "dxaml/xcp/dxaml/lib/Navigation*",
+            "dxaml/xcp/dxaml/lib/Page*",
+            "dxaml/xcp/tools/XCPTypesAutoGen/Modules/Navigation/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/Frame/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "popup-gallery",
+      "displayName": "Popup platform primitive and Gallery sample",
+      "auditDocuments": [
+        "docs/custom-popup-source-findings.md",
+        "docs/popup-winui-gallery-source-audit.md",
+        "docs/winui3-source-parity.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/CommonStyles/Popup*",
+            "dxaml/xcp/core/core/elements/Popup*",
+            "dxaml/xcp/core/inc/Popup*",
+            "dxaml/xcp/dxaml/lib/Popup*",
+            "dxaml/xcp/dxaml/lib/winrtgeneratedclasses/Popup*",
+            "dxaml/xcp/tools/XCPTypesAutoGen/Modules/Popup/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/Popup/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "theme-shadow",
+      "displayName": "ThemeShadow",
+      "auditDocuments": [
+        "docs/theme-shadow-winui3-parity.md",
+        "docs/theme-shadow-source-coverage.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/CommonStyles/Common_themeresources.xaml",
+            "dxaml/test/native/external/foundation/graphics/rendering/ThemeShadowTests.cpp",
+            "dxaml/test/resources/masters/*ThemeShadow*",
+            "dxaml/xcp/components/graphics/ProjectedShadowManager*",
+            "dxaml/xcp/components/graphics/ThemeShadow*",
+            "dxaml/xcp/core/core/elements/Popup.cpp",
+            "dxaml/xcp/dxaml/lib/ElevationHelper*",
+            "dxaml/xcp/dxaml/lib/ThemeShadow*"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/Samples/ThemeShadow/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "title-bar",
+      "displayName": "TitleBar",
+      "auditDocuments": [
+        "docs/titlebar-winui3-gallery-parity.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "controls/dev/Generated/TitleBar*",
+            "controls/dev/TitleBar/**"
+          ]
+        },
+        {
+          "repository": "winui-gallery",
+          "paths": [
+            "WinUIGallery/SampleSupport/SamplePages/TitleBar*",
+            "WinUIGallery/Samples/TitleBar/**"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "xaml-core-api-surface",
+      "displayName": "Shared XAML core API surface",
+      "auditDocuments": [
+        "docs/winui3-source-parity.md"
+      ],
+      "watches": [
+        {
+          "repository": "winui-product",
+          "paths": [
+            "dxaml/xcp/core/core/elements/*FrameworkElement*",
+            "dxaml/xcp/core/core/elements/framework.*",
+            "dxaml/xcp/core/inc/*FrameworkElement*",
+            "dxaml/xcp/core/inc/framework.*",
+            "dxaml/xcp/dxaml/idl/**/Microsoft.UI.Xaml*.idl",
+            "dxaml/xcp/dxaml/lib/*FrameworkElement*",
+            "dxaml/xcp/dxaml/lib/winrtgeneratedclasses/*FrameworkElement*",
+            "dxaml/xcp/tools/XCPTypesAutoGen/Modules/FrameworkElement*",
+            "dxaml/xcp/tools/XCPTypesAutoGen/Modules/FrameworkElement/**",
+            "dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml*.cs"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tools/upstream/upstream-sync.schema.json
+++ b/tools/upstream/upstream-sync.schema.json
@@ -1,0 +1,302 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://modernwpf.dev/schemas/upstream-sync.schema.json",
+  "title": "ModernWpf upstream synchronization manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "repositories",
+    "families"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "repositories": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "$ref": "#/$defs/repository"
+      }
+    },
+    "families": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/family"
+      }
+    }
+  },
+  "$defs": {
+    "revision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "revision",
+        "label"
+      ],
+      "properties": {
+        "revision": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "observedRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "ref"
+      ],
+      "properties": {
+        "kind": {
+          "const": "ref"
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "observedLatestStable": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "tagPattern"
+      ],
+      "properties": {
+        "kind": {
+          "const": "latestStableRelease"
+        },
+        "tagPattern": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "track": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "channel",
+        "reviewedBaseline",
+        "epochTarget",
+        "epochAdoption",
+        "observedHead"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
+        },
+        "channel": {
+          "enum": [
+            "stable",
+            "main"
+          ]
+        },
+        "reviewedBaseline": {
+          "$ref": "#/$defs/revision"
+        },
+        "epochTarget": {
+          "$ref": "#/$defs/revision"
+        },
+        "epochAdoption": {
+          "$ref": "#/$defs/epochAdoption"
+        },
+        "latestStableAtEpoch": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "tag",
+            "revision"
+          ],
+          "properties": {
+            "tag": {
+              "type": "string",
+              "minLength": 1
+            },
+            "revision": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{40}$"
+            }
+          }
+        },
+        "observedHead": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/observedRef"
+            },
+            {
+              "$ref": "#/$defs/observedLatestStable"
+            }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "channel": {
+                "const": "stable"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "latestStableAtEpoch"
+            ],
+            "properties": {
+              "observedHead": {
+                "$ref": "#/$defs/observedLatestStable"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "epochAdoption": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "dispositionDocument"
+      ],
+      "properties": {
+        "status": {
+          "const": "adopted"
+        },
+        "dispositionDocument": {
+          "type": "string",
+          "pattern": "^docs/[^\\\\]+\\.md$"
+        }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "owner",
+        "name",
+        "ignorePaths",
+        "tracks"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ignorePaths": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ignorePath"
+          }
+        },
+        "tracks": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/track"
+          }
+        }
+      }
+    },
+    "ignorePath": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "justification"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[^\\\\]+$"
+        },
+        "justification": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "watch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "paths"
+      ],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
+        },
+        "paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^\\\\]+$"
+          }
+        }
+      }
+    },
+    "family": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "displayName",
+        "auditDocuments",
+        "watches"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
+        },
+        "displayName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "auditDocuments": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^docs/[^\\\\]+\\.md$"
+          }
+        },
+        "watches": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/watch"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- make current applicable WinUI 3 behavior and API shape authoritative throughout the 1.0 preview series, while retaining Preview 1 as the audit/migration baseline
- audit and adopt the current WinUI stable, `winui3/main`, and WinUI Gallery epochs across every existing WinUI-derived control family
- port the applicable CommandBar fractional-DPI threshold, WindowedPopup pending-open lifecycle, and ItemsRepeater ownerless-recycling fixes, with focused WPF regression coverage
- add a machine-readable upstream manifest, schema, fixtures, read-only weekly/manual drift workflow, and fail-closed drift reporter without automatic source porting
- update parity audits, API/resource governance, migration guidance, release notes, and release-readiness documentation

## Why

The prior wording treated `1.0.0-preview.1` too much like an immutable compatibility boundary. During previews, ModernWpf should follow source-audited applicable WinUI API and behavior changes, including deliberate breaks with inventory rebaselining and migration guidance. Stable `1.0.0` remains the SemVer boundary for the 1.x line.

## User and developer impact

- existing controls track current WinUI behavior with documented WPF adaptations
- future stable/main/Gallery movement is reported by control family and requires human review
- the automation never ports, commits, merges, advances pins, or opens pull requests
- no public CLR API or explicit public resource-key inventory change was applicable in this epoch

## Validation

- `dotnet restore ModernWpf.sln`: passed
- Release solution build: 0 warnings, 0 errors
- focused affected regressions: 30 WinUI tests and 1 Gallery audit test passed
- Tools: 23/23
- Theme: 20/20 on .NET 8 and 23/23 on .NET 10
- Gallery: 717/717 on both .NET 8 and .NET 10
- WinUI: 1071/1071, three consecutive final-source runs
- retained .NET Framework suite: 181 passed, 11 documented skips
- aggregate TRX validation: 4,894 passed, 11 documented skips across 9 files
- package verification: passed
- package smoke: 6/6 across `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0`, using both resource entry points
- live scheduled drift gate: clean at the three adopted upstream heads
- CommandBar primary visual crop: exact 271x48 and below the 2.5 delta gate in Light (1.70) and Dark (2.08)

The generic Light full-card visual comparison remains red because the capture host produced a 693-pixel card against a 771-pixel reference. The authoritative exact-size CommandBar crop passes, the Dark full-card comparison passes, and the unchanged Gallery host/capture geometry is documented in the epoch validation record.