### PR TITLE
Harden Gallery release evidence checks

### DIFF
--- a/test/ModernWpf.Gallery.Tests/WpfGallerySourceShapeTests.cs
+++ b/test/ModernWpf.Gallery.Tests/WpfGallerySourceShapeTests.cs
@@ -5765,6 +5765,13 @@ namespace ModernWpf.Gallery.Tests
                 "pointer disclosure click expected",
                 "if ($click.UsedAutomationFallback)",
                 "used automation fallback for {1}; pointer disclosure proof is required.");
+            AssertContainsInOrder(
+                source,
+                "return [ordered]@{",
+                "Invoked = $designExpandedClick.Clicked -and $basicInputExpandedClick.Clicked -and $designCollapsedClick.Clicked -and $basicInputCollapsedClick.Clicked",
+                "Clicks = @($designExpandedClick, $basicInputExpandedClick, $designCollapsedClick, $basicInputCollapsedClick)");
+            Assert.IsFalse(source.Contains("$samplesExpandedClick", StringComparison.Ordinal));
+            Assert.IsFalse(source.Contains("$samplesCollapsedClick", StringComparison.Ordinal));
         }
 
         [TestMethod]
@@ -5845,16 +5852,45 @@ namespace ModernWpf.Gallery.Tests
                 "$firstOpenElementBoundsHint = if ($firstOpen) { Get-FastOpenRepeatPopupBounds $trigger $control } else { \"\" }",
                 "$firstOpenElement = if ($openNames.Count -eq 0 -or ![string]::IsNullOrWhiteSpace($firstOpenElementBoundsHint)) { $null } else { Wait-ForOpenInteractionElement $window $trigger $openNames $control $openElementTimeoutMilliseconds }",
                 "$firstOpenElementAnchored = $openNames.Count -eq 0 -or (Test-ControlAllowsDetachedOpenRepeatElement $control) -or (Test-OpenInteractionElementAnchored $trigger $firstOpenElement) -or (Test-BoundingRectangleStringAnchored $trigger $firstOpenElementBoundsHint)",
+                "$firstOpenWindowHandle = Get-ElementNativeWindowHandle $firstOpenElement",
+                "$firstOpenWindow = Find-TopLevelElementByNativeWindowHandleInProcess",
+                "$firstOpenWindowIsTopLevel = $null -ne $firstOpenWindow",
+                "if ($null -ne $visualCloseContext -and $firstOpenWindowIsTopLevel)",
+                "$visualCloseContext[\"OpenWindowHandle\"] = $firstOpenWindowHandleValue",
                 "$visualCloseContext[\"Bounds\"] = $firstOpenElementBounds",
                 "$closeResult = Close-OpenInteractionElement $window $control $trigger $openNames $sampleElement $visualCloseContext $firstOpenElementBounds",
                 "$secondOpenElementBoundsHint = if ($secondOpen) { Get-FastOpenRepeatPopupBounds $secondTrigger $control } else { \"\" }",
                 "$secondOpenElementAnchored = $openNames.Count -eq 0 -or (Test-ControlAllowsDetachedOpenRepeatElement $control) -or (Test-OpenInteractionElementAnchored $secondTrigger $secondOpenElement) -or (Test-BoundingRectangleStringAnchored $secondTrigger $secondOpenElementBoundsHint)",
+                "FirstOpenWindowHandle = $firstOpenWindowHandleValue",
+                "FirstOpenWindowIsTopLevel = $firstOpenWindowIsTopLevel",
+                "CloseNativeWindowChecked = $closeNativeWindowChecked",
+                "CloseNativeWindowHidden = $closeNativeWindowHidden",
+                "CloseExpandCollapseCollapsed = $closeExpandCollapseCollapsed",
+                "CloseUiaElementGone = $closeUiaElementGone",
+                "MenuFlyoutOutputMatched = $menuFlyoutOutputMatched",
+                "MenuFlyoutItemSelectionClosed = $menuFlyoutItemSelectionClosed",
+                "MenuFlyoutPointerSelectionClosed = $menuFlyoutPointerSelectionClosed",
                 "CloseVisualChecked = $closeVisualChecked",
                 "FirstOpenElementAnchored = $firstOpenElementAnchored",
                 "SecondOpenElementAnchored = $secondOpenElementAnchored",
                 "TriggerBounds = $triggerBounds",
                 "FirstOpenElementBounds = $firstOpenElementBounds",
                 "SecondOpenElementBounds = $secondOpenElementBounds");
