### PR TITLE
Fix Gallery close-button right-edge alignment

### DIFF
--- a/ModernWpf.Gallery/MainWindow.xaml.cs
+++ b/ModernWpf.Gallery/MainWindow.xaml.cs
@@ -181,26 +181,9 @@ namespace ModernWpf.Gallery
 
         internal static Thickness GetMainGridMargin(WindowState windowState, bool isHighContrast)
         {
-            return GetMainGridMargin(windowState, isHighContrast, IsWindows11OrGreater());
-        }
-
-        internal static Thickness GetMainGridMargin(
-            WindowState windowState,
-            bool isHighContrast,
-            bool isWindows11OrGreater)
-        {
             if (windowState == WindowState.Maximized)
             {
                 return isHighContrast ? new Thickness(0, 8, 0, 0) : new Thickness(8);
-            }
-
-            // A WinUI 3 AppWindow lays its client content inside the normal
-            // eight-DIP resize frame. WindowChrome extends WPF content beneath
-            // that frame, so compensate here to keep the title bar,
-            // NavigationView, and right content on the same pixel boundaries.
-            if (!isHighContrast && isWindows11OrGreater)
-            {
-                return new Thickness(8, 0, 8, 8);
             }
 
             return default;

--- a/test/ModernWpf.Gallery.Tests/GalleryNavigationRuntimeTests.cs
+++ b/test/ModernWpf.Gallery.Tests/GalleryNavigationRuntimeTests.cs
@@ -899,6 +899,52 @@ namespace ModernWpf.Gallery.Tests
         }
 
         [TestMethod]
+        public void MainWindowCloseButtonReachesRightEdgeInNormalState()
+        {
+            WpfTestHost.Run(() =>
+            {
+                var window = new MainWindow
+                {
+                    Left = -30000,
+                    Top = -30000,
+                    ShowInTaskbar = false,
+                    WindowStartupLocation = WindowStartupLocation.Manual
+                };
+
+                try
+                {
+                    window.Show();
+                    WpfTestHost.DoEvents();
+
+                    var highContrastBorder = (Border)window.FindName("HighContrastBorder");
+                    var mainGrid = (Grid)window.FindName("MainGrid");
+                    var closeButton = (Button)window.FindName("CloseButton");
+
+                    highContrastBorder.BorderThickness = MainWindow.GetHighContrastBorderThickness(false);
+                    mainGrid.Margin = MainWindow.GetMainGridMargin(
+                        WindowState.Normal,
+                        isHighContrast: false);
+                    window.UpdateLayout();
+
+                    Assert.IsTrue(closeButton.ActualWidth > 0);
+                    var closeButtonRight = closeButton.TranslatePoint(
+                        new Point(closeButton.ActualWidth, 0),
+                        highContrastBorder).X;
+                    Assert.AreEqual(
+                        highContrastBorder.ActualWidth,
+                        closeButtonRight,
+                        0.01,
+                        "The normal-window close button must reach the rendered window's right edge.");
+                }
+                finally
+                {
+                    window.Close();
+                    WpfTestHost.DoEvents();
+                }
+            });
+        }
+
+        [TestMethod]
         public void MainWindowChromePolicyMatchesWpfGalleryHighContrastPath()
         {
             WpfTestHost.Run(() =>
@@ -912,23 +958,15 @@ namespace ModernWpf.Gallery.Tests
                 Assert.AreEqual(MainWindow.GetPrefferedNonClientFrameEdges(), chrome.NonClientFrameEdges);
 
                 Assert.AreEqual(
-                    new Thickness(8, 0, 8, 8),
+                    new Thickness(0),
                     MainWindow.GetMainGridMargin(
                         WindowState.Normal,
-                        isHighContrast: false,
-                        isWindows11OrGreater: true));
+                        isHighContrast: false));
                 Assert.AreEqual(
                     new Thickness(0),
                     MainWindow.GetMainGridMargin(
                         WindowState.Normal,
-                        isHighContrast: false,
-                        isWindows11OrGreater: false));
-                Assert.AreEqual(
-                    new Thickness(0),
-                    MainWindow.GetMainGridMargin(
-                        WindowState.Normal,
-                        isHighContrast: true,
-                        isWindows11OrGreater: true));
+                        isHighContrast: true));
                 Assert.AreEqual(new Thickness(8), MainWindow.GetMainGridMargin(WindowState.Maximized, false));
                 Assert.AreEqual(new Thickness(0, 8, 0, 0), MainWindow.GetMainGridMargin(WindowState.Maximized, true));
                 Assert.AreEqual(new Thickness(0), MainWindow.GetHighContrastBorderThickness(false));


### PR DESCRIPTION
## Summary

- remove the Gallery's normal-window eight-DIP client margin so the close button reaches the rendered right edge
- preserve the existing maximized, high-contrast, and non-client resize-edge policies
- add a WPF-hosted regression test that measures the close button against the rendered window surface

## Root cause and impact

The normal Windows 11 path inset the entire `MainGrid` by eight DIPs, which also moved the title-bar close button eight DIPs left. The Gallery now follows the current official WPF Gallery behavior and applies client margins only while maximized.

## Validation

- pre-fix regression: 0 passed, 1 failed, 0 skipped; expected 1180 DIPs, actual 1172 DIPs
- post-fix focused regression: 1 passed, 0 failed, 0 skipped
- focused title-bar policy tests: 3 passed, 0 failed, 0 skipped
- complete Gallery tests on `net8.0-windows7.0`: 751 passed, 0 failed, 0 skipped
- complete Gallery tests on `net10.0-windows7.0`: 751 passed, 0 failed, 0 skipped
- `dotnet restore ModernWpf.sln`
- `dotnet build ModernWpf.sln --configuration Release --no-restore` (0 warnings, 0 errors)

The full release-readiness gate and manual screenshot capture were not run because this is a narrow Gallery-only change.

Closes #774