### PR TITLE
Pin CI to .NET SDK 10.0.302

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.302",
-    "rollForward": "latestPatch"
+    "rollForward": "disable"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.203",
-    "rollForward": "latestFeature"
+    "version": "10.0.302",
+    "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
## Summary

- pin `global.json` to SDK `10.0.302`
- disable SDK roll-forward so CI cannot silently select a regressed servicing patch or feature band

## Root cause and impact

The last green `master` release gate used SDK `10.0.302`. Subsequent runs selected SDK `10.0.400`, and an initial feature-band pin still allowed SDK `10.0.303`; both newer SDKs leak .NET 8 WPF reference-pack assemblies into the generated `net462` markup-compile project. That produces `MSB3277` conflicts between `WindowsBase` 4.0 and 8.0 while validating the legacy `XamlControlsResources` consumer.

This failure is independent of the product change in #775, but it blocks every pull request using the current release gate.

## Validation

- `dotnet --version` resolves exactly `10.0.302`
- `dotnet restore ModernWpf.sln`
- `dotnet build ModernWpf.sln --configuration Release --no-restore --maxcpucount:1` (0 warnings, 0 errors)
- `dotnet pack ModernWpf.Controls\ModernWpf.Controls.csproj --configuration Release --no-build --no-restore`
- `Verify-ModernWpfPackage.ps1` passed
- `Test-ModernWpfPackageSmoke.ps1` passed twice for both consumers on `net462`, `net8.0-windows7.0`, and `net10.0-windows7.0`
- complete `ModernWpf.Tools.Tests` project: 47 passed, 0 failed, 0 skipped

The first CI attempt proved that `latestPatch` was insufficient because GitHub selected regressed SDK `10.0.303`; the current head uses `rollForward: disable`.