### PR TITLE
Fix Preview 3 release note status

### DIFF
--- a/docs/release-notes-1.0.0-preview.3.md
+++ b/docs/release-notes-1.0.0-preview.3.md
@@ -73,8 +73,9 @@ keys are additive preview surfaces and may be adopted independently.
 
 ## Known preview limitations
 
-- This preview remains unpublished until the tagged Trusted Publishing
-  workflow completes.
+- This release is not the stable 1.x compatibility boundary. Intentional,
+  source-audited API or public resource-key corrections may still occur before
+  the RC freeze and will carry explicit migration guidance.
 - `TitleBar`, window materials, `TabView`, `ItemContainer`,
   `LinedFlowLayout`, and `ItemsView` remain assigned to later 1.0 previews.
 - `PipsPager` remains deferred to 1.1.


### PR DESCRIPTION
## Summary

- replace the transient “unpublished until the tagged workflow completes” line with an evergreen prerelease compatibility notice
- prevent the published Preview 3 release notes from becoming immediately false after publication

## Impact

Documentation-only. Product, Gallery, API, resource, and package trees are unchanged.

## Validation

- `git diff --check`
- `dotnet test .\test\ModernWpf.Tools.Tests\ModernWpf.Tools.Tests.csproj --configuration Release --framework net10.0 --no-build --no-restore` — 47 passed, 0 failed, 0 skipped