+            AssertContainsInOrder(
+                source,
+                "function Invoke-SampleOptionCloseAttempt($window, $button, [string]$method)",
+                "$buttonWindowHandle = Get-ElementNativeWindowHandle $button",
+                "$buttonUsesDetachedWindow = $buttonWindowHandle -ne [IntPtr]::Zero",
+                "Find-TopLevelElementByNativeWindowHandleInProcess",
+                "if (!$buttonUsesDetachedWindow)",
+                "[GalleryRecordingNative]::Activate([IntPtr]$window.Current.NativeWindowHandle)",
+                "if ($method -eq \"Invoke\")");
+            AssertContainsInOrder(
+                source,
+                "function Close-WithVerifiedSampleOption($window, $sampleElement, $trigger, [string[]]$openNames, [string]$control, [string]$name, [string]$methodName, $visualCloseContext = $null)",
+                "$methods = if ($control -eq \"MenuFlyout\" -or $control -eq \"MenuBar\" -or $control -eq \"Menu\")",
+                "@(\"Click\", \"FocusSpace\", \"Invoke\")",
+                "foreach ($method in $methods)");
             AssertContainsInOrder(
                 source,
                 "function Get-OpenRepeatCloseOptionName([string]$control)",
@@ -5905,14 +5941,33 @@ namespace ModernWpf.Gallery.Tests
                 "Close-WithVerifiedSampleOption $window $sampleElement $trigger $openNames $control $openRepeatCloseOptionName \"LeafCloseItem\" $visualCloseContext",
                 "if (Test-ControlSupportsTriggerToggleClose $control)",
                 "Method = \"TriggerToggle\"");
+            var closeStart = source.IndexOf(
+                "function Wait-ForOpenInteractionElementGone",
+                StringComparison.Ordinal);
+            var closeEnd = source.IndexOf(
+                "function Click-OpenInteractionDismissPoint",
+                closeStart,
+                StringComparison.Ordinal);
+            Assert.IsTrue(closeStart >= 0 && closeEnd > closeStart);
+            var closeSource = source.Substring(closeStart, closeEnd - closeStart);
             AssertContainsInOrder(
-                source,
-                "function Wait-ForOpenInteractionElementGone($window, $element, [string[]]$openNames, [string]$control, [int]$timeoutMilliseconds, $visualCloseContext = $null)",
-                "$visualCloseResult = Test-OpenRepeatVisualClosed $window $visualCloseContext",
-                "if ($null -ne $visualCloseResult -and $visualCloseResult.Checked)",
-                "if ($visualCloseResult.Closed)",
+                closeSource,
+                "$visualCloseContext.Contains(\"OpenWindowHandle\")",
+                "[GalleryRecordingNative]::IsVisible",
+                "if (!$popupWindowVisible)",
+                "[void](Test-OpenRepeatVisualClosed $window $visualCloseContext)",
                 "return $true",
-                "if ($null -eq $openElement)");
+                "if ((Get-ExpandCollapseStateName $element) -eq \"Collapsed\")",
+                "$visualCloseContext[\"LastCloseExpandCollapseCollapsed\"] = $true",
+                "[void](Test-OpenRepeatVisualClosed $window $visualCloseContext)",
+                "return $true",
+                "$openElement = Find-OpenInteractionElement $window $element $openNames $control",
+                "if ($null -eq $openElement)",
+                "$visualCloseContext[\"LastCloseUiaElementGone\"] = $true",
+                "[void](Test-OpenRepeatVisualClosed $window $visualCloseContext)",
+                "return $true");
+            Assert.IsFalse(closeSource.Contains("$visualCloseResult", StringComparison.Ordinal));
+            Assert.IsFalse(closeSource.Contains("if ($visualCloseResult.Closed)", StringComparison.Ordinal));
             AssertContainsInOrder(
                 source,
                 "function Close-OpenInteractionElement($window, [string]$control, $trigger, [string[]]$openNames, $sampleElement, $visualCloseContext = $null, [string]$openedBoundsHint = \"\")",
@@ -5920,16 +5975,58 @@ namespace ModernWpf.Gallery.Tests
                 "Close-WithVerifiedSampleOption $window $sampleElement $trigger $openNames $control \"Cancel\" \"DialogCancelButton\" $visualCloseContext");
             AssertContainsInOrder(
                 source,
+                "if ($control -eq \"MenuFlyout\")",
+                "Close-WithVerifiedSampleOption $window $sampleElement $trigger $openNames $control \"By rating\" \"LeafMenuItem\" $visualCloseContext",
+                "MenuFlyoutItemSelectionClosed = $true",
+                "MenuFlyoutPointerSelectionClosed = $sampleClose.Method -eq \"LeafMenuItem:Click\"",
+                "$collapseClose = Close-WithVerifiedCollapsePattern $window $trigger $openNames $control $visualCloseContext",
+                "Method = \"MenuFlyoutCollapse\"",
+                "MenuFlyoutItemSelectionClosed = $false",
+                "MenuFlyoutPointerSelectionClosed = $false",
+                "$menuFlyoutOutputMatched = $control -ne \"MenuFlyout\" -or",
+                "@(\"Sort by: rating\")",
+                "$menuFlyoutItemSelectionClosed = $control -ne \"MenuFlyout\" -or",
+                "-and $menuFlyoutOutputMatched -and $menuFlyoutItemSelectionClosed");
+            AssertContainsInOrder(
+                source,
+                "if ($control -eq \"MenuFlyout\" -and",
+                "!$interactionResult.Contains(\"MenuFlyoutItemSelectionClosed\") -or",
+                "!$interactionResult.MenuFlyoutItemSelectionClosed",
+                "!$interactionResult.Contains(\"MenuFlyoutOutputMatched\") -or",
+                "!$interactionResult.MenuFlyoutOutputMatched",
+                "$status = \"Failed\"",
+                "$notes.Add(\"MenuFlyout leaf selection did not both produce the expected output and dismiss the flyout; cleanup close does not satisfy this gate.\")");
+            AssertContainsInOrder(
+                source,
                 "function Test-ControlRequiresLiveVisualClose([string]$control)",
                 "return $control -eq \"TeachingTip\" -or",
                 "$control -eq \"ComboBox\" -or",
                 "$control -eq \"DatePicker\" -or",
                 "$control -eq \"ContentDialog\" -or",
+                "function Save-WindowVisualSnapshot($window, [string]$name, $captureRect = $null)",
+                "Copy-Item -LiteralPath $liveFramePath -Destination $path -Force",
+                "$stats = Get-ImageStats $path",
+                "if ($null -ne $stats -and $stats.NonBlank)",
+                "$stats = Get-ImageStats $path",
+                "if ($null -eq $stats -or !$stats.NonBlank)",
+                "return $null",
                 "function New-OpenRepeatVisualCloseContext($window, [string]$control)",
                 "BaselinePath = $baseline.Path",
                 "function Test-OpenRepeatVisualClosed($window, $visualCloseContext)",
                 "$closed = $null -ne $delta -and [double]$delta -le 1.0",
                 "$visualCloseContext[\"LastCloseVisualChecked\"] = $true");
