### PR TITLE
Fix downstream canary environment

### DIFF
--- a/.github/workflows/downstream-canaries.yml
+++ b/.github/workflows/downstream-canaries.yml
@@ -121,7 +121,7 @@ jobs:
             -CandidatePackagePath $packages[0].FullName `
             -MSBuildDotNetRoot (Join-Path $env:RUNNER_TEMP 'dotnet-msbuild') `
             -MSBuildSdkVersion $env:DOWNSTREAM_MSBUILD_SDK_VERSION `
-            -WorkPath (Join-Path $env:RUNNER_TEMP 'modernwpf-downstream-work') `
+            -WorkPath (Join-Path $env:RUNNER_TEMP 'mw') `
             -OutputPath (Join-Path $env:RUNNER_TEMP 'modernwpf-downstream-result')
 
       - name: Publish canary summary

--- a/.github/workflows/downstream-canaries.yml
+++ b/.github/workflows/downstream-canaries.yml
@@ -13,6 +13,7 @@ concurrency:
 env:
   CI: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOWNSTREAM_MSBUILD_SDK_VERSION: 8.0.423
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED: false
 
@@ -83,10 +84,18 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Setup isolated .NET SDK for full MSBuild
+        uses: actions/setup-dotnet@v6
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}\dotnet-msbuild
+        with:
+          dotnet-version: ${{ env.DOWNSTREAM_MSBUILD_SDK_VERSION }}
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
+          dotnet-version: ${{ env.DOWNSTREAM_MSBUILD_SDK_VERSION }}
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
@@ -110,6 +119,8 @@ jobs:
           .\tools\downstream-canaries\Invoke-DownstreamCanary.ps1 `
             -CanaryId '${{ matrix.id }}' `
             -CandidatePackagePath $packages[0].FullName `
+            -MSBuildDotNetRoot (Join-Path $env:RUNNER_TEMP 'dotnet-msbuild') `
+            -MSBuildSdkVersion $env:DOWNSTREAM_MSBUILD_SDK_VERSION `
             -WorkPath (Join-Path $env:RUNNER_TEMP 'modernwpf-downstream-work') `
             -OutputPath (Join-Path $env:RUNNER_TEMP 'modernwpf-downstream-result')
 

--- a/docs/downstream-canaries.md
+++ b/docs/downstream-canaries.md
@@ -30,7 +30,9 @@ source to ModernWPF.
 2. A separate disposable `windows-2022` matrix job anonymously fetches each
    exact downstream commit and attaches it to a synthetic local branch. The
    local branch gives versioning tools a branch name without consulting or
-   trusting a moving upstream branch.
+   trusting a moving upstream branch. BililiveRecorder alone fetches the
+   pinned commit's full ancestry and tags because its build runs GitVersion;
+   the other consumers retain depth-one, tag-free fetches.
 3. The unchanged project restores and builds in `Debug` with an isolated NuGet
    cache and an explicit nuget.org-only configuration. The full-MSBuild
    .NET Framework canary pins an isolated .NET 8-only SDK resolver so its

--- a/docs/downstream-canaries.md
+++ b/docs/downstream-canaries.md
@@ -64,6 +64,11 @@ validation.
 The workflow is `workflow_dispatch` only and grants `contents: read`. Checkout
 does not persist credentials, no OIDC permission or repository secret is
 available, NuGet credential caching is disabled, and every job has a timeout.
+Every Git, .NET, and MSBuild child process starts with an empty environment and
+receives only a reviewed OS/tool-discovery allowlist plus runner-created cache
+and SDK overrides. GitHub Actions variables, tokens, feed credentials, and
+ambient credential-provider environment variables are not copied into
+downstream processes.
 Third-party MSBuild targets still execute as part of compilation, so every
 consumer runs alone on a disposable hosted runner and never in release or pull
 request jobs.

--- a/docs/downstream-canaries.md
+++ b/docs/downstream-canaries.md
@@ -28,7 +28,9 @@ source to ModernWPF.
 1. It builds one candidate `.nupkg` from the exact manually selected ModernWPF
    commit and retains that package as a workflow artifact.
 2. A separate disposable `windows-2022` matrix job anonymously fetches each
-   exact downstream commit.
+   exact downstream commit and attaches it to a synthetic local branch. The
+   local branch gives versioning tools a branch name without consulting or
+   trusting a moving upstream branch.
 3. The unchanged project restores and builds in `Debug` with an isolated NuGet
    cache and an explicit nuget.org-only configuration. The full-MSBuild
    .NET Framework canary pins an isolated .NET 8-only SDK resolver so its

--- a/docs/downstream-canaries.md
+++ b/docs/downstream-canaries.md
@@ -37,7 +37,8 @@ source to ModernWPF.
    cache and an explicit nuget.org-only configuration. The full-MSBuild
    .NET Framework canary pins an isolated .NET 8-only SDK resolver so its
    upstream `latestMajor` policy cannot select an SDK that Visual Studio 2022
-   MSBuild cannot load.
+   MSBuild cannot load. Compact temporary roots also keep restored Windows
+   metadata paths below the legacy WPF markup compiler's path limit.
 4. A second pristine checkout receives only reviewed migrations from the 0.9
    guide: replace the `ModernWpfUI` package version and, where the pinned source
    uses it, rename `SimpleStackPanel` to `StackPanelEx`. Exact file paths and

--- a/docs/downstream-canaries.md
+++ b/docs/downstream-canaries.md
@@ -19,6 +19,9 @@ historical NuGet download traffic.
 The reviewed manifest and its schema are under `tools/downstream-canaries/`.
 Changing a repository, commit, project, build tool, or migration requires a
 normal reviewed repository change. Moving branches are never used.
+OpenKh's four reviewed gitlink paths are also manifest-locked; the workflow
+checks out those exact submodule commits transiently without committing their
+source to ModernWPF.
 
 ## What the workflow does
 
@@ -27,7 +30,10 @@ normal reviewed repository change. Moving branches are never used.
 2. A separate disposable `windows-2022` matrix job anonymously fetches each
    exact downstream commit.
 3. The unchanged project restores and builds in `Debug` with an isolated NuGet
-   cache and an explicit nuget.org-only configuration.
+   cache and an explicit nuget.org-only configuration. The full-MSBuild
+   .NET Framework canary pins an isolated .NET 8-only SDK resolver so its
+   upstream `latestMajor` policy cannot select an SDK that Visual Studio 2022
+   MSBuild cannot load.
 4. A second pristine checkout receives only reviewed migrations from the 0.9
    guide: replace the `ModernWpfUI` package version and, where the pinned source
    uses it, rename `SimpleStackPanel` to `StackPanelEx`. Exact file paths and

--- a/docs/downstream-canaries.md
+++ b/docs/downstream-canaries.md
@@ -41,9 +41,10 @@ source to ModernWPF.
    metadata paths below the legacy WPF markup compiler's path limit.
 4. A second pristine checkout receives only reviewed migrations from the 0.9
    guide: replace the `ModernWpfUI` package version and, where the pinned source
-   uses it, rename `SimpleStackPanel` to `StackPanelEx`. Exact file paths and
-   occurrence counts are manifest-locked. The existing `XamlControlsResources`
-   entry remains in place as the documented staged migration path.
+   uses them, rename `SimpleStackPanel` to `StackPanelEx` and the old `TitleBar`
+   facade to `WindowTitleBar`. Exact file paths and occurrence counts are
+   manifest-locked. The existing `XamlControlsResources` entry remains in place
+   as the documented staged migration path.
 5. The candidate restores through package-source mapping that maps the exact
    `ModernWpfUI` ID to the downloaded local feed. Other dependencies may come
    from nuget.org; the candidate package cannot.

--- a/docs/release-readiness-1x.md
+++ b/docs/release-readiness-1x.md
@@ -116,6 +116,8 @@ $package = Get-ChildItem .\artifacts\ModernWpfUI.*.nupkg | Sort-Object LastWrite
 ```
 
 Build and test are intentionally serialized. Running solution build and test builds in parallel can create shared `obj` file locks in WPF projects.
