### PR TITLE
Start 1.0.0-preview.3 development

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <Version>1.0.0-preview.2</Version>
+    <Version>1.0.0-preview.3</Version>
     <!-- Immutable identifier for the published historical audit/migration
          package. It is informational and is not the active NuGet gate. -->
     <ModernWpfPreviewAuditBaselineVersion>1.0.0-preview.1</ModernWpfPreviewAuditBaselineVersion>
@@ -8,7 +8,7 @@
          this only in the same change as an accepted breaking-change audit,
          inventory rebaseline, focused tests, and release-note migration entry.
          Once stable 1.0.0 ships, this becomes the SemVer baseline for 1.x. -->
-    <ModernWpfPackageValidationBaselineVersion>1.0.0-preview.1</ModernWpfPackageValidationBaselineVersion>
+    <ModernWpfPackageValidationBaselineVersion>1.0.0-preview.2</ModernWpfPackageValidationBaselineVersion>
     <ModernWpfPublicApiAnalyzersVersion>5.6.0</ModernWpfPublicApiAnalyzersVersion>
     <ModernWpfSystemValueTupleVersion>4.6.2</ModernWpfSystemValueTupleVersion>
     <ModernWpfWindowsSdkContractsVersion>10.0.28000.2526</ModernWpfWindowsSdkContractsVersion>

--- a/ModernWpf.Controls/readme.md
+++ b/ModernWpf.Controls/readme.md
@@ -5,14 +5,14 @@ Presentation Foundation applications. **ModernWPF** is the product name;
 `ModernWpfUI` remains the NuGet package ID and `ModernWpf` remains the CLR
 namespace and repository name.
 
-![ModernWPF Gallery showing controls, samples, and navigation](https://raw.githubusercontent.com/Kinnara/ModernWpf/v1.0.0-preview.2/docs/images/Gallery.Light.png)
+![ModernWPF Gallery showing controls, samples, and navigation](https://raw.githubusercontent.com/Kinnara/ModernWpf/v1.0.0-preview.3/docs/images/Gallery.Light.png)
 
-## Install Preview 2
+## Install Preview 3
 
 Install the preview explicitly:
 
 ```powershell
-dotnet add package ModernWpfUI --version 1.0.0-preview.2
+dotnet add package ModernWpfUI --version 1.0.0-preview.3
 ```
 
 | Target framework | Stock-control theme |
@@ -60,7 +60,7 @@ The 1.0 preview series may make source-audited API or resource-key corrections
 before stable `1.0.0`. Intentional changes are documented with migration
 guidance; stable 1.0 will establish the SemVer compatibility boundary for 1.x.
 
-- [Preview 2 release notes](https://github.com/Kinnara/ModernWpf/blob/v1.0.0-preview.2/docs/release-notes-1.0.0-preview.2.md)
-- [Migrate from ModernWPF 0.9.x](https://github.com/Kinnara/ModernWpf/blob/v1.0.0-preview.2/docs/migrating-from-0.9.md)
+- [Preview 3 release notes](https://github.com/Kinnara/ModernWpf/blob/v1.0.0-preview.3/docs/release-notes-1.0.0-preview.3.md)
+- [Migrate from ModernWPF 0.9.x](https://github.com/Kinnara/ModernWpf/blob/v1.0.0-preview.3/docs/migrating-from-0.9.md)
 - [Report a Preview bug](https://github.com/Kinnara/ModernWpf/issues/new?template=preview-bug.yml)
 - [Documentation and source](https://github.com/Kinnara/ModernWpf#documentation)

--- a/docs/release-notes-1.0.0-preview.3.md
+++ b/docs/release-notes-1.0.0-preview.3.md
@@ -1,0 +1,42 @@
+# ModernWPF 1.0.0-preview.3
+
+<!-- RELEASE-NOTES: DRAFT -->
+
+`1.0.0-preview.3` is under development. This draft tracks the source-audited
+`TimePicker` and `TwoPaneView` milestone in the fixed ModernWPF 1.0 roadmap.
+
+## Preview compatibility
+
+- `1.0.0-preview.2` is the active package-validation baseline for this
+  development cycle.
+- `1.0.0-preview.1` remains the immutable historical audit and migration
+  baseline rather than an API freeze across later previews.
+- Stable `1.0.0` will establish the SemVer compatibility boundary for
+  subsequent 1.x releases.
+
+See [Migrating from ModernWPF 0.9.x](migrating-from-0.9.md) and the
+[1.x public API contract](public-api-contract-1x.md) for the compatibility and
+migration policies.
+
+## Planned milestone
+
+- Add source-audited `TimePicker` and `TwoPaneView` controls using current
+  applicable WinUI API shape, with documented WPF adaptations.
+- Add Gallery pages, focused behavior and automation coverage, Light, Dark,
+  High Contrast, and compact-resource validation, and public API and resource
+  inventories for both controls.
+- Run the complete release, package, consumer, and downstream compatibility
+  gates before publication.
+
+## Breaking changes
+
+No Preview 3 breaking changes have been finalized. Any intentional preview
+change will update this section with explicit migration guidance before the
+draft marker is removed.
+
+## Known preview limitations
+
+- This draft does not represent a published package.
+- `TitleBar`, window materials, `TabView`, `ItemContainer`,
+  `LinedFlowLayout`, and `ItemsView` remain assigned to later 1.0 previews.
+- `PipsPager` remains deferred to 1.1.

--- a/docs/release-readiness-1x.md
+++ b/docs/release-readiness-1x.md
@@ -194,7 +194,7 @@ match `Directory.Build.props`. Dispatch the workflow from that same tag ref;
 for example:
 
 ```powershell
-gh workflow run release.yml --ref v1.0.0-preview.2 -f tag=v1.0.0-preview.2
+gh workflow run release.yml --ref v1.0.0-preview.3 -f tag=v1.0.0-preview.3
 ```
 
 Stable publication also names the accepted RC explicitly:

--- a/samples/PackageConsumer/README.md
+++ b/samples/PackageConsumer/README.md
@@ -17,7 +17,7 @@ the feed directory:
 ```powershell
 dotnet run --project .\samples\PackageConsumer\ModernWpf.PackageConsumer.csproj `
     --framework net8.0-windows7.0 `
-    -p:ModernWpfPackageVersion=1.0.0-preview.2 `
+    -p:ModernWpfPackageVersion=1.0.0-preview.3 `
     -p:ModernWpfPackageSource=.\artifacts
 ```
 


### PR DESCRIPTION
## Summary

- advances the development version to `1.0.0-preview.3`
- makes the published `1.0.0-preview.2` package the active package-validation baseline while retaining Preview 1 as the historical audit baseline
- adds draft Preview 3 release notes for the TimePicker and TwoPaneView milestone
- updates development-facing package and release examples to Preview 3 while leaving repository public surfaces on the currently published Preview 2

## Validation

- `dotnet test .\test\ModernWpf.Tools.Tests\ModernWpf.Tools.Tests.csproj --configuration Release` — 47 passed, 0 failed, 0 skipped
- `dotnet restore ModernWpf.sln`
- `dotnet build ModernWpf.sln --configuration Release --no-restore` — 0 warnings, 0 errors
- `dotnet pack .\ModernWpf.Controls\ModernWpf.Controls.csproj --configuration Release --no-build --no-restore --output .\artifacts\preview3-validation` — passed package validation against public Preview 2
- `Verify-ModernWpfPackage.ps1` — Preview 3 `.nupkg` and `.snupkg` verified