+            var visualCloseStart = source.IndexOf(
+                "function Test-OpenRepeatVisualClosed",
+                StringComparison.Ordinal);
+            var visualCloseEnd = source.IndexOf(
+                "function Get-PosterFrameIntervalSeconds",
+                visualCloseStart,
+                StringComparison.Ordinal);
+            Assert.IsTrue(visualCloseStart >= 0 && visualCloseEnd > visualCloseStart);
+            var visualCloseSource = source.Substring(
+                visualCloseStart,
+                visualCloseEnd - visualCloseStart);
+            Assert.IsFalse(visualCloseSource.Contains("Closed = $true", StringComparison.Ordinal));
             AssertContainsInOrder(
                 source,
                 "function Get-OpenRepeatOpenThreshold([string]$control)",
@@ -6943,11 +7040,28 @@ namespace ModernWpf.Gallery.Tests
                 "[void](Invoke-Element $lastItem)",
                 "$case.Id -ne \"ShellClickDesignGuidanceCollapse\"",
                 "Wait-ModernWpfRouteReady");
+            var captureStart = source.IndexOf(
+                "function Capture-ModernWpf",
+                StringComparison.Ordinal);
+            var captureEnd = source.IndexOf(
+                "function Capture-OfficialWpfGalleryDirectHost",
+                captureStart,
+                StringComparison.Ordinal);
+            Assert.IsTrue(captureStart >= 0 && captureEnd > captureStart);
+            var captureSource = source.Substring(captureStart, captureEnd - captureStart);
             AssertContainsInOrder(
-                source,
+                captureSource,
+                "$contentNonBlank = $null -ne $contentCrop -and [bool]$contentCrop.NonBlank",
+                "if ([string]::IsNullOrWhiteSpace($lastException) -and",
+                "!$contentNonBlank -and",
                 "if ([string]::IsNullOrWhiteSpace($lastException)) {",
                 "$lastException = Test-ModernShellNavigationState $window $case",
-                "Status = $(if (($windowNonBlank -or $contentCrop.NonBlank) -and $contentCrop.NonBlank -and [string]::IsNullOrWhiteSpace($lastException)) { \"Passed\" } else { \"Failed\" })");
+                "if ([string]::IsNullOrWhiteSpace($lastException) -and !$contentNonBlank)",
+                "$lastException = \"ModernWpf rendered content was unavailable or blank.\"",
+                "Status = $(if ($contentNonBlank -and [string]::IsNullOrWhiteSpace($lastException)) { \"Passed\" } else { \"Failed\" })");
+            Assert.IsFalse(captureSource.Contains(
+                "Status = $(if (($windowNonBlank -or $contentCrop.NonBlank)",
+                StringComparison.Ordinal));
         }
 
         [TestMethod]