+Package verification also requires the packaged `icon.png` bytes to match the
+reviewed, checked-in ModernWPF logo exactly.
 
 The WinUI run above is the complete suite. Before merge, run it three
 consecutive times from the final clean tip without retries. The retained

--- a/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
+++ b/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
@@ -44,6 +44,7 @@ namespace ModernWpf.Tools.Tests
                 "BilibiliLiveRecordDownLoader/BilibiliLiveRecordDownLoader.csproj",
                 "net10.0-windows10.0.26100.0",
                 "dotnet",
+                1,
                 Array.Empty<string>(),
                 "0.9.6",
                 "GPL-3.0",
@@ -56,6 +57,7 @@ namespace ModernWpf.Tools.Tests
                 "BililiveRecorder.WPF/BililiveRecorder.WPF.csproj",
                 "net472",
                 "msbuild",
+                0,
                 Array.Empty<string>(),
                 "0.9.4",
                 "GPL-3.0",
@@ -68,6 +70,7 @@ namespace ModernWpf.Tools.Tests
                 "OpenKh.Tools.Kh2ObjectEditor/OpenKh.Tools.Kh2ObjectEditor.csproj",
                 "net8.0-windows",
                 "dotnet",
+                1,
                 new[]
                 {
                     "ModelingToolkit",
@@ -345,6 +348,9 @@ namespace ModernWpf.Tools.Tests
             StringAssert.Contains(runner, "--no-hardlinks");
             StringAssert.Contains(runner, "'modernwpf-canary'");
             StringAssert.Contains(runner, "'-b'");
+            StringAssert.Contains(runner, "$canary.fetchDepth -eq 0");
+            StringAssert.Contains(runner, "$cloneFetchArguments += '--tags'");
+            StringAssert.Contains(runner, "$cloneFetchArguments += '--no-tags'");
             Assert.IsFalse(runner.Contains("'--branch'", StringComparison.Ordinal));
             Assert.IsFalse(runner.Contains("'--detach'", StringComparison.Ordinal));
             StringAssert.Contains(runner, "baseline-submodules");
@@ -367,6 +373,7 @@ namespace ModernWpf.Tools.Tests
             string project,
             string targetFramework,
             string buildTool,
+            int fetchDepth,
             string[] submodules,
             string baselineVersion,
             string license,
@@ -380,6 +387,7 @@ namespace ModernWpf.Tools.Tests
             Assert.AreEqual(targetFramework, RequiredString(canary, "targetFramework"));
             Assert.AreEqual(buildTool, RequiredString(canary, "buildTool"));
             Assert.AreEqual("Debug", RequiredString(canary, "configuration"));
+            Assert.AreEqual(fetchDepth, canary.GetProperty("fetchDepth").GetInt32());
             CollectionAssert.AreEqual(
                 submodules,
                 canary.GetProperty("submodules")

--- a/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
+++ b/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
@@ -44,6 +44,7 @@ namespace ModernWpf.Tools.Tests
                 "BilibiliLiveRecordDownLoader/BilibiliLiveRecordDownLoader.csproj",
                 "net10.0-windows10.0.26100.0",
                 "dotnet",
+                Array.Empty<string>(),
                 "0.9.6",
                 "GPL-3.0",
                 4);
@@ -55,6 +56,7 @@ namespace ModernWpf.Tools.Tests
                 "BililiveRecorder.WPF/BililiveRecorder.WPF.csproj",
                 "net472",
                 "msbuild",
+                Array.Empty<string>(),
                 "0.9.4",
                 "GPL-3.0",
                 3);
@@ -66,6 +68,13 @@ namespace ModernWpf.Tools.Tests
                 "OpenKh.Tools.Kh2ObjectEditor/OpenKh.Tools.Kh2ObjectEditor.csproj",
                 "net8.0-windows",
                 "dotnet",
+                new[]
+                {
+                    "ModelingToolkit",
+                    "Simple3DViewport",
+                    "XeEngine.Tools.Public",
+                    "nQuant"
+                },
                 "0.9.6",
                 "Apache-2.0",
                 0);
@@ -269,6 +278,34 @@ namespace ModernWpf.Tools.Tests
             StringAssert.Contains(workflow, "permissions:\n  contents: read");
             StringAssert.Contains(workflow, "runs-on: windows-2022");
             StringAssert.Contains(workflow, "fail-fast: false");