--- a/tools/visual-checks/Record-GalleryControlInteractions.ps1
+++ b/tools/visual-checks/Record-GalleryControlInteractions.ps1
@@ -90,6 +90,9 @@ public static class GalleryRecordingNative
     private static extern bool ShowWindow(IntPtr hWnd, int command);
 
     [DllImport("user32.dll")]
+    private static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
     private static extern bool SetForegroundWindow(IntPtr hWnd);
 
     [DllImport("user32.dll")]
@@ -216,6 +219,11 @@ public static class GalleryRecordingNative
     {
         ShowWindow(hWnd, SW_RESTORE);
         SetForegroundWindow(hWnd);
+    }
+
+    public static bool IsVisible(IntPtr hWnd)
+    {
+        return hWnd != IntPtr.Zero && IsWindowVisible(hWnd);
     }
 
     public static void SetTopMost(IntPtr hWnd, bool topMost)
@@ -2086,9 +2094,9 @@ function Invoke-ShellNavigationInteraction($window, $navigationView) {
     }
 
     return [ordered]@{
-        Invoked = $designExpandedClick.Clicked -and $samplesExpandedClick.Clicked -and $designCollapsedClick.Clicked -and $samplesCollapsedClick.Clicked
+        Invoked = $designExpandedClick.Clicked -and $basicInputExpandedClick.Clicked -and $designCollapsedClick.Clicked -and $basicInputCollapsedClick.Clicked
         HomeVisible = Test-ElementVisible $homeItem
-        Clicks = @($designExpandedClick, $samplesExpandedClick, $designCollapsedClick, $samplesCollapsedClick)
+        Clicks = @($designExpandedClick, $basicInputExpandedClick, $designCollapsedClick, $basicInputCollapsedClick)
         Steps = $steps.ToArray()
         ShellNavigationChanged = $failures.Count -eq 0
         Failures = $failures.ToArray()
@@ -3065,31 +3073,33 @@ function Wait-ForOpenInteractionElementGone($window, $element, [string[]]$openNa
 
     $deadline = (Get-Date).AddMilliseconds($timeoutMilliseconds)
     do {
-        $visualCloseResult = Test-OpenRepeatVisualClosed $window $visualCloseContext
-        if ($null -ne $visualCloseResult -and $visualCloseResult.Checked) {
-            if ($visualCloseResult.Closed) {
+        if ($null -ne $visualCloseContext -and
+            $visualCloseContext.Contains("OpenWindowHandle") -and
+            [int64]$visualCloseContext.OpenWindowHandle -ne 0) {
+            $popupWindowVisible = [GalleryRecordingNative]::IsVisible([IntPtr][int64]$visualCloseContext.OpenWindowHandle)
+            $visualCloseContext["LastCloseNativeWindowChecked"] = $true
+            $visualCloseContext["LastCloseNativeWindowHidden"] = !$popupWindowVisible
+            if (!$popupWindowVisible) {
+                [void](Test-OpenRepeatVisualClosed $window $visualCloseContext)
                 return $true
             }
-
-            Start-Sleep -Milliseconds 100
-            continue
         }
 
-        $openElement = if ($control -eq "Flyout" -or
-            $control -eq "ContentDialog" -or
-            $control -eq "Popup" -or
-            $control -eq "MenuFlyout" -or
-            $control -eq "CommandBar" -or
-            $control -eq "CommandBarFlyout") {
-            Find-ElementByNameInProcess $window.Current.ProcessId $openNames
+        if ((Get-ExpandCollapseStateName $element) -eq "Collapsed") {
+            if ($null -ne $visualCloseContext) {
+                $visualCloseContext["LastCloseExpandCollapseCollapsed"] = $true
+            }
+            [void](Test-OpenRepeatVisualClosed $window $visualCloseContext)
+            return $true
         }
-        else {
-            Find-OpenInteractionElement $window $element $openNames $control
-        }
+
+        $openElement = Find-OpenInteractionElement $window $element $openNames $control
         if ($null -eq $openElement) {
-            if ($null -eq $visualCloseResult -or !$visualCloseResult.Checked -or $visualCloseResult.Closed) {
-                return $true
+            if ($null -ne $visualCloseContext) {
+                $visualCloseContext["LastCloseUiaElementGone"] = $true
             }
+            [void](Test-OpenRepeatVisualClosed $window $visualCloseContext)
+            return $true
         }
 
         Start-Sleep -Milliseconds 100
@@ -3136,7 +3146,13 @@ function Invoke-SampleOptionCloseAttempt($window, $button, [string]$method) {
         return $false
     }
 
-    [GalleryRecordingNative]::Activate([IntPtr]$window.Current.NativeWindowHandle)
+    $buttonWindowHandle = Get-ElementNativeWindowHandle $button
+    $buttonUsesDetachedWindow = $buttonWindowHandle -ne [IntPtr]::Zero -and
+        [int64]$buttonWindowHandle -ne [int64]$window.Current.NativeWindowHandle -and
+        $null -ne (Find-TopLevelElementByNativeWindowHandleInProcess $window.Current.ProcessId ([int]$buttonWindowHandle))
+    if (!$buttonUsesDetachedWindow) {
+        [GalleryRecordingNative]::Activate([IntPtr]$window.Current.NativeWindowHandle)
+    }
     Start-Sleep -Milliseconds 80
 
     if ($method -eq "Invoke") {
@@ -3184,7 +3200,13 @@ function Close-WithVerifiedSampleOption($window, $sampleElement, $trigger, [stri
         }
     }
 
-    foreach ($method in @("Invoke", "FocusSpace", "Click", "Fallback")) {
+    $methods = if ($control -eq "MenuFlyout" -or $control -eq "MenuBar" -or $control -eq "Menu") {
+        @("Click", "FocusSpace", "Invoke")
+    }
+    else {
+        @("Invoke", "FocusSpace", "Click", "Fallback")
+    }
+    foreach ($method in $methods) {
         if (Invoke-SampleOptionCloseAttempt $window $button $method) {
             Start-Sleep -Milliseconds 700
             if (Wait-ForOpenInteractionElementGone $window $trigger $openNames $control 1200 $visualCloseContext) {
@@ -3444,7 +3466,22 @@ function Close-OpenInteractionElement($window, [string]$control, $trigger, [stri
     if ($control -eq "MenuFlyout") {
         $sampleClose = Close-WithVerifiedSampleOption $window $sampleElement $trigger $openNames $control "By rating" "LeafMenuItem" $visualCloseContext
         if ($sampleClose.Closed) {
-            return $sampleClose
+            return [ordered]@{
+                Closed = $true
+                Method = $sampleClose.Method
+                MenuFlyoutItemSelectionClosed = $true
+                MenuFlyoutPointerSelectionClosed = $sampleClose.Method -eq "LeafMenuItem:Click"
+            }
+        }
+
+        $collapseClose = Close-WithVerifiedCollapsePattern $window $trigger $openNames $control $visualCloseContext
+        if ($collapseClose.Closed) {
+            return [ordered]@{
+                Closed = $true
+                Method = "MenuFlyoutCollapse"
+                MenuFlyoutItemSelectionClosed = $false
+                MenuFlyoutPointerSelectionClosed = $false
+            }
         }
     }
 
@@ -4004,6 +4041,19 @@ function Invoke-OpenRepeatInteraction($window, [string]$control, $sampleElement)
         Start-Sleep -Milliseconds 450
         $firstOpenVisualSeconds = Get-RecordingElapsedSeconds
     }
+    $firstOpenWindowHandle = Get-ElementNativeWindowHandle $firstOpenElement
+    $firstOpenWindowHandleValue = [int64]$firstOpenWindowHandle
+    $firstOpenWindowIsTopLevel = $false
+    if ($firstOpenWindowHandleValue -ne 0 -and
+        $firstOpenWindowHandleValue -ne [int64]$window.Current.NativeWindowHandle) {
+        $firstOpenWindow = Find-TopLevelElementByNativeWindowHandleInProcess `
+            $window.Current.ProcessId `
+            ([int]$firstOpenWindowHandle)
+        $firstOpenWindowIsTopLevel = $null -ne $firstOpenWindow
+        if ($null -ne $visualCloseContext -and $firstOpenWindowIsTopLevel) {
+            $visualCloseContext["OpenWindowHandle"] = $firstOpenWindowHandleValue
+        }
+    }
     if ($null -eq $firstOpenVisualSeconds) {
         $firstOpenVisualSeconds = Get-RecordingElapsedSeconds
     }
@@ -4020,15 +4070,40 @@ function Invoke-OpenRepeatInteraction($window, [string]$control, $sampleElement)
     $closedVisualSeconds = Get-RecordingElapsedSeconds
     $closedToggleState = Get-ToggleStateName $trigger
     $closedElementGone = $closeResult.Closed
+    $menuFlyoutOutputMatched = $control -ne "MenuFlyout" -or
+        $null -ne (Find-ElementByNameInProcess $window.Current.ProcessId @("Sort by: rating"))
+    $menuFlyoutItemSelectionClosed = $control -ne "MenuFlyout" -or
+        ($closeResult.Contains("MenuFlyoutItemSelectionClosed") -and $closeResult.MenuFlyoutItemSelectionClosed)
+    $menuFlyoutPointerSelectionClosed = $control -eq "MenuFlyout" -and
+        $closeResult.Contains("MenuFlyoutPointerSelectionClosed") -and
+        $closeResult.MenuFlyoutPointerSelectionClosed
     $closeVisualChecked = $false
     $closeVisualClosed = $false
     $closeVisualDelta = $null
     $closeVisualSnapshot = ""
+    $closeNativeWindowChecked = $false
+    $closeNativeWindowHidden = $false
+    $closeExpandCollapseCollapsed = $false
+    $closeUiaElementGone = $false
     if ($null -ne $visualCloseContext -and $visualCloseContext.Contains("LastCloseVisualChecked")) {
         $closeVisualChecked = $visualCloseContext.LastCloseVisualChecked
         $closeVisualClosed = $visualCloseContext.LastCloseVisualClosed
         $closeVisualDelta = $visualCloseContext.LastCloseVisualDelta
         $closeVisualSnapshot = $visualCloseContext.LastCloseVisualSnapshot
+    }
+    if ($null -ne $visualCloseContext) {
+        if ($visualCloseContext.Contains("LastCloseNativeWindowChecked")) {
+            $closeNativeWindowChecked = $visualCloseContext.LastCloseNativeWindowChecked
+        }
+        if ($visualCloseContext.Contains("LastCloseNativeWindowHidden")) {
+            $closeNativeWindowHidden = $visualCloseContext.LastCloseNativeWindowHidden
+        }
+        if ($visualCloseContext.Contains("LastCloseExpandCollapseCollapsed")) {
+            $closeExpandCollapseCollapsed = $visualCloseContext.LastCloseExpandCollapseCollapsed
+        }
+        if ($visualCloseContext.Contains("LastCloseUiaElementGone")) {
+            $closeUiaElementGone = $visualCloseContext.LastCloseUiaElementGone
+        }
     }
     $secondTrigger = Get-OpenInteractionTriggerElement $window $control $sampleElement
     if ($null -eq $secondTrigger) {
@@ -4080,7 +4155,7 @@ function Invoke-OpenRepeatInteraction($window, [string]$control, $sampleElement)
         $firstCommandBarFlyoutSecondaryExpanded -and $secondCommandBarFlyoutSecondaryExpanded)
 
     return [ordered]@{
-        Invoked = $firstOpen -and $secondOpen -and $firstOpenElementFound -and $secondOpenElementFound -and $firstOpenElementAnchored -and $secondOpenElementAnchored -and $closedElementGone -and $commandBarFlyoutSecondaryExpanded
+        Invoked = $firstOpen -and $secondOpen -and $firstOpenElementFound -and $secondOpenElementFound -and $firstOpenElementAnchored -and $secondOpenElementAnchored -and $closedElementGone -and $commandBarFlyoutSecondaryExpanded -and $menuFlyoutOutputMatched -and $menuFlyoutItemSelectionClosed
         FirstOpen = $firstOpen
         Closed = $closedElementGone
         CloseMethod = $closeResult.Method
@@ -4088,6 +4163,15 @@ function Invoke-OpenRepeatInteraction($window, [string]$control, $sampleElement)
         FirstOpenElementFound = $firstOpenElementFound
         SecondOpenElementFound = $secondOpenElementFound
         ClosedElementGone = $closedElementGone
+        FirstOpenWindowHandle = $firstOpenWindowHandleValue
+        FirstOpenWindowIsTopLevel = $firstOpenWindowIsTopLevel
+        CloseNativeWindowChecked = $closeNativeWindowChecked
+        CloseNativeWindowHidden = $closeNativeWindowHidden
+        CloseExpandCollapseCollapsed = $closeExpandCollapseCollapsed
+        CloseUiaElementGone = $closeUiaElementGone
+        MenuFlyoutOutputMatched = $menuFlyoutOutputMatched
+        MenuFlyoutItemSelectionClosed = $menuFlyoutItemSelectionClosed
+        MenuFlyoutPointerSelectionClosed = $menuFlyoutPointerSelectionClosed
         CloseVisualChecked = $closeVisualChecked
         CloseVisualClosed = $closeVisualClosed
         CloseVisualDelta = $closeVisualDelta
@@ -5856,10 +5940,13 @@ function Save-WindowVisualSnapshot($window, [string]$name, $captureRect = $null)
     if (![string]::IsNullOrWhiteSpace($liveFramePath)) {
         try {
             Copy-Item -LiteralPath $liveFramePath -Destination $path -Force
-            return [ordered]@{
-                Path = $path
-                Rect = Format-CaptureRectangle $captureRect
-                CaptureRect = $captureRect
+            $stats = Get-ImageStats $path
+            if ($null -ne $stats -and $stats.NonBlank) {
+                return [ordered]@{
+                    Path = $path
+                    Rect = Format-CaptureRectangle $captureRect
+                    CaptureRect = $captureRect
+                }
             }
         }
         catch {
@@ -5880,6 +5967,11 @@ function Save-WindowVisualSnapshot($window, [string]$name, $captureRect = $null)
         $bitmap.Dispose()
     }
 
+    $stats = Get-ImageStats $path
+    if ($null -eq $stats -or !$stats.NonBlank) {
+        return $null
+    }
+
     return [ordered]@{
         Path = $path
         Rect = Format-CaptureRectangle $captureRect
@@ -5897,6 +5989,11 @@ function New-OpenRepeatVisualCloseContext($window, [string]$control) {
         return [ordered]@{
             Generated = $false
             Reason = "Baseline live snapshot could not be captured."
+            OpenWindowHandle = 0
+            LastCloseNativeWindowChecked = $false
+            LastCloseNativeWindowHidden = $false
+            LastCloseExpandCollapseCollapsed = $false
+            LastCloseUiaElementGone = $false
         }
     }
 
@@ -5906,10 +6003,15 @@ function New-OpenRepeatVisualCloseContext($window, [string]$control) {
         CaptureRect = $baseline.Rect
         CaptureRectValue = $baseline.CaptureRect
         Bounds = ""
+        OpenWindowHandle = 0
         LastCloseVisualChecked = $false
         LastCloseVisualClosed = $false
         LastCloseVisualDelta = $null
         LastCloseVisualSnapshot = ""
+        LastCloseNativeWindowChecked = $false
+        LastCloseNativeWindowHidden = $false
+        LastCloseExpandCollapseCollapsed = $false
+        LastCloseUiaElementGone = $false
     }
 }
 
@@ -5921,7 +6023,7 @@ function Test-OpenRepeatVisualClosed($window, $visualCloseContext) {
     if (!$visualCloseContext.Contains("Generated") -or !$visualCloseContext.Generated) {
         return [ordered]@{
             Checked = $false
-            Closed = $true
+            Closed = $false
             Reason = if ($visualCloseContext.Contains("Reason")) { $visualCloseContext.Reason } else { "Visual close context was not generated." }
         }
     }
@@ -5929,7 +6031,7 @@ function Test-OpenRepeatVisualClosed($window, $visualCloseContext) {
     if (!$visualCloseContext.Contains("Bounds") -or [string]::IsNullOrWhiteSpace($visualCloseContext.Bounds)) {
         return [ordered]@{
             Checked = $false
-            Closed = $true
+            Closed = $false
             Reason = "Open-repeat bounds are not available."
         }
     }
@@ -5938,7 +6040,7 @@ function Test-OpenRepeatVisualClosed($window, $visualCloseContext) {
     if ($null -eq $snapshot) {
         return [ordered]@{
             Checked = $false
-            Closed = $true
+            Closed = $false
             Reason = "Live close snapshot could not be captured."
         }
     }
@@ -7905,6 +8007,16 @@ foreach ($control in $Controls) {
         if ($null -ne $interactionResult -and $interactionResult.Contains("Invoked") -and !$interactionResult.Invoked -and !$openRepeatClosedFailed -and !$openRepeatGeometryFailed -and !$visualOpenRepeatEvidenceAccepted) {
             $status = "Failed"
             $notes.Add("Interaction could not be invoked.")
+        }
+
+        if ($control -eq "MenuFlyout" -and
+            ($null -eq $interactionResult -or
+                !$interactionResult.Contains("MenuFlyoutItemSelectionClosed") -or
+                !$interactionResult.MenuFlyoutItemSelectionClosed -or
+                !$interactionResult.Contains("MenuFlyoutOutputMatched") -or
+                !$interactionResult.MenuFlyoutOutputMatched)) {
+            $status = "Failed"
+            $notes.Add("MenuFlyout leaf selection did not both produce the expected output and dismiss the flyout; cleanup close does not satisfy this gate.")
         }
 
         if ($control -eq "CommandBarFlyout" -and

--- a/tools/visual-checks/Run-WpfGalleryVisualAudit.ps1
+++ b/tools/visual-checks/Run-WpfGalleryVisualAudit.ps1
@@ -1965,6 +1965,7 @@ function Capture-ModernWpf($case, [string]$caseDir) {
         if (($null -eq $contentCrop -or !$contentCrop.NonBlank) -and $windowNonBlank) {
             $contentCrop = Save-ModernContentCrop $window $screenshot $contentCropPath $case
         }
+        $contentNonBlank = $null -ne $contentCrop -and [bool]$contentCrop.NonBlank
 
         $statusFile = Read-ModernWpfStatusFile $artifactDir
         $lastException = if ($null -ne $statusFile) { $statusFile.LastException } else { Get-AutomationText $window "GalleryVisualTestLastException" }
@@ -1972,20 +1973,22 @@ function Capture-ModernWpf($case, [string]$caseDir) {
             $lastException = Get-AutomationText $window "GalleryVisualTestLastException"
         }
         if ([string]::IsNullOrWhiteSpace($lastException) -and
-            ($null -eq $contentCrop -or !$contentCrop.NonBlank) -and
+            !$contentNonBlank -and
             !$capture.Succeeded) {
             $lastException = $capture.LastException
         }
         if ([string]::IsNullOrWhiteSpace($lastException)) {
             $lastException = Test-ModernShellNavigationState $window $case
         }
-
+        if ([string]::IsNullOrWhiteSpace($lastException) -and !$contentNonBlank) {
+            $lastException = "ModernWpf rendered content was unavailable or blank."
+        }
         return [ordered]@{
             App = "ModernWpf"
             Case = $case.Id
             Route = $case.ModernRoute
             ReadyRoute = $case.ReadyRoute
-            Status = $(if (($windowNonBlank -or $contentCrop.NonBlank) -and $contentCrop.NonBlank -and [string]::IsNullOrWhiteSpace($lastException)) { "Passed" } else { "Failed" })
+            Status = $(if ($contentNonBlank -and [string]::IsNullOrWhiteSpace($lastException)) { "Passed" } else { "Failed" })
             Screenshot = $screenshot
             ContentCrop = $contentCrop
             WindowNonBlank = $windowNonBlank


### PR DESCRIPTION
## Summary

- require native-window, expand/collapse, or UI Automation evidence before accepting popup dismissal; pixel comparison is diagnostic only
- keep MenuFlyout item-selection dismissal and expected output as unconditional pass requirements, independent of cleanup captures
- fix the ShellNavigation disclosure result variables
- handle missing or blank Gallery content captures without throwing and report a useful diagnostic
- add source-shape regression coverage for these contracts

## Why

Remote Windows sessions can produce transparent WPF render captures, and detached popup UI Automation elements can outlive the visible popup. The previous evidence tooling could therefore throw on an unavailable crop or accept invalid pixel evidence as proof of dismissal.

## Validation

- both modified PowerShell scripts parse successfully
- focused source-shape tests: 3/3 passed on net8.0-windows7.0 and 3/3 passed on net10.0-windows7.0
- live semantic lifecycle probes exercised ContentDialog, MenuBar, MenuFlyout, and CommandBarFlyout across net462, net8, net10, Light, and Dark
- the final remote MenuFlyout probe intentionally reports Failed when selection output is observed but only cleanup can prove closure
- complete local Gallery suites reached 706/719 on both net8 and net10; the identical 13 failures are render-only checks receiving fully transparent pixels in this remote session, so hosted Windows CI is the authoritative full-suite result

## Scope

This changes release-evidence tooling and its tests only. It does not change product code or package surface, and it does not claim completion of the remaining final-tip Light, Dark, and real OS High Contrast release gate.