+            StringAssert.Contains(workflow, "DOWNSTREAM_MSBUILD_SDK_VERSION: 8.0.423");
+            StringAssert.Contains(workflow, "Setup isolated .NET SDK for full MSBuild");
+            StringAssert.Contains(
+                workflow,
+                "DOTNET_INSTALL_DIR: ${{ runner.temp }}\\dotnet-msbuild");
+            StringAssert.Contains(workflow, "global-json-file: global.json");
+            StringAssert.Contains(
+                workflow,
+                "dotnet-version: ${{ env.DOWNSTREAM_MSBUILD_SDK_VERSION }}");
+            StringAssert.Contains(
+                workflow,
+                "-MSBuildSdkVersion $env:DOWNSTREAM_MSBUILD_SDK_VERSION");
+            StringAssert.Contains(
+                workflow,
+                "-MSBuildDotNetRoot (Join-Path $env:RUNNER_TEMP 'dotnet-msbuild')");
+            var canaryJobStart = workflow.IndexOf("\n  canary:\n", StringComparison.Ordinal);
+            Assert.IsTrue(canaryJobStart > 0);
+            var packageJob = workflow[..canaryJobStart];
+            var canaryJob = workflow[canaryJobStart..];
+            Assert.IsFalse(
+                packageJob.Contains(
+                    "Setup isolated .NET SDK for full MSBuild",
+                    StringComparison.Ordinal));
+            Assert.IsTrue(
+                canaryJob.IndexOf(
+                    "Setup isolated .NET SDK for full MSBuild",
+                    StringComparison.Ordinal) <
+                canaryJob.IndexOf("\n      - name: Setup .NET\n", StringComparison.Ordinal));
             StringAssert.Contains(workflow, "persist-credentials: false");
             StringAssert.Contains(workflow, "continue-on-error: true");
             StringAssert.Contains(workflow, "if: always()");
@@ -290,6 +327,10 @@ namespace ModernWpf.Tools.Tests
             StringAssert.Contains(runner, ".nupkg.metadata");
             StringAssert.Contains(runner, "Verified local candidate source");
             StringAssert.Contains(runner, "NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED");
+            StringAssert.Contains(runner, "DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR");
+            StringAssert.Contains(runner, "DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR");
+            StringAssert.Contains(runner, "DOTNET_MSBUILD_SDK_RESOLVER_SDKS_VER");
+            StringAssert.Contains(runner, "DOTNET_MULTILEVEL_LOOKUP = '0'");
             StringAssert.Contains(runner, "$startInfo.Environment.Clear()");
             StringAssert.Contains(runner, "New-CleanProcessEnvironment");
             StringAssert.Contains(runner, "GIT_CONFIG_KEY_0 = 'credential.helper'");
@@ -302,6 +343,11 @@ namespace ModernWpf.Tools.Tests
             Assert.IsFalse(runner.Contains("'ACTIONS_RUNTIME_TOKEN'", StringComparison.Ordinal));
             StringAssert.Contains(runner, "credential.helper=");
             StringAssert.Contains(runner, "--no-hardlinks");
+            StringAssert.Contains(runner, "baseline-submodules");
+            StringAssert.Contains(runner, "candidate-submodules");
+            StringAssert.Contains(runner, "--jobs=1");
+            StringAssert.Contains(runner, "submoduleWorktree.Name)-status");
+            StringAssert.Contains(runner, "'status'");
             StringAssert.Contains(runner, "migration.patch");
             StringAssert.Contains(runner, "Set-DownstreamCanaryTextReplacement.ps1");
             Assert.IsFalse(runner.Contains("dotnet run", StringComparison.OrdinalIgnoreCase));
@@ -317,6 +363,7 @@ namespace ModernWpf.Tools.Tests
             string project,
             string targetFramework,
             string buildTool,
+            string[] submodules,
             string baselineVersion,
             string license,
             int expectedTextMigrations)
@@ -329,6 +376,12 @@ namespace ModernWpf.Tools.Tests
             Assert.AreEqual(targetFramework, RequiredString(canary, "targetFramework"));
             Assert.AreEqual(buildTool, RequiredString(canary, "buildTool"));
             Assert.AreEqual("Debug", RequiredString(canary, "configuration"));
+            CollectionAssert.AreEqual(
+                submodules,
+                canary.GetProperty("submodules")
+                    .EnumerateArray()
+                    .Select(item => item.GetString()!)
+                    .ToArray());
             Assert.AreEqual(baselineVersion, RequiredString(canary, "baselinePackageVersion"));
             Assert.AreEqual("XamlControlsResources", RequiredString(canary, "resourceEntry"));
             Assert.AreEqual(license, RequiredString(canary, "license"));

--- a/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
+++ b/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
@@ -61,7 +61,7 @@ namespace ModernWpf.Tools.Tests
                 Array.Empty<string>(),
                 "0.9.4",
                 "GPL-3.0",
-                3);
+                4);
             AssertCanary(
                 repositories,
                 "openkh-kh2-object-editor",
@@ -117,6 +117,11 @@ namespace ModernWpf.Tools.Tests
                 "bililive-recorder",
                 "BililiveRecorder.WPF/Pages/SettingsPage.xaml",
                 2);
+            AssertTitleBarMigration(
+                repositories,
+                "bililive-recorder",
+                "BililiveRecorder.WPF/NewMainWindow.xaml",
+                3);
         }
 
         [TestMethod]
@@ -428,6 +433,25 @@ namespace ModernWpf.Tools.Tests
                     RequiredString(item, "path") == path);
             Assert.AreEqual("SimpleStackPanel", RequiredString(migration, "from"));
             Assert.AreEqual("StackPanelEx", RequiredString(migration, "to"));
+            Assert.AreEqual(
+                expectedOccurrences,
+                migration.GetProperty("expectedOccurrences").GetInt32());
+        }
+
+        private static void AssertTitleBarMigration(
+            JsonElement[] repositories,
+            string id,
+            string path,
+            int expectedOccurrences)
+        {
+            var canary = repositories.Single(item => RequiredString(item, "id") == id);
+            var migration = canary.GetProperty("migrations")
+                .EnumerateArray()
+                .Single(item =>
+                    RequiredString(item, "kind") == "text-replacement" &&
+                    RequiredString(item, "path") == path);
+            Assert.AreEqual("TitleBar.", RequiredString(migration, "from"));
+            Assert.AreEqual("WindowTitleBar.", RequiredString(migration, "to"));
             Assert.AreEqual(
                 expectedOccurrences,
                 migration.GetProperty("expectedOccurrences").GetInt32());

--- a/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
+++ b/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
@@ -375,6 +375,95 @@ namespace ModernWpf.Tools.Tests
             Assert.IsFalse(runner.Contains("gh pr", StringComparison.OrdinalIgnoreCase));
         }
 
+        [TestMethod]
+        public void ChildProcessesReceiveOnlyReviewedEnvironmentVariables()
+        {
+            var repoRoot = FindRepoRoot();
+            var runner = File.ReadAllText(Path.Combine(
+                repoRoot,
+                "tools",
+                "downstream-canaries",
+                "Invoke-DownstreamCanary.ps1"));
+            const string declaration = "$allowedChildEnvironmentVariables = @(";
+            var declarationStart = runner.IndexOf(declaration, StringComparison.Ordinal);
+            Assert.IsTrue(declarationStart >= 0);
+            var declarationEnd = runner.IndexOf(
+                "\n)",
+                declarationStart,
+                StringComparison.Ordinal);
+            Assert.IsTrue(declarationEnd > declarationStart);
+
+            var allowedVariables = runner[declarationStart..declarationEnd]
+                .Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(line => line.Trim().TrimEnd(','))
+                .Where(line =>
+                    line.StartsWith("'", StringComparison.Ordinal) &&
+                    line.EndsWith("'", StringComparison.Ordinal))
+                .Select(line => line[1..^1])
+                .ToArray();
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "APPDATA",
+                    "CommonProgramFiles",
+                    "CommonProgramFiles(x86)",
+                    "CommonProgramW6432",
+                    "ComSpec",
+                    "HOMEDRIVE",
+                    "HOMEPATH",
+                    "LOCALAPPDATA",
+                    "NUMBER_OF_PROCESSORS",
+                    "OS",
+                    "Path",
+                    "PATHEXT",
+                    "PROCESSOR_ARCHITECTURE",
+                    "ProgramData",
+                    "ProgramFiles",
+                    "ProgramFiles(x86)",
+                    "ProgramW6432",
+                    "SystemDrive",
+                    "SystemRoot",
+                    "USERNAME",
+                    "USERPROFILE",
+                    "windir"
+                },
+                allowedVariables);
+
+            Assert.AreEqual(
+                1,
+                runner.Split(
+                    "[Environment]::GetEnvironmentVariable(",
+                    StringSplitOptions.None).Length - 1);
+            Assert.IsFalse(
+                runner.Contains(
+                    "[Environment]::GetEnvironmentVariables(",
+                    StringComparison.Ordinal));
+            StringAssert.Contains(runner, "$startInfo.Environment.Clear()");
+            StringAssert.Contains(
+                runner,
+                "$childEnvironment = New-CleanProcessEnvironment -Overrides $Environment");
+
+            var forbiddenVariables = new[]
+            {
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+                "ACTIONS_RUNTIME_TOKEN",
+                "AZURE_DEVOPS_EXT_PAT",
+                "GH_TOKEN",
+                "GITHUB_TOKEN",
+                "NUGET_AUTH_TOKEN",
+                "SYSTEM_ACCESSTOKEN",
+                "VSS_NUGET_EXTERNAL_FEED_ENDPOINTS"
+            };
+            foreach (var forbiddenVariable in forbiddenVariables)
+            {
+                Assert.IsFalse(
+                    allowedVariables.Contains(
+                        forbiddenVariable,
+                        StringComparer.OrdinalIgnoreCase),
+                    $"'{forbiddenVariable}' must not enter downstream child processes.");
+            }
+        }
+
         private static void AssertCanary(
             JsonElement[] repositories,
             string id,

--- a/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
+++ b/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
@@ -344,6 +344,8 @@ namespace ModernWpf.Tools.Tests
             StringAssert.Contains(runner, "credential.helper=");
             StringAssert.Contains(runner, "--no-hardlinks");
             StringAssert.Contains(runner, "'modernwpf-canary'");
+            StringAssert.Contains(runner, "'-b'");
+            Assert.IsFalse(runner.Contains("'--branch'", StringComparison.Ordinal));
             Assert.IsFalse(runner.Contains("'--detach'", StringComparison.Ordinal));
             StringAssert.Contains(runner, "baseline-submodules");
             StringAssert.Contains(runner, "candidate-submodules");

--- a/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
+++ b/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
@@ -296,6 +296,9 @@ namespace ModernWpf.Tools.Tests
             StringAssert.Contains(
                 workflow,
                 "-MSBuildDotNetRoot (Join-Path $env:RUNNER_TEMP 'dotnet-msbuild')");
+            StringAssert.Contains(
+                workflow,
+                "-WorkPath (Join-Path $env:RUNNER_TEMP 'mw')");
             var canaryJobStart = workflow.IndexOf("\n  canary:\n", StringComparison.Ordinal);
             Assert.IsTrue(canaryJobStart > 0);
             var packageJob = workflow[..canaryJobStart];
@@ -351,6 +354,8 @@ namespace ModernWpf.Tools.Tests
             StringAssert.Contains(runner, "$canary.fetchDepth -eq 0");
             StringAssert.Contains(runner, "$cloneFetchArguments += '--tags'");
             StringAssert.Contains(runner, "$cloneFetchArguments += '--no-tags'");
+            StringAssert.Contains(runner, ".Substring(0, 8)");
+            StringAssert.Contains(runner, "\"c-$runId\"");
             Assert.IsFalse(runner.Contains("'--branch'", StringComparison.Ordinal));
             Assert.IsFalse(runner.Contains("'--detach'", StringComparison.Ordinal));
             StringAssert.Contains(runner, "baseline-submodules");

--- a/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
+++ b/test/ModernWpf.Tools.Tests/DownstreamCanaryTests.cs
@@ -343,6 +343,8 @@ namespace ModernWpf.Tools.Tests
             Assert.IsFalse(runner.Contains("'ACTIONS_RUNTIME_TOKEN'", StringComparison.Ordinal));
             StringAssert.Contains(runner, "credential.helper=");
             StringAssert.Contains(runner, "--no-hardlinks");
+            StringAssert.Contains(runner, "'modernwpf-canary'");
+            Assert.IsFalse(runner.Contains("'--detach'", StringComparison.Ordinal));
             StringAssert.Contains(runner, "baseline-submodules");
             StringAssert.Contains(runner, "candidate-submodules");
             StringAssert.Contains(runner, "--jobs=1");

--- a/test/ModernWpf.Tools.Tests/ReleaseVersioningTests.cs
+++ b/test/ModernWpf.Tools.Tests/ReleaseVersioningTests.cs
@@ -299,6 +299,9 @@ namespace ModernWpf.Tools.Tests
                 iconBytes.Take(8).ToArray());
             Assert.AreEqual(128, ReadBigEndianInt32(iconBytes, 16));
             Assert.AreEqual(128, ReadBigEndianInt32(iconBytes, 20));
+            Assert.AreEqual(
+                "9D53A8A54CB8C436665E8C7764700F035CA78275790DF7CE47881D2A6409ECF0",
+                Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(iconBytes)));
             StringAssert.Contains(iconExporter, "ModernWpf.Gallery\\App.xaml");
             StringAssert.Contains(iconExporter, "ModernWpfLogoImage");
             StringAssert.Contains(iconExporter, "$pixelSize = 128");
@@ -326,6 +329,7 @@ namespace ModernWpf.Tools.Tests
             {
                 "Assert-PackageEntry \"icon.png\"",
                 "Package icon.png must be exactly 128x128",
+                "Package icon.png does not match the checked-in ModernWPF logo",
                 "release notes must be pinned to its version tag",
                 "Package readme.md is missing required content",
                 "$ExpectedRepositoryCommit",

--- a/tools/downstream-canaries/Invoke-DownstreamCanary.ps1
+++ b/tools/downstream-canaries/Invoke-DownstreamCanary.ps1
@@ -826,7 +826,7 @@ try {
                 '-C',
                 $baselineRoot,
                 'checkout',
-                '--branch',
+                '-b',
                 'modernwpf-canary',
                 $canary.commit) `
             -WorkingDirectory $runRoot -LogDirectory $logDirectory `

--- a/tools/downstream-canaries/Invoke-DownstreamCanary.ps1
+++ b/tools/downstream-canaries/Invoke-DownstreamCanary.ps1
@@ -83,10 +83,15 @@ function Test-Manifest {
         foreach ($textMigration in @($repository.migrations | Where-Object {
             $_.kind -eq 'text-replacement'
         })) {
-            if ($textMigration.from -ne 'SimpleStackPanel' -or
-                $textMigration.to -ne 'StackPanelEx') {
+            $isStackPanelRename =
+                $textMigration.from -eq 'SimpleStackPanel' -and
+                $textMigration.to -eq 'StackPanelEx'
+            $isTitleBarRename =
+                $textMigration.from -eq 'TitleBar.' -and
+                $textMigration.to -eq 'WindowTitleBar.'
+            if (-not $isStackPanelRename -and -not $isTitleBarRename) {
                 throw "Canary '$($repository.id)' contains a text migration that is not " +
-                    'the documented SimpleStackPanel to StackPanelEx rename.'
+                    'a reviewed rename from the 0.9 migration guide.'
             }
         }
     }

--- a/tools/downstream-canaries/Invoke-DownstreamCanary.ps1
+++ b/tools/downstream-canaries/Invoke-DownstreamCanary.ps1
@@ -737,8 +737,8 @@ New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
 if ([string]::IsNullOrWhiteSpace($WorkPath)) {
     $WorkPath = Join-Path ([IO.Path]::GetTempPath()) 'modernwpf-downstream-canaries'
 }
-$runRoot = Join-Path ([IO.Path]::GetFullPath($WorkPath)) `
-    "$($canary.id)-$([Guid]::NewGuid().ToString('N'))"
+$runId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+$runRoot = Join-Path ([IO.Path]::GetFullPath($WorkPath)) "c-$runId"
 New-Item -ItemType Directory -Path $runRoot -ErrorAction Stop | Out-Null
 $baselineRoot = Join-Path $runRoot 'baseline'
 $candidateRoot = Join-Path $runRoot 'candidate'

--- a/tools/downstream-canaries/Invoke-DownstreamCanary.ps1
+++ b/tools/downstream-canaries/Invoke-DownstreamCanary.ps1
@@ -8,6 +8,10 @@ param(
 
     [string]$WorkPath,
 
+    [string]$MSBuildDotNetRoot,
+
+    [string]$MSBuildSdkVersion,
+
     [string]$ManifestPath = (Join-Path $PSScriptRoot 'downstream-canaries.json'),
 
     [string]$SchemaPath = (Join-Path $PSScriptRoot 'downstream-canaries.schema.json'),
@@ -398,6 +402,72 @@ function Add-Stage {
     })
 }
 
+function Get-MSBuildSdkResolverEnvironment {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DotNetRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+
+        [Parameter(Mandatory = $true)]
+        [string]$LogDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [Collections.Generic.List[object]]$Stages
+    )
+
+    $environment = @{}
+    $exitCode = 1
+    $message = ''
+    try {
+        $cliDirectory = [IO.Path]::GetFullPath($DotNetRoot)
+        $sdkRoot = Join-Path $cliDirectory 'sdk'
+        $installedSdks = @(
+            Get-ChildItem -LiteralPath $sdkRoot -Directory -ErrorAction Stop |
+                Select-Object -ExpandProperty Name
+        )
+        if ($installedSdks.Count -ne 1 -or $installedSdks[0] -ne $Version) {
+            throw "The isolated .NET root must contain only SDK $Version."
+        }
+
+        $sdksDirectory = Join-Path (Join-Path $sdkRoot $Version) 'Sdks'
+        if (-not (Test-Path -LiteralPath $sdksDirectory -PathType Container) -or
+            -not (Test-Path -LiteralPath (Join-Path $cliDirectory 'dotnet.exe') -PathType Leaf)) {
+            throw "The isolated .NET root does not contain SDK $Version and its CLI."
+        }
+
+        $environment = @{
+            DOTNET_MULTILEVEL_LOOKUP = '0'
+            DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR = $cliDirectory
+            DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR = $sdksDirectory
+            DOTNET_MSBUILD_SDK_RESOLVER_SDKS_VER = $Version
+        }
+        $message = "Pinned full MSBuild to .NET SDK $Version at $sdksDirectory."
+        $exitCode = 0
+    }
+    catch {
+        $message = $_.Exception.Message
+    }
+
+    [IO.File]::WriteAllText(
+        (Join-Path $LogDirectory 'msbuild-sdk-selection.log'),
+        $message,
+        [Text.UTF8Encoding]::new($false))
+    Add-Stage -List $Stages -Stage ([pscustomobject]@{
+        name = 'msbuild-sdk-selection'
+        outcome = if ($exitCode -eq 0) { 'passed' } else { 'failed' }
+        exitCode = $exitCode
+        log = 'logs/msbuild-sdk-selection.log'
+    })
+
+    return [pscustomobject]@{
+        ExitCode = $exitCode
+        Environment = $environment
+    }
+}
+
 function Test-LocalPackageSource {
     param(
         [Parameter(Mandatory = $true)]
@@ -487,12 +557,17 @@ function Invoke-RestoreAndBuild {
 
         [string]$CandidatePackageVersion,
 
-        [string]$ExpectedLocalFeed
+        [string]$ExpectedLocalFeed,
+
+        [hashtable]$BuildEnvironment = @{}
     )
 
     $projectPath = Resolve-ChildPath -Root $SourceRoot `
         -RelativePath $Canary.project -MustExist
     $environment = New-IsolatedEnvironment -Root $PhaseRoot
+    foreach ($entry in $BuildEnvironment.GetEnumerator()) {
+        $environment[$entry.Key] = [string]$entry.Value
+    }
     if ($Canary.buildTool -eq 'dotnet') {
         $restoreArguments = @(
             'restore',
@@ -641,6 +716,11 @@ if ($canaryMatches.Count -ne 1) {
     throw "Unknown downstream canary '$CanaryId'."
 }
 $canary = $canaryMatches[0]
+if ($canary.buildTool -eq 'msbuild' -and
+    ([string]::IsNullOrWhiteSpace($MSBuildDotNetRoot) -or
+        $MSBuildSdkVersion -notmatch '^\d+\.\d+\.\d+$')) {
+    throw '-MSBuildDotNetRoot and an exact stable -MSBuildSdkVersion are required for an MSBuild canary.'
+}
 $package = Get-PackageIdentity -Path $CandidatePackagePath
 if ($package.Id -ne $manifest.packageId) {
     throw "Expected candidate package '$($manifest.packageId)', found '$($package.Id)'."
@@ -774,10 +854,95 @@ try {
             throw 'Could not create the isolated candidate worktree.'
         }
 
+        if (@($canary.submodules).Count -gt 0) {
+            foreach ($submoduleWorktree in @(
+                [pscustomobject]@{ Name = 'baseline-submodules'; Root = $baselineRoot },
+                [pscustomobject]@{ Name = 'candidate-submodules'; Root = $candidateRoot }
+            )) {
+                $submodulePaths = @($canary.submodules | ForEach-Object { [string]$_ })
+                $submoduleArguments = @(
+                    '-c',
+                    'credential.helper=',
+                    '-C',
+                    $submoduleWorktree.Root,
+                    'submodule',
+                    'update',
+                    '--init',
+                    '--recursive',
+                    '--depth=1',
+                    '--jobs=1',
+                    '--') + $submodulePaths
+                $submoduleUpdate = Invoke-LoggedCommand `
+                    -Name $submoduleWorktree.Name -FileName 'git' `
+                    -Arguments $submoduleArguments `
+                    -WorkingDirectory $runRoot -LogDirectory $logDirectory `
+                    -Environment $cloneEnvironment
+                Add-Stage -List $stages -Stage $submoduleUpdate
+                if ($submoduleUpdate.exitCode -ne 0) {
+                    if (Test-EnvironmentalFailure -Stage $submoduleUpdate) {
+                        $result.classification = 'environmental'
+                        $result.summary = 'A reviewed public submodule could not be fetched because of an environmental failure.'
+                        $exitCode = 3
+                    }
+                    else {
+                        $result.classification = 'infrastructure-failure'
+                        $result.summary = 'A reviewed public submodule could not be initialized at its pinned commit.'
+                        $exitCode = 5
+                    }
+                    break
+                }
+
+                $submoduleStatus = Invoke-LoggedCommand `
+                    -Name "$($submoduleWorktree.Name)-status" -FileName 'git' `
+                    -Arguments (@(
+                        '-C',
+                        $submoduleWorktree.Root,
+                        'submodule',
+                        'status',
+                        '--recursive',
+                        '--') + $submodulePaths) `
+                    -WorkingDirectory $runRoot -LogDirectory $logDirectory `
+                    -Environment $cloneEnvironment
+                if ($submoduleStatus.exitCode -eq 0 -and
+                    $submoduleStatus.StandardOutput -match '(?m)^[\-+U]') {
+                    $submoduleStatus.exitCode = 1
+                    $submoduleStatus.outcome = 'failed'
+                }
+                Add-Stage -List $stages -Stage $submoduleStatus
+                if ($submoduleStatus.exitCode -ne 0 -or
+                    [string]::IsNullOrWhiteSpace($submoduleStatus.StandardOutput)) {
+                    $result.classification = 'infrastructure-failure'
+                    $result.summary = 'A reviewed public submodule is not checked out at its pinned gitlink.'
+                    $exitCode = 5
+                    break
+                }
+            }
+        }
+    }
+
+    if ($exitCode -eq -1) {
+        $buildEnvironment = @{}
+        if ($canary.buildTool -eq 'msbuild') {
+            $sdkResolver = Get-MSBuildSdkResolverEnvironment `
+                -DotNetRoot $MSBuildDotNetRoot -Version $MSBuildSdkVersion `
+                -LogDirectory $logDirectory -Stages $stages
+            if ($sdkResolver.ExitCode -ne 0) {
+                $result.classification = 'infrastructure-failure'
+                $result.summary = 'The pinned .NET SDK for full MSBuild could not be selected.'
+                $exitCode = 5
+            }
+            else {
+                $buildEnvironment = $sdkResolver.Environment
+            }
+        }
+    }
+
+    if ($exitCode -eq -1) {
         $baseline = Invoke-RestoreAndBuild -Canary $canary `
             -SourceRoot $baselineRoot -ConfigPath $baselineConfig `
             -PhaseRoot (Join-Path $runRoot 'baseline-state') `
-            -PhaseName 'baseline' -LogDirectory $logDirectory -Stages $stages
+            -PhaseName 'baseline' -LogDirectory $logDirectory -Stages $stages `
+            -BuildEnvironment $buildEnvironment
         if ($baseline.Restore.exitCode -eq -1) {
             $result.classification = 'infrastructure-failure'
             $result.summary = 'The configured baseline build tool could not be started.'
@@ -890,7 +1055,8 @@ try {
             -PhaseName 'candidate' -LogDirectory $logDirectory -Stages $stages `
             -CandidatePackageId $package.Id `
             -CandidatePackageVersion $package.Version `
-            -ExpectedLocalFeed (Split-Path -Parent $package.Path)
+            -ExpectedLocalFeed (Split-Path -Parent $package.Path) `
+            -BuildEnvironment $buildEnvironment
         if ($candidateBuild.Restore.exitCode -eq -1) {
             $result.classification = 'infrastructure-failure'
             $result.summary = 'The configured candidate build tool could not be started.'

--- a/tools/downstream-canaries/Invoke-DownstreamCanary.ps1
+++ b/tools/downstream-canaries/Invoke-DownstreamCanary.ps1
@@ -760,6 +760,7 @@ $result = [pscustomobject]@{
         commit = $canary.commit
         project = $canary.project
         targetFramework = $canary.targetFramework
+        fetchDepth = $canary.fetchDepth
         license = $canary.license
     }
     package = [pscustomobject]@{
@@ -800,17 +801,22 @@ try {
         throw 'Could not configure the public canary remote.'
     }
 
+    $cloneFetchArguments = @(
+        '-c',
+        'credential.helper=',
+        '-C',
+        $baselineRoot,
+        'fetch')
+    if ($canary.fetchDepth -eq 0) {
+        $cloneFetchArguments += '--tags'
+    }
+    else {
+        $cloneFetchArguments += "--depth=$($canary.fetchDepth)"
+        $cloneFetchArguments += '--no-tags'
+    }
+    $cloneFetchArguments += @('origin', $canary.commit)
     $cloneFetch = Invoke-LoggedCommand -Name 'clone-fetch' -FileName 'git' `
-        -Arguments @(
-            '-c',
-            'credential.helper=',
-            '-C',
-            $baselineRoot,
-            'fetch',
-            '--depth=1',
-            '--no-tags',
-            'origin',
-            $canary.commit) `
+        -Arguments $cloneFetchArguments `
         -WorkingDirectory $runRoot -LogDirectory $logDirectory `
         -Environment $cloneEnvironment
     Add-Stage -List $stages -Stage $cloneFetch

--- a/tools/downstream-canaries/Invoke-DownstreamCanary.ps1
+++ b/tools/downstream-canaries/Invoke-DownstreamCanary.ps1
@@ -822,7 +822,13 @@ try {
 
     if ($exitCode -eq -1) {
         $cloneCheckout = Invoke-LoggedCommand -Name 'clone-checkout' -FileName 'git' `
-            -Arguments @('-C', $baselineRoot, 'checkout', '--detach', $canary.commit) `
+            -Arguments @(
+                '-C',
+                $baselineRoot,
+                'checkout',
+                '--branch',
+                'modernwpf-canary',
+                $canary.commit) `
             -WorkingDirectory $runRoot -LogDirectory $logDirectory `
             -Environment $cloneEnvironment
         Add-Stage -List $stages -Stage $cloneCheckout

--- a/tools/downstream-canaries/downstream-canaries.json
+++ b/tools/downstream-canaries/downstream-canaries.json
@@ -12,6 +12,7 @@
       "targetFramework": "net10.0-windows10.0.26100.0",
       "buildTool": "dotnet",
       "configuration": "Debug",
+      "submodules": [],
       "baselinePackageVersion": "0.9.6",
       "resourceEntry": "XamlControlsResources",
       "license": "GPL-3.0",
@@ -60,6 +61,7 @@
       "targetFramework": "net472",
       "buildTool": "msbuild",
       "configuration": "Debug",
+      "submodules": [],
       "baselinePackageVersion": "0.9.4",
       "resourceEntry": "XamlControlsResources",
       "license": "GPL-3.0",
@@ -101,6 +103,12 @@
       "targetFramework": "net8.0-windows",
       "buildTool": "dotnet",
       "configuration": "Debug",
+      "submodules": [
+        "ModelingToolkit",
+        "Simple3DViewport",
+        "XeEngine.Tools.Public",
+        "nQuant"
+      ],
       "baselinePackageVersion": "0.9.6",
       "resourceEntry": "XamlControlsResources",
       "license": "Apache-2.0",

--- a/tools/downstream-canaries/downstream-canaries.json
+++ b/tools/downstream-canaries/downstream-canaries.json
@@ -12,6 +12,7 @@
       "targetFramework": "net10.0-windows10.0.26100.0",
       "buildTool": "dotnet",
       "configuration": "Debug",
+      "fetchDepth": 1,
       "submodules": [],
       "baselinePackageVersion": "0.9.6",
       "resourceEntry": "XamlControlsResources",
@@ -61,6 +62,7 @@
       "targetFramework": "net472",
       "buildTool": "msbuild",
       "configuration": "Debug",
+      "fetchDepth": 0,
       "submodules": [],
       "baselinePackageVersion": "0.9.4",
       "resourceEntry": "XamlControlsResources",
@@ -103,6 +105,7 @@
       "targetFramework": "net8.0-windows",
       "buildTool": "dotnet",
       "configuration": "Debug",
+      "fetchDepth": 1,
       "submodules": [
         "ModelingToolkit",
         "Simple3DViewport",

--- a/tools/downstream-canaries/downstream-canaries.json
+++ b/tools/downstream-canaries/downstream-canaries.json
@@ -94,6 +94,13 @@
           "from": "SimpleStackPanel",
           "to": "StackPanelEx",
           "expectedOccurrences": 2
+        },
+        {
+          "kind": "text-replacement",
+          "path": "BililiveRecorder.WPF/NewMainWindow.xaml",
+          "from": "TitleBar.",
+          "to": "WindowTitleBar.",
+          "expectedOccurrences": 3
         }
       ]
     },

--- a/tools/downstream-canaries/downstream-canaries.schema.json
+++ b/tools/downstream-canaries/downstream-canaries.schema.json
@@ -44,6 +44,7 @@
         "targetFramework",
         "buildTool",
         "configuration",
+        "submodules",
         "baselinePackageVersion",
         "resourceEntry",
         "license",
@@ -77,6 +78,14 @@
         },
         "configuration": {
           "const": "Debug"
+        },
+        "submodules": {
+          "type": "array",
+          "maxItems": 8,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/submodulePath"
+          }
         },
         "baselinePackageVersion": {
           "type": "string",
@@ -174,6 +183,11 @@
       "type": "string",
       "minLength": 1,
       "pattern": "^(?![A-Za-z]:)(?![/\\\\])(?!.*(?:^|[/\\\\])\\.\\.(?:[/\\\\]|$)).+\\.xaml$"
+    },
+    "submodulePath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?![A-Za-z]:)(?![/\\\\])(?!.*(?:^|[/\\\\])\\.{1,2}(?:[/\\\\]|$))[A-Za-z0-9_.-]+(?:[/\\\\][A-Za-z0-9_.-]+)*$"
     }
   }
 }

--- a/tools/downstream-canaries/downstream-canaries.schema.json
+++ b/tools/downstream-canaries/downstream-canaries.schema.json
@@ -44,6 +44,7 @@
         "targetFramework",
         "buildTool",
         "configuration",
+        "fetchDepth",
         "submodules",
         "baselinePackageVersion",
         "resourceEntry",
@@ -78,6 +79,12 @@
         },
         "configuration": {
           "const": "Debug"
+        },
+        "fetchDepth": {
+          "enum": [
+            0,
+            1
+          ]
         },
         "submodules": {
           "type": "array",

--- a/tools/release/Verify-ModernWpfPackage.ps1
+++ b/tools/release/Verify-ModernWpfPackage.ps1
@@ -493,6 +493,22 @@ try {
         $iconBuffer.Dispose()
     }
 
+    $canonicalIconPath = Join-Path $PSScriptRoot "..\..\ModernWpf.Controls\icon.png"
+    [byte[]]$canonicalIconBytes = [IO.File]::ReadAllBytes(
+        (Resolve-Path -LiteralPath $canonicalIconPath -ErrorAction Stop).Path)
+    $iconMatchesCanonicalAsset = $iconBytes.Length -eq $canonicalIconBytes.Length
+    if ($iconMatchesCanonicalAsset) {
+        for ($index = 0; $index -lt $iconBytes.Length; $index++) {
+            if ($iconBytes[$index] -ne $canonicalIconBytes[$index]) {
+                $iconMatchesCanonicalAsset = $false
+                break
+            }
+        }
+    }
+    if (-not $iconMatchesCanonicalAsset) {
+        throw "Package icon.png does not match the checked-in ModernWPF logo."
+    }
+
     [byte[]]$pngSignature = 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
     if ($iconBytes.Length -lt 24) {
         throw "Package icon.png is truncated."


### PR DESCRIPTION
## What changed

- isolate BililiveRecorder's full-MSBuild SDK resolver on .NET SDK 8.0.423 so its upstream `latestMajor` policy cannot select an SDK newer than Visual Studio 2022 MSBuild supports
- initialize and verify only OpenKh's four reviewed, commit-pinned submodule paths
- check out every pinned consumer commit on a synthetic local branch, and fetch full history only for the GitVersion-dependent BililiveRecorder canary
- use compact runner paths to stay below the legacy WPF markup compiler's path limit
- apply only manifest-locked migrations already documented for 0.9.x consumers, including `SimpleStackPanel` → `StackPanelEx` and `TitleBar` → `WindowTitleBar`
- clear each downstream child-process environment and rebuild it from a reviewed OS/tool-discovery allowlist plus isolated cache/SDK overrides; regression tests reject token and feed-credential variables
- retain commit-pinned migration-guide evidence and verify the packaged icon byte-for-byte against the reviewed ModernWPF logo

## Why

The first live downstream run on merged Preview 2 preparation ([run 31143317654](https://github.com/Kinnara/ModernWpf/actions/runs/31143317654)) exposed harness/environment defects before all candidate builds could complete:

- BililiveRecorder selected .NET SDK 10.0.302, which requires MSBuild 18, while `windows-2022` provides Visual Studio MSBuild 17.14.
- OpenKh's required gitlink dependencies were not initialized.
- BililiveRecorder also depends on Git history/branch metadata and long legacy WPF tool paths.

The corrected harness preserves exact commit pinning, read-only permissions, no secrets, no credential cache, no application execution, and local-feed-only candidate substitution.

## Validation

- `dotnet test .\test\ModernWpf.Tools.Tests\ModernWpf.Tools.Tests.csproj --configuration Release --no-restore --maxcpucount:1` — 47 passed, 0 failed, 0 skipped
- updated package verifier passed against the existing Preview 2 `.nupkg` and `.snupkg`
- `git diff --check`
- final commit-exact [downstream canary run 31147094197](https://github.com/Kinnara/ModernWpf/actions/runs/31147094197) passed on `d623cc40322472be1e0cb15620c8d972bc516318`
  - BilibiliLiveRecordDownLoader: `migrated`
  - BililiveRecorder: `migrated`
  - OpenKh: `migrated`
  - candidate package SHA-256: `db1834d0647cd5ee03e298091b9a927893dda159dce2981b69c58555dd862002`
